### PR TITLE
Disable auto sync for sdk on branches.

### DIFF
--- a/.github/workflows/sync-agent-sdk-openapi.yml
+++ b/.github/workflows/sync-agent-sdk-openapi.yml
@@ -1,9 +1,6 @@
 name: Sync agent-sdk OpenAPI
 
 on:
-  push:
-    branches:
-      - '**'      # run on every branch
   schedule:
     - cron: '0 2 * * *'   # nightly catch-up
   workflow_dispatch:

--- a/.github/workflows/sync-docs-code-blocks.yml
+++ b/.github/workflows/sync-docs-code-blocks.yml
@@ -1,9 +1,6 @@
 name: Sync Documentation Code Blocks
 
 on:
-  push:
-    branches:
-      - '**'   # run on every branch
   schedule:
     # Run daily at 2 AM UTC to catch any changes
     - cron: '0 2 * * *'


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [x] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

Disable auto sync for sdk on branches. This workflow makes it so the PRs have commits that the author didn't write. Disabling on branches.