### PR TITLE
Document AgentErrorEvent vs ConversationErrorEvent in Events architecture

### DIFF
--- a/sdk/arch/events.mdx
+++ b/sdk/arch/events.mdx
@@ -196,7 +196,7 @@ Two distinct error events exist in the SDK, with different purpose and visibilit
   - Scope: Conversation-level runtime failure (no tool_name/tool_call_id)
   - Source: typically "environment"
   - LLM visibility: Not sent to the model
-  - Effect: Run loop transitions to ERROR and run() raises ConversationRunError; surface top-level error to UI
+  - Effect: Run loop transitions to ERROR and run() raises ConversationRunError; surface top-level error to client applications
   - Code: https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-sdk/openhands/sdk/event/conversation_error.py
 
 ## See Also


### PR DESCRIPTION
**Document AgentErrorEvent vs ConversationErrorEvent in Events architecture**

This PR adds a concise section to the Events architecture page documenting the two essential error events and their differences.

**Changes**
- sdk/arch/events.mdx: New section "Error Events: Agent vs Conversation" explaining:
  - AgentErrorEvent: LLM-convertible, tool-scoped (tool_name/tool_call_id), source="agent", conversation continues, sent to LLM as a tool message
  - ConversationErrorEvent: not LLM-convertible, conversation-level failure (no tool fields), typically source="environment", transitions run loop to ERROR and raises ConversationRunError; surface as top-level UI error

**Notes**
- The per-package API docs (sdk/api-reference/openhands.sdk.event.mdx) are auto-generated via scripts/generate-api-docs.py. Since ConversationErrorEvent is not re-exported in openhands.sdk.event.__init__, it doesn’t currently appear there. If we want it listed in that page, we can re-export it in the SDK and regenerate.

Co-authored-by: openhands <openhands@all-hands.dev>
