### PR TITLE
docs: Remove gratuitous uses of the word "comprehensive"

### DIFF
--- a/openhands/usage/contributing.mdx
+++ b/openhands/usage/contributing.mdx
@@ -77,7 +77,7 @@ Start with these easy contributions:
 - **Share OpenHands** with other developers
 
 ### 2. Set Up Your Development Environment
-Follow our comprehensive setup guide:
+Follow our setup guide:
 - **Requirements**: Linux/Mac/WSL, Docker, Python 3.12, Node.js 22+, Poetry 1.8+
 - **Quick setup**: `make build` to get everything ready
 - **Configuration**: `make setup-config` to configure your LLM

--- a/openhands/usage/developers/development-overview.mdx
+++ b/openhands/usage/developers/development-overview.mdx
@@ -10,7 +10,7 @@ description: This guide provides an overview of the key documentation resources 
   The primary entry point for understanding OpenHands, including features and basic setup instructions.
 
 - **Development Guide** (`/Development.md`)
-  Comprehensive guide for developers working on OpenHands, including setup, requirements, and development workflows.
+  Guide for developers working on OpenHands, including setup, requirements, and development workflows.
 
 - **Contributing Guidelines** (`/CONTRIBUTING.md`)
   Essential information for contributors, covering code style, PR process, and contribution workflows.
@@ -33,7 +33,7 @@ description: This guide provides an overview of the key documentation resources 
 
 #### Infrastructure
 - **Container Documentation** (`/containers/README.md`)
-  Comprehensive information about Docker containers, deployment strategies, and container management.
+  Information about Docker containers, deployment strategies, and container management.
 
 ### Testing and Evaluation
 - **Unit Testing Guide** (`/tests/unit/README.md`)

--- a/openhands/usage/microagents/microagents-overview.mdx
+++ b/openhands/usage/microagents/microagents-overview.mdx
@@ -11,7 +11,7 @@ Currently OpenHands supports the following types of microagents:
 - [Keyword-Triggered Microagents](/openhands/usage/microagents/microagents-keyword): Guidelines activated by specific keywords in prompts.
 
 To customize OpenHands' behavior, create a .openhands/microagents/ directory in the root of your repository and
-add `<microagent_name>.md` files inside. For repository-specific guidelines, you can ask OpenHands to analyze your repository and create a comprehensive `repo.md` file (see [General Microagents](/openhands/usage/microagents/microagents-repo) for details).
+add `<microagent_name>.md` files inside. For repository-specific guidelines, you can ask OpenHands to analyze your repository and create a `repo.md` file (see [General Microagents](/openhands/usage/microagents/microagents-repo) for details).
 
 <Note>
 Loaded microagents take up space in the context window.

--- a/openhands/usage/microagents/microagents-repo.mdx
+++ b/openhands/usage/microagents/microagents-repo.mdx
@@ -17,7 +17,7 @@ Frontmatter should be enclosed in triple dashes (---) and may include the follow
 |-----------|-----------------------------------------|----------|----------------|
 | `agent`   | The agent this microagent applies to    | No       | 'CodeActAgent' |
 
-## Creating a Comprehensive Repository Agent
+## Creating a Repository Agent
 
 To create an effective repository agent, you can ask OpenHands to analyze your repository with a prompt like:
 
@@ -36,7 +36,7 @@ This approach helps OpenHands capture repository context efficiently, reducing t
 
 ## Example Content
 
-A comprehensive repository agent file (`.openhands/microagents/repo.md`) should include:
+A repository agent file (`.openhands/microagents/repo.md`) should include:
 
 ```
 # Repository Purpose

--- a/sdk/guides/convo-persistence.mdx
+++ b/sdk/guides/convo-persistence.mdx
@@ -165,7 +165,7 @@ conversation.run()  # Continues from saved state
 
 ### What Gets Persisted
 
-The conversation state includes comprehensive information that allows seamless restoration:
+The conversation state includes information that allows seamless restoration:
 
 - **Message History**: Complete event log including user messages, agent responses, and system events
 - **Agent Configuration**: LLM settings, tools, MCP servers, and agent parameters

--- a/sdk/guides/metrics.mdx
+++ b/sdk/guides/metrics.mdx
@@ -5,7 +5,7 @@ description: Track token usage, costs, and latency metrics for your agents.
 
 ## Overview
 
-The OpenHands SDK provides comprehensive metrics tracking at two levels: individual LLM metrics and aggregated conversation-level costs:
+The OpenHands SDK provides metrics tracking at two levels: individual LLM metrics and aggregated conversation-level costs:
 - You can access detailed metrics from each LLM instance using the `llm.metrics` object to track token usage, costs, and latencies per API call.
 - For a complete view, use `conversation.conversation_stats` to get aggregated costs across all LLMs used in a conversation, including the primary agent LLM and any auxiliary LLMs (such as those used by the [context condenser](/sdk/guides/context-condenser)).
 
@@ -385,7 +385,7 @@ uv run python examples/01_standalone_sdk/21_generate_extraneous_conversation_cos
 
 ### Understanding Conversation Stats
 
-The `conversation.conversation_stats` object provides comprehensive cost tracking across all LLMs used in a conversation. It is an instance of the [ConversationStats class](https://github.com/OpenHands/software-agent-sdk/blob/32e1e75f7e962033a8fd6773a672612e07bc8c0d/openhands-sdk/openhands/sdk/conversation/conversation_stats.py), which provides the following key features:
+The `conversation.conversation_stats` object provides cost tracking across all LLMs used in a conversation. It is an instance of the [ConversationStats class](https://github.com/OpenHands/software-agent-sdk/blob/32e1e75f7e962033a8fd6773a672612e07bc8c0d/openhands-sdk/openhands/sdk/conversation/conversation_stats.py), which provides the following key features:
 
 #### Key Methods and Properties
 


### PR DESCRIPTION
- [X] I have read and reviewed the documentation changes to the best of my ability.
- [X] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

Searched docs for the word "comprehensive", which is one of Claude Sonnet's favorite words. Remove instances that don't appear to mean anything.

> "Omit needless words" - Strunk & White, [Elements of Style](https://en.wikipedia.org/wiki/The_Elements_of_Style)
