### PR TITLE
docs(nav): add Agent SDK (V1) to Mintlify nav

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -64,53 +64,53 @@
               {
                 "group": "Advanced Configuration",
                 "pages": [
-                {
-                  "group": "LLM Configuration",
-                  "pages": [
-                    "openhands-repo/docs/usage/llms/llms",
-                    {
-                      "group": "Providers",
-                      "pages": [
-                        "openhands-repo/docs/usage/llms/openhands-llms",
-                        "openhands-repo/docs/usage/llms/azure-llms",
-                        "openhands-repo/docs/usage/llms/google-llms",
-                        "openhands-repo/docs/usage/llms/groq",
-                        "openhands-repo/docs/usage/llms/local-llms",
-                        "openhands-repo/docs/usage/llms/litellm-proxy",
-                        "openhands-repo/docs/usage/llms/moonshot",
-                        "openhands-repo/docs/usage/llms/openai-llms",
-                        "openhands-repo/docs/usage/llms/openrouter"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "group": "Runtime Configuration",
-                  "pages": [
-                    "openhands-repo/docs/usage/runtimes/overview",
-                    {
-                      "group": "Providers",
-                      "pages": [
-                        "openhands-repo/docs/usage/runtimes/docker",
-                        "openhands-repo/docs/usage/runtimes/remote",
-                        "openhands-repo/docs/usage/runtimes/local",
-                        {
-                          "group": "Third-Party Providers",
-                          "pages": [
-                            "openhands-repo/docs/usage/runtimes/modal",
-                            "openhands-repo/docs/usage/runtimes/daytona",
-                            "openhands-repo/docs/usage/runtimes/runloop",
-                            "openhands-repo/docs/usage/runtimes/e2b"
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                },
-                "openhands-repo/docs/usage/configuration-options",
-                "openhands-repo/docs/usage/how-to/custom-sandbox-guide",
-                "openhands-repo/docs/usage/search-engine-setup",
-                "openhands-repo/docs/usage/mcp"
+                  {
+                    "group": "LLM Configuration",
+                    "pages": [
+                      "openhands-repo/docs/usage/llms/llms",
+                      {
+                        "group": "Providers",
+                        "pages": [
+                          "openhands-repo/docs/usage/llms/openhands-llms",
+                          "openhands-repo/docs/usage/llms/azure-llms",
+                          "openhands-repo/docs/usage/llms/google-llms",
+                          "openhands-repo/docs/usage/llms/groq",
+                          "openhands-repo/docs/usage/llms/local-llms",
+                          "openhands-repo/docs/usage/llms/litellm-proxy",
+                          "openhands-repo/docs/usage/llms/moonshot",
+                          "openhands-repo/docs/usage/llms/openai-llms",
+                          "openhands-repo/docs/usage/llms/openrouter"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Runtime Configuration",
+                    "pages": [
+                      "openhands-repo/docs/usage/runtimes/overview",
+                      {
+                        "group": "Providers",
+                        "pages": [
+                          "openhands-repo/docs/usage/runtimes/docker",
+                          "openhands-repo/docs/usage/runtimes/remote",
+                          "openhands-repo/docs/usage/runtimes/local",
+                          {
+                            "group": "Third-Party Providers",
+                            "pages": [
+                              "openhands-repo/docs/usage/runtimes/modal",
+                              "openhands-repo/docs/usage/runtimes/daytona",
+                              "openhands-repo/docs/usage/runtimes/runloop",
+                              "openhands-repo/docs/usage/runtimes/e2b"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "openhands-repo/docs/usage/configuration-options",
+                  "openhands-repo/docs/usage/how-to/custom-sandbox-guide",
+                  "openhands-repo/docs/usage/search-engine-setup",
+                  "openhands-repo/docs/usage/mcp"
                 ]
               }
             ]
@@ -160,6 +160,22 @@
               "openhands-repo/docs/usage/how-to/evaluation-harness",
               "openhands-repo/docs/usage/how-to/websocket-connection"
             ]
+          },
+          {
+            "group": "Agent SDK (V1)",
+            "pages": [
+              "agent-sdk/docs/README",
+              "agent-sdk/docs/getting-started",
+              "agent-sdk/docs/architecture",
+              "agent-sdk/docs/tools",
+              "agent-sdk/docs/examples",
+              {
+                "group": "Context",
+                "pages": [
+                  "agent-sdk/docs/context/README"
+                ]
+              }
+            ]
           }
         ]
       },
@@ -170,8 +186,8 @@
         ]
       },
       {
-          "tab": "API Reference",
-          "openapi": "/openhands-repo/docs/openapi.json"
+        "tab": "API Reference",
+        "openapi": "/openhands-repo/docs/openapi.json"
       }
     ],
     "global": {
@@ -199,8 +215,7 @@
     "dark": "/openhands-repo/docs/logo/dark.svg"
   },
   "navbar": {
-    "links": [
-    ],
+    "links": [],
     "primary": {
       "type": "github",
       "href": "https://github.com/All-Hands-AI/OpenHands"


### PR DESCRIPTION
This PR integrates the Agent SDK docs into the Mintlify navigation.

Changes:
- Add "Agent SDK (V1)" group under the Docs tab in docs.json
- Link pages from the agent-sdk submodule: README, Getting Started, Architecture, Tools, Examples, and Context

Rationale:
- Surface Agent SDK docs via the left sidebar, matching Mintlify’s navigation pattern
- Reduce reliance on ad-hoc link blocks in page bodies

Follow-ups after merge:
- Trim the What's next list from agent-sdk/docs/README.md in the source repo (since the sidebar provides navigation)

Co-authored-by: openhands <openhands@all-hands.dev>