### PR TITLE
Fix broken link: Replace app.openhands.dev with app.all-hands.dev

### DIFF
--- a/sdk/getting-started.mdx
+++ b/sdk/getting-started.mdx
@@ -22,7 +22,7 @@ The SDK requires an LLM API key from any [LiteLLM-supported provider](https://do
 
 <AccordionGroup>
   <Accordion title="Option 1: OpenHands Cloud (Recommended)" icon="cloud">
-    Sign up for [OpenHands Cloud](https://app.openhands.dev) and get an API key from the [API keys page](https://app.openhands.dev/settings/api-keys). This gives you access to recommended models with no markup.
+    Sign up for [OpenHands Cloud](https://app.all-hands.dev) and get an API key from the [API keys page](https://app.all-hands.dev/settings/api-keys). This gives you access to recommended models with no markup.
     
     [Learn more →](/openhands/usage/llms/openhands-llms)
   </Accordion>


### PR DESCRIPTION
## Summary
This PR fixes broken links in the SDK getting started guide where `app.openhands.dev` (which has no DNS configuration) was being used instead of the correct domain `app.all-hands.dev`.

## Changes
- Updated `sdk/getting-started.mdx` to replace both instances of `app.openhands.dev` with `app.all-hands.dev` in the OpenHands Cloud signup links

## Issue
Users following the SDK getting started guide were encountering broken links when trying to sign up for OpenHands Cloud. The domain `app.openhands.dev` does not have DNS configured and returns `NXDOMAIN`.

## Testing
- ✅ Verified no other instances of `app.openhands.dev` exist in the documentation
- ✅ Confirmed the rest of the docs consistently use `app.all-hands.dev`
- ✅ Links now point to the functional domain

Fixes the issue reported where users couldn't access the OpenHands Cloud signup page from the SDK documentation.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/be6249de689f4830bda44cd293d1d7d3)