### PR TITLE
Update package name from openhands-ai to openhands

### DIFF
--- a/openhands/usage/run-openhands/cli-mode.mdx
+++ b/openhands/usage/run-openhands/cli-mode.mdx
@@ -32,7 +32,7 @@ We recommend using [uv](https://docs.astral.sh/uv/) for the best OpenHands exper
 
 2. **Launch OpenHands CLI**:
 ```bash
-uvx --python 3.12 --from openhands-ai openhands
+uvx --python 3.12 openhands
 ```
 
 <AccordionGroup>
@@ -43,7 +43,7 @@ If you prefer to use pip:
 
 ```bash
 # Install OpenHands
-pip install openhands-ai
+pip install openhands
 ```
 
 Note that you'll still need `uv` installed for the default MCP servers to work properly.
@@ -56,8 +56,8 @@ Add the following to your shell configuration file (`.bashrc`, `.zshrc`, etc.):
 
 ```bash
 # Add OpenHands aliases (recommended)
-alias openhands="uvx --python 3.12 --from openhands-ai openhands"
-alias oh="uvx --python 3.12 --from openhands-ai openhands"
+alias openhands="uvx --python 3.12 openhands"
+alias oh="uvx --python 3.12 openhands"
 ```
 
 After adding these lines, reload your shell configuration with `source ~/.bashrc` or `source ~/.zshrc` (depending on your shell).
@@ -74,7 +74,7 @@ cd ~
 uv venv .openhands-venv --python 3.12
 
 # Install OpenHands in the virtual environment
-uv pip install -t ~/.openhands-venv/lib/python3.12/site-packages openhands-ai
+uv pip install -t ~/.openhands-venv/lib/python3.12/site-packages openhands
 
 # Add the bin directory to your PATH in your shell configuration file
 echo 'export PATH="$PATH:$HOME/.openhands-venv/bin"' >> ~/.bashrc  # or ~/.zshrc

--- a/openhands/usage/run-openhands/gui-mode.mdx
+++ b/openhands/usage/run-openhands/gui-mode.mdx
@@ -14,7 +14,7 @@ description: High level overview of the Graphical User Interface (GUI) in OpenHa
 You can launch the OpenHands GUI server directly from the command line using the `serve` command:
 
 <Callout type="info">
-**Prerequisites**: You need to have the [OpenHands CLI installed](/usage/run-openhands/cli-mode) first, OR have `uv` installed and run `uvx --python 3.12 --from openhands-ai openhands serve`. Otherwise, you'll need to use Docker directly (see the [Docker section](#using-docker-directly) below).
+**Prerequisites**: You need to have the [OpenHands CLI installed](/usage/run-openhands/cli-mode) first, OR have `uv` installed and run `uvx --python 3.12 openhands serve`. Otherwise, you'll need to use Docker directly (see the [Docker section](#using-docker-directly) below).
 </Callout>
 
 ```bash

--- a/openhands/usage/run-openhands/local-setup.mdx
+++ b/openhands/usage/run-openhands/local-setup.mdx
@@ -84,13 +84,13 @@ See the [uv installation guide](https://docs.astral.sh/uv/getting-started/instal
 **Launch OpenHands**:
 ```bash
 # Launch the GUI server
-uvx --python 3.12 --from openhands-ai openhands serve
+uvx --python 3.12 openhands serve
 
 # Or with GPU support (requires nvidia-docker)
-uvx --python 3.12 --from openhands-ai openhands serve --gpu
+uvx --python 3.12 openhands serve --gpu
 
 # Or with current directory mounted
-uvx --python 3.12 --from openhands-ai openhands serve --mount-cwd
+uvx --python 3.12 openhands serve --mount-cwd
 ```
 
 This will automatically handle Docker requirements checking, image pulling, and launching the GUI server. The `--gpu` flag enables GPU support via nvidia-docker, and `--mount-cwd` mounts your current directory into the container.
@@ -101,7 +101,7 @@ If you prefer to use pip and have Python 3.12+ installed:
 
 ```bash
 # Install OpenHands
-pip install openhands-ai
+pip install openhands
 
 # Launch the GUI server
 openhands serve

--- a/openhands/usage/runtimes/overview.mdx
+++ b/openhands/usage/runtimes/overview.mdx
@@ -25,7 +25,7 @@ OpenHands supports several different runtime environments:
 The following third-party runtimes are available when you install the `third_party_runtimes` extra:
 
 ```bash
-pip install openhands-ai[third_party_runtimes]
+pip install openhands[third_party_runtimes]
 ```
 
 - [E2B Runtime](/usage/runtimes/e2b) - Open source runtime using E2B sandboxes.

--- a/openhands/usage/windows-without-wsl.mdx
+++ b/openhands/usage/windows-without-wsl.mdx
@@ -162,7 +162,7 @@ After installation, restart your PowerShell session to ensure the environment va
 After installing the prerequisites, you can install and run OpenHands with:
 
 ```powershell
-uvx --python 3.12 --from openhands-ai openhands
+uvx --python 3.12 openhands
 ```
 
 ### Troubleshooting CLI Issues


### PR DESCRIPTION
## Summary

This PR updates the documentation to reflect the package name change from `openhands-ai` to `openhands`, syncing with changes made in OpenHands PR #11271.

## Changes Made

### Files Updated:
- `openhands/usage/run-openhands/cli-mode.mdx` (4 changes)
- `openhands/usage/run-openhands/gui-mode.mdx` (1 change)
- `openhands/usage/run-openhands/local-setup.mdx` (4 changes)
- `openhands/usage/windows-without-wsl.mdx` (1 change)
- `openhands/usage/runtimes/overview.mdx` (1 change)

### Specific Updates:
1. **uvx commands**: Changed `uvx --python 3.12 --from openhands-ai openhands` to `uvx --python 3.12 openhands`
2. **pip install**: Changed `pip install openhands-ai` to `pip install openhands`
3. **Shell aliases**: Updated to use the simplified uvx syntax
4. **Third-party runtimes**: Updated `pip install openhands-ai[third_party_runtimes]` to `pip install openhands[third_party_runtimes]`

## Impact

- Simplifies installation commands for users
- Maintains consistency with the main OpenHands repository
- No functional changes, only package naming updates

## Related

- Syncs with OpenHands PR #11271: https://github.com/All-Hands-AI/OpenHands/pull/11271/files

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/98e4f88ba7684bd79ee9d939a49d1e8d)