### PR TITLE
docs: Update GitHub repository URLs from All-Hands-AI to OpenHands

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -61,52 +61,52 @@
               {
                 "group": "Advanced Configuration",
                 "pages": [
-                {
-                  "group": "LLM Configuration",
-                  "pages": [
-                    "openhands/usage/llms/llms",
-                    {
-                      "group": "Providers",
-                      "pages": [
-                        "openhands/usage/llms/openhands-llms",
-                        "openhands/usage/llms/azure-llms",
-                        "openhands/usage/llms/google-llms",
-                        "openhands/usage/llms/groq",
-                        "openhands/usage/llms/local-llms",
-                        "openhands/usage/llms/litellm-proxy",
-                        "openhands/usage/llms/moonshot",
-                        "openhands/usage/llms/openai-llms",
-                        "openhands/usage/llms/openrouter"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "group": "Runtime Configuration",
-                  "pages": [
-                    "openhands/usage/runtimes/overview",
-                    {
-                      "group": "Providers",
-                      "pages": [
-                        "openhands/usage/runtimes/docker",
-                        "openhands/usage/runtimes/remote",
-                        "openhands/usage/runtimes/local",
-                        {
-                          "group": "Third-Party Providers",
-                          "pages": [
-                            "openhands/usage/runtimes/modal",
-                            "openhands/usage/runtimes/daytona",
-                            "openhands/usage/runtimes/runloop",
-                            "openhands/usage/runtimes/e2b"
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                },
-                "openhands/usage/advanced/configuration-options",
-                "openhands/usage/advanced/custom-sandbox-guide",
-                "openhands/usage/advanced/search-engine-setup"
+                  {
+                    "group": "LLM Configuration",
+                    "pages": [
+                      "openhands/usage/llms/llms",
+                      {
+                        "group": "Providers",
+                        "pages": [
+                          "openhands/usage/llms/openhands-llms",
+                          "openhands/usage/llms/azure-llms",
+                          "openhands/usage/llms/google-llms",
+                          "openhands/usage/llms/groq",
+                          "openhands/usage/llms/local-llms",
+                          "openhands/usage/llms/litellm-proxy",
+                          "openhands/usage/llms/moonshot",
+                          "openhands/usage/llms/openai-llms",
+                          "openhands/usage/llms/openrouter"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Runtime Configuration",
+                    "pages": [
+                      "openhands/usage/runtimes/overview",
+                      {
+                        "group": "Providers",
+                        "pages": [
+                          "openhands/usage/runtimes/docker",
+                          "openhands/usage/runtimes/remote",
+                          "openhands/usage/runtimes/local",
+                          {
+                            "group": "Third-Party Providers",
+                            "pages": [
+                              "openhands/usage/runtimes/modal",
+                              "openhands/usage/runtimes/daytona",
+                              "openhands/usage/runtimes/runloop",
+                              "openhands/usage/runtimes/e2b"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "openhands/usage/advanced/configuration-options",
+                  "openhands/usage/advanced/custom-sandbox-guide",
+                  "openhands/usage/advanced/search-engine-setup"
                 ]
               }
             ]
@@ -140,9 +140,7 @@
           },
           {
             "group": "Tips and Tricks",
-            "pages": [
-              "openhands/usage/tips/prompting-best-practices"
-            ]
+            "pages": ["openhands/usage/tips/prompting-best-practices"]
           },
           {
             "group": "Troubleshooting & Feedback",
@@ -264,14 +262,12 @@
         ]
       },
       {
-          "tab": "REST API",
-          "openapi": "openapi/openapi.json"
+        "tab": "REST API",
+        "openapi": "openapi/openapi.json"
       },
       {
         "tab": "Success Stories",
-        "pages": [
-          "success-stories/index"
-        ]
+        "pages": ["success-stories/index"]
       }
     ],
     "global": {
@@ -299,21 +295,20 @@
     "dark": "/logo/dark.png"
   },
   "navbar": {
-    "links": [
-    ],
+    "links": [],
     "primary": {
       "type": "github",
-      "href": "https://github.com/All-Hands-AI/OpenHands"
+      "href": "https://github.com/OpenHands/OpenHands"
     }
   },
   "footer": {
     "socials": {
       "slack": "https://openhands.dev/joinslack",
-      "github": "https://github.com/All-Hands-AI/OpenHands"
+      "github": "https://github.com/OpenHands/OpenHands"
     }
   },
   "banner": {
-    "content": "📢 **GitHub Org Rename:** All-Hands-AI to OpenHands on Monday Oct 20th at 18:00 UTC. [Migration details →](https://github.com/All-Hands-AI/OpenHands/issues/11376)",
+    "content": "📢 **GitHub Org Rename:** All-Hands-AI to OpenHands on Monday Oct 20th at 18:00 UTC. [Migration details →](https://github.com/OpenHands/OpenHands/issues/11376)",
     "dismissible": true
   },
   "head": [
@@ -325,37 +320,98 @@
     }
   ],
   "contextual": {
-    "options": [
-      "copy",
-      "view",
-      "chatgpt",
-      "claude"
-    ]
+    "options": ["copy", "view", "chatgpt", "claude"]
   },
   "redirects": [
-    { "source": "/modules/:slug*", "destination": "/:slug*"},
-    { "source": "/usage/:slug*", "destination": "/openhands/usage/:slug*"},
-    { "source": "/openhands/usage/configuration-options", "destination": "/openhands/usage/advanced/configuration-options" },
-    { "source": "/openhands/usage/how-to/custom-sandbox-guide", "destination": "/openhands/usage/advanced/custom-sandbox-guide" },
-    { "source": "/openhands/usage/search-engine-setup", "destination": "/openhands/usage/advanced/search-engine-setup" },
-    { "source": "/openhands/usage/prompting/repository", "destination": "/openhands/usage/customization/repository" },
-    { "source": "/openhands/usage/how-to/debugging", "destination": "/openhands/usage/developers/debugging" },
-    { "source": "/openhands/usage/how-to/development-overview", "destination": "/openhands/usage/developers/development-overview" },
-    { "source": "/openhands/usage/how-to/evaluation-harness", "destination": "/openhands/usage/developers/evaluation-harness" },
-    { "source": "/openhands/usage/how-to/websocket-connection", "destination": "/openhands/usage/developers/websocket-connection" },
-    { "source": "/openhands/usage/prompting/microagents-keyword", "destination": "/openhands/usage/microagents/microagents-keyword" },
-    { "source": "/openhands/usage/prompting/microagents-org", "destination": "/openhands/usage/microagents/microagents-org" },
-    { "source": "/openhands/usage/prompting/microagents-overview", "destination": "/openhands/usage/microagents/microagents-overview" },
-    { "source": "/openhands/usage/prompting/microagents-public", "destination": "/openhands/usage/microagents/microagents-public" },
-    { "source": "/openhands/usage/prompting/microagents-repo", "destination": "/openhands/usage/microagents/microagents-repo" },
-    { "source": "/openhands/usage/installation", "destination": "/openhands/usage/quick-start" },
-    { "source": "/openhands/usage/how-to/cli-mode", "destination": "/openhands/usage/run-openhands/cli-mode" },
-    { "source": "/openhands/usage/how-to/github-action", "destination": "/openhands/usage/run-openhands/github-action" },
-    { "source": "/openhands/usage/how-to/gui-mode", "destination": "/openhands/usage/run-openhands/gui-mode" },
-    { "source": "/openhands/usage/how-to/headless-mode", "destination": "/openhands/usage/run-openhands/headless-mode" },
-    { "source": "/openhands/usage/local-setup", "destination": "/openhands/usage/run-openhands/local-setup" },
-    { "source": "/openhands/usage/getting-started", "destination": "/openhands/usage/start-building" },
-    { "source": "/openhands/usage/prompting/prompting-best-practices", "destination": "/openhands/usage/tips/prompting-best-practices" },
-    { "source": "/openhands/usage/feedback", "destination": "/openhands/usage/troubleshooting/feedback" }
+    { "source": "/modules/:slug*", "destination": "/:slug*" },
+    { "source": "/usage/:slug*", "destination": "/openhands/usage/:slug*" },
+    {
+      "source": "/openhands/usage/configuration-options",
+      "destination": "/openhands/usage/advanced/configuration-options"
+    },
+    {
+      "source": "/openhands/usage/how-to/custom-sandbox-guide",
+      "destination": "/openhands/usage/advanced/custom-sandbox-guide"
+    },
+    {
+      "source": "/openhands/usage/search-engine-setup",
+      "destination": "/openhands/usage/advanced/search-engine-setup"
+    },
+    {
+      "source": "/openhands/usage/prompting/repository",
+      "destination": "/openhands/usage/customization/repository"
+    },
+    {
+      "source": "/openhands/usage/how-to/debugging",
+      "destination": "/openhands/usage/developers/debugging"
+    },
+    {
+      "source": "/openhands/usage/how-to/development-overview",
+      "destination": "/openhands/usage/developers/development-overview"
+    },
+    {
+      "source": "/openhands/usage/how-to/evaluation-harness",
+      "destination": "/openhands/usage/developers/evaluation-harness"
+    },
+    {
+      "source": "/openhands/usage/how-to/websocket-connection",
+      "destination": "/openhands/usage/developers/websocket-connection"
+    },
+    {
+      "source": "/openhands/usage/prompting/microagents-keyword",
+      "destination": "/openhands/usage/microagents/microagents-keyword"
+    },
+    {
+      "source": "/openhands/usage/prompting/microagents-org",
+      "destination": "/openhands/usage/microagents/microagents-org"
+    },
+    {
+      "source": "/openhands/usage/prompting/microagents-overview",
+      "destination": "/openhands/usage/microagents/microagents-overview"
+    },
+    {
+      "source": "/openhands/usage/prompting/microagents-public",
+      "destination": "/openhands/usage/microagents/microagents-public"
+    },
+    {
+      "source": "/openhands/usage/prompting/microagents-repo",
+      "destination": "/openhands/usage/microagents/microagents-repo"
+    },
+    {
+      "source": "/openhands/usage/installation",
+      "destination": "/openhands/usage/quick-start"
+    },
+    {
+      "source": "/openhands/usage/how-to/cli-mode",
+      "destination": "/openhands/usage/run-openhands/cli-mode"
+    },
+    {
+      "source": "/openhands/usage/how-to/github-action",
+      "destination": "/openhands/usage/run-openhands/github-action"
+    },
+    {
+      "source": "/openhands/usage/how-to/gui-mode",
+      "destination": "/openhands/usage/run-openhands/gui-mode"
+    },
+    {
+      "source": "/openhands/usage/how-to/headless-mode",
+      "destination": "/openhands/usage/run-openhands/headless-mode"
+    },
+    {
+      "source": "/openhands/usage/local-setup",
+      "destination": "/openhands/usage/run-openhands/local-setup"
+    },
+    {
+      "source": "/openhands/usage/getting-started",
+      "destination": "/openhands/usage/start-building"
+    },
+    {
+      "source": "/openhands/usage/prompting/prompting-best-practices",
+      "destination": "/openhands/usage/tips/prompting-best-practices"
+    },
+    {
+      "source": "/openhands/usage/feedback",
+      "destination": "/openhands/usage/troubleshooting/feedback"
+    }
   ]
 }

--- a/index.mdx
+++ b/index.mdx
@@ -120,7 +120,7 @@ it can modify code, run commands, browse the web, call APIs, and yes-even copy c
   </Card>
   <Card
     title="Create GitHub Issues"
-    href="https://github.com/All-Hands-AI/OpenHands/issues"
+    href="https://github.com/OpenHands/OpenHands/issues"
   >
     Report and look for issues in Github.
   </Card>

--- a/openhands/usage/about.mdx
+++ b/openhands/usage/about.mdx
@@ -27,4 +27,4 @@ enhance the capabilities of OpenHands.
 
 ## License
 
-Distributed under MIT [License](https://github.com/All-Hands-AI/OpenHands/blob/main/LICENSE).
+Distributed under MIT [License](https://github.com/OpenHands/OpenHands/blob/main/LICENSE).

--- a/openhands/usage/advanced/custom-sandbox-guide.mdx
+++ b/openhands/usage/advanced/custom-sandbox-guide.mdx
@@ -60,7 +60,7 @@ docker run -it --rm --pull=always \
 
 ### Setup
 
-First, ensure you can run OpenHands by following the instructions in [Development.md](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md).
+First, ensure you can run OpenHands by following the instructions in [Development.md](https://github.com/OpenHands/OpenHands/blob/main/Development.md).
 
 ### Specify the Base Sandbox Image
 

--- a/openhands/usage/agents.mdx
+++ b/openhands/usage/agents.mdx
@@ -17,10 +17,10 @@ The conceptual idea is illustrated below. At each turn, the agent can:
 - Execute any valid Linux `bash` command
 - Execute any valid `Python` code with [an interactive Python interpreter](https://ipython.org/). This is simulated through `bash` command, see plugin system below for more details.
 
-![image](https://github.com/All-Hands-AI/OpenHands/assets/38853559/92b622e3-72ad-4a61-8f41-8c040b6d5fb3)
+![image](https://github.com/OpenHands/OpenHands/assets/38853559/92b622e3-72ad-4a61-8f41-8c040b6d5fb3)
 
 ### Demo
 
-https://github.com/All-Hands-AI/OpenHands/assets/38853559/f592a192-e86c-4f48-ad31-d69282d5f6ac
+https://github.com/OpenHands/OpenHands/assets/38853559/f592a192-e86c-4f48-ad31-d69282d5f6ac
 
 _Example of CodeActAgent with `gpt-4-turbo-2024-04-09` performing a data science task (linear regression)_.

--- a/openhands/usage/architecture/runtime.mdx
+++ b/openhands/usage/architecture/runtime.mdx
@@ -67,7 +67,7 @@ The role of the client:
 
 OpenHands' approach to building and managing runtime images ensures efficiency, consistency, and flexibility in creating and maintaining Docker images for both production and development environments.
 
-Check out the [relevant code](https://github.com/All-Hands-AI/OpenHands/blob/main/openhands/runtime/utils/runtime_build.py) if you are interested in more details.
+Check out the [relevant code](https://github.com/OpenHands/OpenHands/blob/main/openhands/runtime/utils/runtime_build.py) if you are interested in more details.
 
 ### Image Tagging System
 

--- a/openhands/usage/cloud/slack-installation.mdx
+++ b/openhands/usage/cloud/slack-installation.mdx
@@ -81,7 +81,7 @@ Initial request is followed up by mentioning `@openhands` in a thread reply.
 You can mention a repo name when starting a new conversation in the following formats
 
 1. "My-Repo" repo (e.g `@openhands in the openhands repo ...`)
-2. "All-Hands-AI/OpenHands" (e.g `@openhands in All-Hands-AI/OpenHands ...`)
+2. "OpenHands/OpenHands" (e.g `@openhands in OpenHands/OpenHands ...`)
 
 The repo match is case insensitive. If a repo name match is made, it will kick off the conversation.
 If the repo name partially matches against multiple repos, you'll be asked to select a repo from the filtered list.

--- a/openhands/usage/contributing.mdx
+++ b/openhands/usage/contributing.mdx
@@ -71,9 +71,9 @@ Ready to contribute? Here's your path to making an impact:
 
 ### 1. Quick Wins
 Start with these easy contributions:
-- **Use OpenHands** and [report issues](https://github.com/All-Hands-AI/OpenHands/issues) you encounter
+- **Use OpenHands** and [report issues](https://github.com/OpenHands/OpenHands/issues) you encounter
 - **Give feedback** using the thumbs-up/thumbs-down buttons after each session
-- **Star our repository** on [GitHub](https://github.com/All-Hands-AI/OpenHands)
+- **Star our repository** on [GitHub](https://github.com/OpenHands/OpenHands)
 - **Share OpenHands** with other developers
 
 ### 2. Set Up Your Development Environment
@@ -83,12 +83,12 @@ Follow our comprehensive setup guide:
 - **Configuration**: `make setup-config` to configure your LLM
 - **Run locally**: `make run` to start the application
 
-*Full details in our [Development Guide](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md)*
+*Full details in our [Development Guide](https://github.com/OpenHands/OpenHands/blob/main/Development.md)*
 
 ### 3. Find Your First Issue
 Look for beginner-friendly opportunities:
-- Browse [good first issues](https://github.com/All-Hands-AI/OpenHands/labels/good%20first%20issue)
-- Check our [project boards](https://github.com/All-Hands-AI/OpenHands/projects) for organized tasks
+- Browse [good first issues](https://github.com/OpenHands/OpenHands/labels/good%20first%20issue)
+- Check our [project boards](https://github.com/OpenHands/OpenHands/projects) for organized tasks
 - Ask in [Slack](https://openhands.dev/joinslack) what needs help
 
 ### 4. Join the Community
@@ -98,11 +98,11 @@ Connect with other contributors in our [Slack Community](https://openhands.dev/j
 
 ### Understanding the Codebase
 Get familiar with our architecture:
-- **[Frontend](https://github.com/All-Hands-AI/OpenHands/tree/main/frontend/README.md)** - React application
-- **[Backend](https://github.com/All-Hands-AI/OpenHands/tree/main/openhands/README.md)** - Python core
-- **[Agents](https://github.com/All-Hands-AI/OpenHands/tree/main/openhands/agenthub/README.md)** - AI agent implementations
-- **[Runtime](https://github.com/All-Hands-AI/OpenHands/tree/main/openhands/runtime/README.md)** - Execution environments
-- **[Evaluation](https://github.com/All-Hands-AI/OpenHands/tree/main/evaluation/README.md)** - Testing and benchmarks
+- **[Frontend](https://github.com/OpenHands/OpenHands/tree/main/frontend/README.md)** - React application
+- **[Backend](https://github.com/OpenHands/OpenHands/tree/main/openhands/README.md)** - Python core
+- **[Agents](https://github.com/OpenHands/OpenHands/tree/main/openhands/agenthub/README.md)** - AI agent implementations
+- **[Runtime](https://github.com/OpenHands/OpenHands/tree/main/openhands/runtime/README.md)** - Execution environments
+- **[Evaluation](https://github.com/OpenHands/OpenHands/tree/main/evaluation/README.md)** - Testing and benchmarks
 
 ### Pull Request Process
 We welcome all pull requests! Here's how we evaluate them:
@@ -118,7 +118,7 @@ We're more careful with agent changes since they affect user experience:
 - **Efficiency** - Does it improve speed or reduce resource usage?
 - **Code Quality** - Is the code maintainable and well-tested?
 
-*Discuss major changes in [GitHub issues](https://github.com/All-Hands-AI/OpenHands/issues) or [Slack](https://openhands.dev/joinslack) first!*
+*Discuss major changes in [GitHub issues](https://github.com/OpenHands/OpenHands/issues) or [Slack](https://openhands.dev/joinslack) first!*
 
 ### Pull Request Guidelines
 We recommend the following for smooth reviews but they're not required. Just know that the more you follow these guidelines, the more likely you'll get your PR reviewed faster and reduce the quantity of revisions.
@@ -146,7 +146,7 @@ We recommend the following for smooth reviews but they're not required. Just kno
 - **Respectful** - We treat everyone with kindness and professionalism
 
 ### Code of Conduct
-We follow the [Contributor Covenant Code of Conduct](https://github.com/All-Hands-AI/OpenHands/blob/main/CODE_OF_CONDUCT.md). In summary:
+We follow the [Contributor Covenant Code of Conduct](https://github.com/OpenHands/OpenHands/blob/main/CODE_OF_CONDUCT.md). In summary:
 - Be respectful and inclusive
 - Focus on constructive feedback
 - Help create a welcoming environment
@@ -176,7 +176,7 @@ OpenHands is released under the **MIT License**, which means:
 - OpenHands is provided "as is" without warranty
 - Contributors are not liable for any damages
 
-*Full license text: [LICENSE](https://github.com/All-Hands-AI/OpenHands/blob/main/LICENSE)*
+*Full license text: [LICENSE](https://github.com/OpenHands/OpenHands/blob/main/LICENSE)*
 
 **Special Note:** Content in the `enterprise/` directory has a separate license. See `enterprise/LICENSE` for details.
 
@@ -184,17 +184,17 @@ OpenHands is released under the **MIT License**, which means:
 
 Ready to make your first contribution?
 
-1. **⭐ Star** our [GitHub repository](https://github.com/All-Hands-AI/OpenHands)
-2. **🔧 Set up** your development environment using our [Development Guide](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md)
+1. **⭐ Star** our [GitHub repository](https://github.com/OpenHands/OpenHands)
+2. **🔧 Set up** your development environment using our [Development Guide](https://github.com/OpenHands/OpenHands/blob/main/Development.md)
 3. **💬 Join** our [Slack community](https://openhands.dev/joinslack) to meet other contributors
-4. **🎯 Find** a [good first issue](https://github.com/All-Hands-AI/OpenHands/labels/good%20first%20issue) to work on
-5. **📝 Read** our [Code of Conduct](https://github.com/All-Hands-AI/OpenHands/blob/main/CODE_OF_CONDUCT.md)
+4. **🎯 Find** a [good first issue](https://github.com/OpenHands/OpenHands/labels/good%20first%20issue) to work on
+5. **📝 Read** our [Code of Conduct](https://github.com/OpenHands/OpenHands/blob/main/CODE_OF_CONDUCT.md)
 
 ## 🆘 Need Help?
 
 Don't hesitate to ask for help:
 - **Slack**: [Join our community](https://openhands.dev/joinslack) for real-time support
-- **GitHub Issues**: [Open an issue](https://github.com/All-Hands-AI/OpenHands/issues) for bugs or feature requests
+- **GitHub Issues**: [Open an issue](https://github.com/OpenHands/OpenHands/issues) for bugs or feature requests
 - **Email**: Contact us at [contact@openhands.dev](mailto:contact@openhands.dev)
 
 ---

--- a/openhands/usage/developers/evaluation-harness.mdx
+++ b/openhands/usage/developers/evaluation-harness.mdx
@@ -6,7 +6,7 @@ This guide provides an overview of how to integrate your own evaluation benchmar
 
 ## Setup Environment and LLM Configuration
 
-Please follow instructions [here](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md) to setup your local development environment.
+Please follow instructions [here](https://github.com/OpenHands/OpenHands/blob/main/Development.md) to setup your local development environment.
 OpenHands in development mode uses `config.toml` to keep track of most configurations.
 
 Here's an example configuration file you can use to define and use multiple LLMs:
@@ -75,7 +75,7 @@ The `run_controller()` function is the core of OpenHands's execution. It manages
 
 ## Easiest way to get started: Exploring Existing Benchmarks
 
-We encourage you to review the various evaluation benchmarks available in the [`evaluation/benchmarks/` directory](https://github.com/All-Hands-AI/OpenHands/blob/main/evaluation/benchmarks) of our repository.
+We encourage you to review the various evaluation benchmarks available in the [`evaluation/benchmarks/` directory](https://github.com/OpenHands/OpenHands/blob/main/evaluation/benchmarks) of our repository.
 
 To integrate your own benchmark, we suggest starting with the one that most closely resembles your needs. This approach can significantly streamline your integration process, allowing you to build upon existing structures and adapt them to your specific requirements.
 

--- a/openhands/usage/faqs.mdx
+++ b/openhands/usage/faqs.mdx
@@ -22,7 +22,7 @@ OpenHands is meant to be run by a single user on their local workstation. It is 
 deployments where multiple users share the same instance. There is no built-in authentication, isolation, or scalability.
 
 If you're interested in running OpenHands in a multi-tenant environment, check out the source-available,
-commercially-licensed [OpenHands Cloud Helm Chart](https://github.com/all-Hands-AI/OpenHands-cloud).
+commercially-licensed [OpenHands Cloud Helm Chart](https://github.com/OpenHands/OpenHands-cloud).
 
 <Info>
 Using OpenHands for work? We'd love to chat! Fill out
@@ -87,11 +87,11 @@ If you would like to set things up more systematically, you can:
 
 ### Something's not working. Where can I get help?
 
-1. **Search existing issues**: Check our [GitHub issues](https://github.com/All-Hands-AI/OpenHands/issues) to see if
+1. **Search existing issues**: Check our [GitHub issues](https://github.com/OpenHands/OpenHands/issues) to see if
   others have encountered the same problem.
 2. **Join our community**: Get help from other users and developers:
    - [Slack community](https://dub.sh/openhands)
 3. **Check our troubleshooting guide**: Common issues and solutions are documented in
   [Troubleshooting](/openhands/usage/troubleshooting/troubleshooting).
-4. **Report bugs**: If you've found a bug, please [create an issue](https://github.com/All-Hands-AI/OpenHands/issues/new)
+4. **Report bugs**: If you've found a bug, please [create an issue](https://github.com/OpenHands/OpenHands/issues/new)
   and fill in as much detail as possible.

--- a/openhands/usage/llms/local-llms.mdx
+++ b/openhands/usage/llms/local-llms.mdx
@@ -204,7 +204,7 @@ Run OpenHands using [the official docker run command](/openhands/usage/run-openh
 
 #### Using Development Mode
 
-Use the instructions in [Development.md](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md) to build OpenHands.
+Use the instructions in [Development.md](https://github.com/OpenHands/OpenHands/blob/main/Development.md) to build OpenHands.
 
 Start OpenHands using `make run`.
 

--- a/openhands/usage/microagents/microagents-keyword.mdx
+++ b/openhands/usage/microagents/microagents-keyword.mdx
@@ -33,4 +33,4 @@ triggers:
 The user has said the magic word. Respond with "That was delicious!"
 ```
 
-[See examples of microagents triggered by keywords in the official OpenHands repository](https://github.com/All-Hands-AI/OpenHands/tree/main/microagents)
+[See examples of microagents triggered by keywords in the official OpenHands repository](https://github.com/OpenHands/OpenHands/tree/main/microagents)

--- a/openhands/usage/microagents/microagents-public.mdx
+++ b/openhands/usage/microagents/microagents-public.mdx
@@ -1,13 +1,13 @@
 ---
 title: Global Microagents
-description: Global microagents are [keyword-triggered microagents](/openhands/usage/microagents/microagents-keyword) that apply to all OpenHands users. A list of the current global microagents can be found [in the OpenHands repository](https://github.com/All-Hands-AI/OpenHands/tree/main/microagents).
+description: Global microagents are [keyword-triggered microagents](/openhands/usage/microagents/microagents-keyword) that apply to all OpenHands users. A list of the current global microagents can be found [in the OpenHands repository](https://github.com/OpenHands/OpenHands/tree/main/microagents).
 ---
 
 ## Contributing a Global Microagent
 
 You can create global microagents and share with the community by opening a pull request to the official repository.
 
-See the [CONTRIBUTING.md](https://github.com/All-Hands-AI/OpenHands/blob/main/CONTRIBUTING.md) for specific instructions on how to contribute to OpenHands.
+See the [CONTRIBUTING.md](https://github.com/OpenHands/OpenHands/blob/main/CONTRIBUTING.md) for specific instructions on how to contribute to OpenHands.
 
 ### Global Microagents Best Practices
 
@@ -31,7 +31,7 @@ Before creating a global microagent, consider:
 #### 2. Create File
 
 Create a new Markdown file with a descriptive name in the appropriate directory:
-[`microagents/`](https://github.com/All-Hands-AI/OpenHands/tree/main/microagents)
+[`microagents/`](https://github.com/OpenHands/OpenHands/tree/main/microagents)
 
 #### 3. Testing the Global Microagent
 

--- a/openhands/usage/microagents/microagents-repo.mdx
+++ b/openhands/usage/microagents/microagents-repo.mdx
@@ -59,4 +59,4 @@ To set it up, you can run `npm run build`.
 Always make sure the tests are passing before committing changes. You can run the tests by running `npm run test`.
 ```
 
-[See more examples of general microagents here.](https://github.com/All-Hands-AI/OpenHands/tree/main/.openhands/microagents)
+[See more examples of general microagents here.](https://github.com/OpenHands/OpenHands/tree/main/.openhands/microagents)

--- a/openhands/usage/run-openhands/cli-mode.mdx
+++ b/openhands/usage/run-openhands/cli-mode.mdx
@@ -47,7 +47,7 @@ configuration format has changed.
   </Tab>
   <Tab title="Executable Binary">
       1. Download the executable binary from
-     [OpenHands release page](https://github.com/All-Hands-AI/OpenHands/releases/tag/1.0.1-cli) and rename it to
+     [OpenHands release page](https://github.com/OpenHands/OpenHands/releases/tag/1.0.1-cli) and rename it to
      `openhands` for simplicity.
 
       2. Make it executable:

--- a/openhands/usage/run-openhands/github-action.mdx
+++ b/openhands/usage/run-openhands/github-action.mdx
@@ -15,7 +15,7 @@ The action will automatically trigger and attempt to resolve the issue.
 ## Installing the Action in a New Repository
 
 To install the OpenHands GitHub Action in your own repository, follow
-the [README for the OpenHands Resolver](https://github.com/All-Hands-AI/OpenHands/blob/main/openhands/resolver/README.md).
+the [README for the OpenHands Resolver](https://github.com/OpenHands/OpenHands/blob/main/openhands/resolver/README.md).
 
 ## Usage Tips
 
@@ -36,7 +36,7 @@ the [README for the OpenHands Resolver](https://github.com/All-Hands-AI/OpenHand
 
 ### Add custom repository settings
 
-You can provide custom directions for OpenHands by following the [README for the resolver](https://github.com/All-Hands-AI/OpenHands/blob/main/openhands/resolver/README.md#providing-custom-instructions).
+You can provide custom directions for OpenHands by following the [README for the resolver](https://github.com/OpenHands/OpenHands/blob/main/openhands/resolver/README.md#providing-custom-instructions).
 
 ### Custom configurations
 

--- a/openhands/usage/run-openhands/headless-mode.mdx
+++ b/openhands/usage/run-openhands/headless-mode.mdx
@@ -9,14 +9,14 @@ This is different from [the CLI](/openhands/usage/run-openhands/cli-mode), which
 ## With Python
 
 To run OpenHands in headless mode with Python:
-1. Ensure you have followed the [Development setup instructions](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md).
+1. Ensure you have followed the [Development setup instructions](https://github.com/OpenHands/OpenHands/blob/main/Development.md).
 2. Run the following command:
 ```bash
 poetry run python -m openhands.core.main -t "write a bash script that prints hi"
 ```
 
 You'll need to be sure to set your model, API key, and other settings via environment variables
-[or the `config.toml` file](https://github.com/All-Hands-AI/OpenHands/blob/main/config.template.toml).
+[or the `config.toml` file](https://github.com/OpenHands/OpenHands/blob/main/config.template.toml).
 
 ### Working with Repositories
 

--- a/openhands/usage/runtimes/daytona.mdx
+++ b/openhands/usage/runtimes/daytona.mdx
@@ -44,4 +44,4 @@ powershell -Command "irm https://get.daytona.io/openhands-windows | iex"
 
 Once executed, OpenHands should be running locally and ready for use.
 
-For more details and manual initialization, view the entire [README.md](https://github.com/All-Hands-AI/OpenHands/blob/main/openhands/runtime/impl/daytona/README.md)
+For more details and manual initialization, view the entire [README.md](https://github.com/OpenHands/OpenHands/blob/main/openhands/runtime/impl/daytona/README.md)

--- a/openhands/usage/runtimes/local.mdx
+++ b/openhands/usage/runtimes/local.mdx
@@ -14,7 +14,7 @@ files on your machine. Only use this runtime in controlled environments or when 
 
 Before using the Local Runtime, ensure that:
 
-1. You can run OpenHands using the [Development workflow](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md).
+1. You can run OpenHands using the [Development workflow](https://github.com/OpenHands/OpenHands/blob/main/Development.md).
 2. For Linux and Mac, tmux is available on your system.
 3. For Windows, PowerShell is available on your system.
     - Only [CLI mode](/openhands/usage/run-openhands/cli-mode) and [headless mode](/openhands/usage/run-openhands/headless-mode) are supported in Windows with Local Runtime.
@@ -22,7 +22,7 @@ Before using the Local Runtime, ensure that:
 ## Configuration
 
 To use the Local Runtime, besides required configurations like the LLM provider, model and API key, you'll need to set
-the following options via environment variables or the [config.toml file](https://github.com/All-Hands-AI/OpenHands/blob/main/config.template.toml) when starting OpenHands:
+the following options via environment variables or the [config.toml file](https://github.com/OpenHands/OpenHands/blob/main/config.template.toml) when starting OpenHands:
 
 Via environment variables (please use PowerShell syntax for Windows PowerShell):
 

--- a/openhands/usage/runtimes/remote.mdx
+++ b/openhands/usage/runtimes/remote.mdx
@@ -1,7 +1,7 @@
 ---
 title: Remote Runtime
 description: This runtime is specifically designed for agent evaluation purposes only through the
-  [OpenHands evaluation harness](https://github.com/All-Hands-AI/OpenHands/tree/main/evaluation). It should not be
+  [OpenHands evaluation harness](https://github.com/OpenHands/OpenHands/tree/main/evaluation). It should not be
   used to launch production OpenHands applications.
 ---
 

--- a/openhands/usage/windows-without-wsl.mdx
+++ b/openhands/usage/windows-without-wsl.mdx
@@ -80,7 +80,7 @@ This guide provides step-by-step instructions for running OpenHands on a Windows
 
 1. **Clone the Repository**
    ```powershell
-   git clone https://github.com/All-Hands-AI/OpenHands.git
+   git clone https://github.com/OpenHands/OpenHands.git
    cd OpenHands
    ```
 

--- a/sdk/arch/overview.mdx
+++ b/sdk/arch/overview.mdx
@@ -9,7 +9,7 @@ Check [this document](/sdk/arch/design) for the core design principles that guid
 
 ## Relationship with OpenHands Applications
 
-The Software Agent SDK serves as the **source of truth for agents** in OpenHands. The [OpenHands repository](https://github.com/All-Hands-AI/OpenHands) provides interfaces—web app, CLI, and cloud—that consume the SDK APIs. This architecture ensures consistency and enables flexible integration patterns.
+The Software Agent SDK serves as the **source of truth for agents** in OpenHands. The [OpenHands repository](https://github.com/OpenHands/OpenHands) provides interfaces—web app, CLI, and cloud—that consume the SDK APIs. This architecture ensures consistency and enables flexible integration patterns.
 - **Software Agent SDK = foundation.** The SDK defines all core components: agents, LLMs, conversations, tools, workspaces, events, and security policies.
 - **Interfaces reuse SDK objects.** The OpenHands GUI or CLI hydrate SDK components from persisted settings and orchestrate execution through SDK APIs.
 - **Consistent configuration.** Whether you launch an agent programmatically or via the OpenHands GUI, the supported parameters and defaults come from the SDK.

--- a/tests/README.md
+++ b/tests/README.md
@@ -23,4 +23,4 @@ This test verifies that the pricing information in the OpenHands LLM documentati
 
 The test fetches data from:
 - LiteLLM's pricing JSON: https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json
-- OpenHands model list: https://github.com/All-Hands-AI/OpenHands/blob/main/openhands/utils/llm.py
+- OpenHands model list: https://github.com/OpenHands/OpenHands/blob/main/openhands/utils/llm.py

--- a/tests/test_pricing_documentation.py
+++ b/tests/test_pricing_documentation.py
@@ -25,7 +25,7 @@ class TestPricingDocumentation:
     def openhands_models(self) -> list[str]:
         """Get the list of OpenHands models from the OpenHands repository."""
         # Since this test is now in the docs repository, we need to fetch from OpenHands
-        url = 'https://raw.githubusercontent.com/All-Hands-AI/OpenHands/main/openhands/utils/llm.py'
+        url = 'https://raw.githubusercontent.com/OpenHands/OpenHands/main/openhands/utils/llm.py'
         response = requests.get(url)
         response.raise_for_status()
         content = response.text


### PR DESCRIPTION
   ## Summary
   Updates all GitHub repository URLs in the documentation to reflect the organization rename from `All-Hands-AI` to `OpenHands`.

   ## Changes Made
   - ✅ Updated all GitHub repository references across documentation files
   - ✅ Changed URLs from `github.com/All-Hands-AI/OpenHands` to `github.com/OpenHands/OpenHands`
   - ✅ Updated Mintlify configuration (`docs.json`) navigation and footer links
   - ✅ Updated issue links, repository links, and documentation references
   - ✅ Updated Slack integration documentation with new repo format

   ## Testing
   - [x] Verified no broken links remain for `All-Hands-AI`
   - [x] Confirmed all new URLs point to the correct `OpenHands` organization

   ## Type of Change
   - [x] Documentation update
   - [x] URL/link updates
   
   Fixes the GitHub organization rename mentioned in the banner.
   