### PR TITLE
Replace All-Hands-AI references with OpenHands

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository aggregates documentation from multiple All Hands AI repositories
 
 To add documentation from a new repository:
 
-1. Add workflow [like this](https://github.com/All-Hands-AI/agent-sdk/blob/main/.github/workflows/deploy-docs.yml) to the new repo.
+1. Add workflow [like this](https://github.com/OpenHands/agent-sdk/blob/main/.github/workflows/deploy-docs.yml) to the new repo.
 2. Update `docs.json` to include navigation for the new content (e.g., `new-repo/docs/`)
 
 ## Local Development

--- a/docs.json
+++ b/docs.json
@@ -215,13 +215,13 @@
     ],
     "primary": {
       "type": "github",
-      "href": "https://github.com/All-Hands-AI/OpenHands"
+      "href": "https://github.com/OpenHands/OpenHands"
     }
   },
   "footer": {
     "socials": {
       "slack": "https://dub.sh/openhands",
-      "github": "https://github.com/All-Hands-AI/OpenHands"
+      "github": "https://github.com/OpenHands/OpenHands"
     }
   },
   "contextual": {

--- a/index.mdx
+++ b/index.mdx
@@ -120,7 +120,7 @@ it can modify code, run commands, browse the web, call APIs, and yes-even copy c
   </Card>
   <Card
     title="Create GitHub Issues"
-    href="https://github.com/All-Hands-AI/OpenHands/issues"
+    href="https://github.com/OpenHands/OpenHands/issues"
   >
     Report and look for issues in Github.
   </Card>

--- a/openhands/usage/about.mdx
+++ b/openhands/usage/about.mdx
@@ -27,4 +27,4 @@ enhance the capabilities of OpenHands.
 
 ## License
 
-Distributed under MIT [License](https://github.com/All-Hands-AI/OpenHands/blob/main/LICENSE).
+Distributed under MIT [License](https://github.com/OpenHands/OpenHands/blob/main/LICENSE).

--- a/openhands/usage/advanced/custom-sandbox-guide.mdx
+++ b/openhands/usage/advanced/custom-sandbox-guide.mdx
@@ -60,7 +60,7 @@ docker run -it --rm --pull=always \
 
 ### Setup
 
-First, ensure you can run OpenHands by following the instructions in [Development.md](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md).
+First, ensure you can run OpenHands by following the instructions in [Development.md](https://github.com/OpenHands/OpenHands/blob/main/Development.md).
 
 ### Specify the Base Sandbox Image
 

--- a/openhands/usage/agents.mdx
+++ b/openhands/usage/agents.mdx
@@ -17,10 +17,10 @@ The conceptual idea is illustrated below. At each turn, the agent can:
 - Execute any valid Linux `bash` command
 - Execute any valid `Python` code with [an interactive Python interpreter](https://ipython.org/). This is simulated through `bash` command, see plugin system below for more details.
 
-![image](https://github.com/All-Hands-AI/OpenHands/assets/38853559/92b622e3-72ad-4a61-8f41-8c040b6d5fb3)
+![image](https://github.com/OpenHands/OpenHands/assets/38853559/92b622e3-72ad-4a61-8f41-8c040b6d5fb3)
 
 ### Demo
 
-https://github.com/All-Hands-AI/OpenHands/assets/38853559/f592a192-e86c-4f48-ad31-d69282d5f6ac
+https://github.com/OpenHands/OpenHands/assets/38853559/f592a192-e86c-4f48-ad31-d69282d5f6ac
 
 _Example of CodeActAgent with `gpt-4-turbo-2024-04-09` performing a data science task (linear regression)_.

--- a/openhands/usage/architecture/runtime.mdx
+++ b/openhands/usage/architecture/runtime.mdx
@@ -67,7 +67,7 @@ The role of the client:
 
 OpenHands' approach to building and managing runtime images ensures efficiency, consistency, and flexibility in creating and maintaining Docker images for both production and development environments.
 
-Check out the [relevant code](https://github.com/All-Hands-AI/OpenHands/blob/main/openhands/runtime/utils/runtime_build.py) if you are interested in more details.
+Check out the [relevant code](https://github.com/OpenHands/OpenHands/blob/main/openhands/runtime/utils/runtime_build.py) if you are interested in more details.
 
 ### Image Tagging System
 

--- a/openhands/usage/cloud/slack-installation.mdx
+++ b/openhands/usage/cloud/slack-installation.mdx
@@ -81,7 +81,7 @@ Initial request is followed up by mentioning `@openhands` in a thread reply.
 You can mention a repo name when starting a new conversation in the following formats
 
 1. "My-Repo" repo (e.g `@openhands in the openhands repo ...`)
-2. "All-Hands-AI/OpenHands" (e.g `@openhands in All-Hands-AI/OpenHands ...`)
+2. "OpenHands/OpenHands" (e.g `@openhands in OpenHands/OpenHands ...`)
 
 The repo match is case insensitive. If a repo name match is made, it will kick off the conversation.
 If the repo name partially matches against multiple repos, you'll be asked to select a repo from the filtered list.

--- a/openhands/usage/developers/evaluation-harness.mdx
+++ b/openhands/usage/developers/evaluation-harness.mdx
@@ -6,7 +6,7 @@ This guide provides an overview of how to integrate your own evaluation benchmar
 
 ## Setup Environment and LLM Configuration
 
-Please follow instructions [here](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md) to setup your local development environment.
+Please follow instructions [here](https://github.com/OpenHands/OpenHands/blob/main/Development.md) to setup your local development environment.
 OpenHands in development mode uses `config.toml` to keep track of most configurations.
 
 Here's an example configuration file you can use to define and use multiple LLMs:
@@ -75,7 +75,7 @@ The `run_controller()` function is the core of OpenHands's execution. It manages
 
 ## Easiest way to get started: Exploring Existing Benchmarks
 
-We encourage you to review the various evaluation benchmarks available in the [`evaluation/benchmarks/` directory](https://github.com/All-Hands-AI/OpenHands/blob/main/evaluation/benchmarks) of our repository.
+We encourage you to review the various evaluation benchmarks available in the [`evaluation/benchmarks/` directory](https://github.com/OpenHands/OpenHands/blob/main/evaluation/benchmarks) of our repository.
 
 To integrate your own benchmark, we suggest starting with the one that most closely resembles your needs. This approach can significantly streamline your integration process, allowing you to build upon existing structures and adapt them to your specific requirements.
 

--- a/openhands/usage/faqs.mdx
+++ b/openhands/usage/faqs.mdx
@@ -21,7 +21,7 @@ OpenHands is meant to be run by a single user on their local workstation. It is 
 deployments where multiple users share the same instance. There is no built-in authentication, isolation, or scalability.
 
 If you're interested in running OpenHands in a multi-tenant environment, check out the source-available,
-commercially-licensed [OpenHands Cloud Helm Chart](https://github.com/all-Hands-AI/OpenHands-cloud).
+commercially-licensed [OpenHands Cloud Helm Chart](https://github.com/openHands/OpenHands-cloud).
 
 <Info>
 Using OpenHands for work? We'd love to chat! Fill out
@@ -86,11 +86,11 @@ If you would like to set things up more systematically, you can:
 
 ### Something's not working. Where can I get help?
 
-1. **Search existing issues**: Check our [GitHub issues](https://github.com/All-Hands-AI/OpenHands/issues) to see if
+1. **Search existing issues**: Check our [GitHub issues](https://github.com/OpenHands/OpenHands/issues) to see if
   others have encountered the same problem.
 2. **Join our community**: Get help from other users and developers:
    - [Slack community](https://dub.sh/openhands)
 3. **Check our troubleshooting guide**: Common issues and solutions are documented in
   [Troubleshooting](/openhands/usage/troubleshooting/troubleshooting).
-4. **Report bugs**: If you've found a bug, please [create an issue](https://github.com/All-Hands-AI/OpenHands/issues/new)
+4. **Report bugs**: If you've found a bug, please [create an issue](https://github.com/OpenHands/OpenHands/issues/new)
   and fill in as much detail as possible.

--- a/openhands/usage/llms/local-llms.mdx
+++ b/openhands/usage/llms/local-llms.mdx
@@ -68,23 +68,23 @@ Download and install the LM Studio desktop app from [lmstudio.ai](https://lmstud
 1. Check [the installation guide](/openhands/usage/run-openhands/local-setup) and ensure all prerequisites are met before running OpenHands, then run:
 
 ```bash
-docker pull docker.all-hands.dev/all-hands-ai/runtime:0.58-nikolaik
+docker pull docker.all-hands.dev/openhands/runtime:0.58-nikolaik
 
 docker run -it --rm --pull=always \
-    -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0.58-nikolaik \
+    -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/openhands/runtime:0.58-nikolaik \
     -e LOG_ALL_EVENTS=true \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v ~/.openhands:/.openhands \
     -p 3000:3000 \
     --add-host host.docker.internal:host-gateway \
     --name openhands-app \
-    docker.all-hands.dev/all-hands-ai/openhands:0.58
+    docker.all-hands.dev/openhands/openhands:0.58
 ```
 
 2. Wait until the server is running (see log below):
 ```
 Digest: sha256:e72f9baecb458aedb9afc2cd5bc935118d1868719e55d50da73190d3a85c674f
-Status: Image is up to date for docker.all-hands.dev/all-hands-ai/openhands:0.58
+Status: Image is up to date for docker.all-hands.dev/openhands/openhands:0.58
 Starting OpenHands...
 Running OpenHands as root
 14:22:13 - openhands:INFO: server_config.py:50 - Using config class None
@@ -204,7 +204,7 @@ Run OpenHands using [the official docker run command](/openhands/usage/run-openh
 
 #### Using Development Mode
 
-Use the instructions in [Development.md](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md) to build OpenHands.
+Use the instructions in [Development.md](https://github.com/OpenHands/OpenHands/blob/main/Development.md) to build OpenHands.
 
 Start OpenHands using `make run`.
 

--- a/openhands/usage/microagents/microagents-keyword.mdx
+++ b/openhands/usage/microagents/microagents-keyword.mdx
@@ -33,4 +33,4 @@ triggers:
 The user has said the magic word. Respond with "That was delicious!"
 ```
 
-[See examples of microagents triggered by keywords in the official OpenHands repository](https://github.com/All-Hands-AI/OpenHands/tree/main/microagents)
+[See examples of microagents triggered by keywords in the official OpenHands repository](https://github.com/OpenHands/OpenHands/tree/main/microagents)

--- a/openhands/usage/microagents/microagents-public.mdx
+++ b/openhands/usage/microagents/microagents-public.mdx
@@ -1,13 +1,13 @@
 ---
 title: Global Microagents
-description: Global microagents are [keyword-triggered microagents](/openhands/usage/microagents/microagents-keyword) that apply to all OpenHands users. A list of the current global microagents can be found [in the OpenHands repository](https://github.com/All-Hands-AI/OpenHands/tree/main/microagents).
+description: Global microagents are [keyword-triggered microagents](/openhands/usage/microagents/microagents-keyword) that apply to all OpenHands users. A list of the current global microagents can be found [in the OpenHands repository](https://github.com/OpenHands/OpenHands/tree/main/microagents).
 ---
 
 ## Contributing a Global Microagent
 
 You can create global microagents and share with the community by opening a pull request to the official repository.
 
-See the [CONTRIBUTING.md](https://github.com/All-Hands-AI/OpenHands/blob/main/CONTRIBUTING.md) for specific instructions on how to contribute to OpenHands.
+See the [CONTRIBUTING.md](https://github.com/OpenHands/OpenHands/blob/main/CONTRIBUTING.md) for specific instructions on how to contribute to OpenHands.
 
 ### Global Microagents Best Practices
 
@@ -31,7 +31,7 @@ Before creating a global microagent, consider:
 #### 2. Create File
 
 Create a new Markdown file with a descriptive name in the appropriate directory:
-[`microagents/`](https://github.com/All-Hands-AI/OpenHands/tree/main/microagents)
+[`microagents/`](https://github.com/OpenHands/OpenHands/tree/main/microagents)
 
 #### 3. Testing the Global Microagent
 

--- a/openhands/usage/microagents/microagents-repo.mdx
+++ b/openhands/usage/microagents/microagents-repo.mdx
@@ -59,4 +59,4 @@ To set it up, you can run `npm run build`.
 Always make sure the tests are passing before committing changes. You can run the tests by running `npm run test`.
 ```
 
-[See more examples of general microagents here.](https://github.com/All-Hands-AI/OpenHands/tree/main/.openhands/microagents)
+[See more examples of general microagents here.](https://github.com/OpenHands/OpenHands/tree/main/.openhands/microagents)

--- a/openhands/usage/run-openhands/cli-mode.mdx
+++ b/openhands/usage/run-openhands/cli-mode.mdx
@@ -113,7 +113,7 @@ The conversation history will be saved in `~/.openhands/sessions`.
 ```bash
 docker run -it \
     --pull=always \
-    -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0.58-nikolaik \
+    -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/openhands/runtime:0.58-nikolaik \
     -e SANDBOX_USER_ID=$(id -u) \
     -e SANDBOX_VOLUMES=$SANDBOX_VOLUMES \
     -e LLM_API_KEY=$LLM_API_KEY \
@@ -122,7 +122,7 @@ docker run -it \
     -v ~/.openhands:/.openhands \
     --add-host host.docker.internal:host-gateway \
     --name openhands-app-$(date +%Y%m%d%H%M%S) \
-    docker.all-hands.dev/all-hands-ai/openhands:0.58 \
+    docker.all-hands.dev/openhands/openhands:0.58 \
     python -m openhands.cli.entry --override-cli-mode true
 ```
 

--- a/openhands/usage/run-openhands/github-action.mdx
+++ b/openhands/usage/run-openhands/github-action.mdx
@@ -15,7 +15,7 @@ The action will automatically trigger and attempt to resolve the issue.
 ## Installing the Action in a New Repository
 
 To install the OpenHands GitHub Action in your own repository, follow
-the [README for the OpenHands Resolver](https://github.com/All-Hands-AI/OpenHands/blob/main/openhands/resolver/README.md).
+the [README for the OpenHands Resolver](https://github.com/OpenHands/OpenHands/blob/main/openhands/resolver/README.md).
 
 ## Usage Tips
 
@@ -36,7 +36,7 @@ the [README for the OpenHands Resolver](https://github.com/All-Hands-AI/OpenHand
 
 ### Add custom repository settings
 
-You can provide custom directions for OpenHands by following the [README for the resolver](https://github.com/All-Hands-AI/OpenHands/blob/main/openhands/resolver/README.md#providing-custom-instructions).
+You can provide custom directions for OpenHands by following the [README for the resolver](https://github.com/OpenHands/OpenHands/blob/main/openhands/resolver/README.md#providing-custom-instructions).
 
 ### Custom configurations
 

--- a/openhands/usage/run-openhands/headless-mode.mdx
+++ b/openhands/usage/run-openhands/headless-mode.mdx
@@ -9,14 +9,14 @@ This is different from [the CLI](/openhands/usage/run-openhands/cli-mode), which
 ## With Python
 
 To run OpenHands in headless mode with Python:
-1. Ensure you have followed the [Development setup instructions](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md).
+1. Ensure you have followed the [Development setup instructions](https://github.com/OpenHands/OpenHands/blob/main/Development.md).
 2. Run the following command:
 ```bash
 poetry run python -m openhands.core.main -t "write a bash script that prints hi"
 ```
 
 You'll need to be sure to set your model, API key, and other settings via environment variables
-[or the `config.toml` file](https://github.com/All-Hands-AI/OpenHands/blob/main/config.template.toml).
+[or the `config.toml` file](https://github.com/OpenHands/OpenHands/blob/main/config.template.toml).
 
 ### Working with Repositories
 
@@ -61,7 +61,7 @@ export GITHUB_TOKEN="your-token"  # Required for repository operations
 # Run OpenHands
 docker run -it \
     --pull=always \
-    -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0.58-nikolaik \
+    -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/openhands/runtime:0.58-nikolaik \
     -e SANDBOX_USER_ID=$(id -u) \
     -e SANDBOX_VOLUMES=$SANDBOX_VOLUMES \
     -e LLM_API_KEY=$LLM_API_KEY \
@@ -73,7 +73,7 @@ docker run -it \
     -v ~/.openhands:/.openhands \
     --add-host host.docker.internal:host-gateway \
     --name openhands-app-$(date +%Y%m%d%H%M%S) \
-    docker.all-hands.dev/all-hands-ai/openhands:0.58 \
+    docker.all-hands.dev/openhands/openhands:0.58 \
     python -m openhands.core.main -t "write a bash script that prints hi"
 ```
 

--- a/openhands/usage/run-openhands/local-setup.mdx
+++ b/openhands/usage/run-openhands/local-setup.mdx
@@ -116,17 +116,17 @@ Note that you'll still need `uv` installed for the default MCP servers to work p
 <Accordion title="Docker Command (Click to expand)">
 
 ```bash
-docker pull docker.all-hands.dev/all-hands-ai/runtime:0.58-nikolaik
+docker pull docker.all-hands.dev/openhands/runtime:0.58-nikolaik
 
 docker run -it --rm --pull=always \
-    -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0.58-nikolaik \
+    -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/openhands/runtime:0.58-nikolaik \
     -e LOG_ALL_EVENTS=true \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v ~/.openhands:/.openhands \
     -p 3000:3000 \
     --add-host host.docker.internal:host-gateway \
     --name openhands-app \
-    docker.all-hands.dev/all-hands-ai/openhands:0.58
+    docker.all-hands.dev/openhands/openhands:0.58
 ```
 
 </Accordion>

--- a/openhands/usage/runtimes/daytona.mdx
+++ b/openhands/usage/runtimes/daytona.mdx
@@ -44,4 +44,4 @@ powershell -Command "irm https://get.daytona.io/openhands-windows | iex"
 
 Once executed, OpenHands should be running locally and ready for use.
 
-For more details and manual initialization, view the entire [README.md](https://github.com/All-Hands-AI/OpenHands/blob/main/openhands/runtime/impl/daytona/README.md)
+For more details and manual initialization, view the entire [README.md](https://github.com/OpenHands/OpenHands/blob/main/openhands/runtime/impl/daytona/README.md)

--- a/openhands/usage/runtimes/local.mdx
+++ b/openhands/usage/runtimes/local.mdx
@@ -14,7 +14,7 @@ files on your machine. Only use this runtime in controlled environments or when 
 
 Before using the Local Runtime, ensure that:
 
-1. You can run OpenHands using the [Development workflow](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md).
+1. You can run OpenHands using the [Development workflow](https://github.com/OpenHands/OpenHands/blob/main/Development.md).
 2. For Linux and Mac, tmux is available on your system.
 3. For Windows, PowerShell is available on your system.
     - Only [CLI mode](/openhands/usage/run-openhands/cli-mode) and [headless mode](/openhands/usage/run-openhands/headless-mode) are supported in Windows with Local Runtime.
@@ -22,7 +22,7 @@ Before using the Local Runtime, ensure that:
 ## Configuration
 
 To use the Local Runtime, besides required configurations like the LLM provider, model and API key, you'll need to set
-the following options via environment variables or the [config.toml file](https://github.com/All-Hands-AI/OpenHands/blob/main/config.template.toml) when starting OpenHands:
+the following options via environment variables or the [config.toml file](https://github.com/OpenHands/OpenHands/blob/main/config.template.toml) when starting OpenHands:
 
 Via environment variables (please use PowerShell syntax for Windows PowerShell):
 

--- a/openhands/usage/runtimes/remote.mdx
+++ b/openhands/usage/runtimes/remote.mdx
@@ -1,7 +1,7 @@
 ---
 title: Remote Runtime
 description: This runtime is specifically designed for agent evaluation purposes only through the
-  [OpenHands evaluation harness](https://github.com/All-Hands-AI/OpenHands/tree/main/evaluation). It should not be
+  [OpenHands evaluation harness](https://github.com/OpenHands/OpenHands/tree/main/evaluation). It should not be
   used to launch production OpenHands applications.
 ---
 

--- a/openhands/usage/troubleshooting/troubleshooting.mdx
+++ b/openhands/usage/troubleshooting/troubleshooting.mdx
@@ -86,14 +86,14 @@ To fix this:
    ```bash
    docker run -it --rm \
        -e SANDBOX_VSCODE_PORT=41234 \
-       -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:latest \
+       -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/openhands/runtime:latest \
        -v /var/run/docker.sock:/var/run/docker.sock \
        -v ~/.openhands:/.openhands \
        -p 3000:3000 \
        -p 41234:41234 \
        --add-host host.docker.internal:host-gateway \
        --name openhands-app \
-       docker.all-hands.dev/all-hands-ai/openhands:latest
+       docker.all-hands.dev/openhands/openhands:latest
    ```
 
    > **Note**: If you used OpenHands before version 0.44, you may want to run `mv ~/.openhands-state ~/.openhands` to migrate your conversation history to the new location.

--- a/openhands/usage/windows-without-wsl.mdx
+++ b/openhands/usage/windows-without-wsl.mdx
@@ -80,7 +80,7 @@ This guide provides step-by-step instructions for running OpenHands on a Windows
 
 1. **Clone the Repository**
    ```powershell
-   git clone https://github.com/All-Hands-AI/OpenHands.git
+   git clone https://github.com/OpenHands/OpenHands.git
    cd OpenHands
    ```
 

--- a/sdk/index.mdx
+++ b/sdk/index.mdx
@@ -3,13 +3,13 @@ title: Introduction
 description: A clean, modular SDK for building AI agents. Core agent framework and production-ready tool implementations.
 ---
 
-The [OpenHands SDK](https://github.com/All-Hands-AI/agent-sdk) allows you to build things with agents that write software. For instance, some use cases include:
+The [OpenHands SDK](https://github.com/OpenHands/agent-sdk) allows you to build things with agents that write software. For instance, some use cases include:
 
 1. A documentation system that checks the changes made to your codebase this week and updates them
 2. An SRE system that reads your server logs and your codebase, then uses this info to debug new errors that are appearing in prod
 3. A customer onboarding system that takes all of their documents in unstructured format and enters information into your database
 
-This SDK also powers [OpenHands](https://github.com/All-Hands-AI/OpenHands), an all-batteries-included coding agent that you can access through a GUI, CLI, or API.
+This SDK also powers [OpenHands](https://github.com/OpenHands/OpenHands), an all-batteries-included coding agent that you can access through a GUI, CLI, or API.
 
 ## Hello World Example
 
@@ -67,7 +67,7 @@ Once this is done, run the following to do a Hello World example.
 
 ```bash
 # Clone the repository
-git clone https://github.com/All-Hands-AI/agent-sdk.git
+git clone https://github.com/OpenHands/agent-sdk.git
 cd agent-sdk
 
 # Install dependencies and setup development environment

--- a/tests/README.md
+++ b/tests/README.md
@@ -23,4 +23,4 @@ This test verifies that the pricing information in the OpenHands LLM documentati
 
 The test fetches data from:
 - LiteLLM's pricing JSON: https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json
-- OpenHands model list: https://github.com/All-Hands-AI/OpenHands/blob/main/openhands/utils/llm.py
+- OpenHands model list: https://github.com/OpenHands/OpenHands/blob/main/openhands/utils/llm.py

--- a/tests/test_pricing_documentation.py
+++ b/tests/test_pricing_documentation.py
@@ -25,7 +25,7 @@ class TestPricingDocumentation:
     def openhands_models(self) -> list[str]:
         """Get the list of OpenHands models from the OpenHands repository."""
         # Since this test is now in the docs repository, we need to fetch from OpenHands
-        url = 'https://raw.githubusercontent.com/All-Hands-AI/OpenHands/main/openhands/utils/llm.py'
+        url = 'https://raw.githubusercontent.com/OpenHands/OpenHands/main/openhands/utils/llm.py'
         response = requests.get(url)
         response.raise_for_status()
         content = response.text


### PR DESCRIPTION
This PR replaces all occurrences of 'All-Hands-AI' with 'OpenHands' or 'openhands' while preserving case patterns.

## Changes made:
- `All-Hands-AI` → `OpenHands`
- `all-hands-ai` → `openhands`
- `ALL-HANDS-AI` → `OPENHANDS`
- Other case variations handled appropriately

This is part of the organization rebranding effort.

## Files changed:
- 26 files were modified

## Review notes:
- All changes are simple string replacements
- Case patterns are preserved
- No functional changes to code logic