### PR TITLE
Pin Python 3.12 in uv tool install commands

### DIFF
--- a/openhands/usage/run-openhands/cli-mode.mdx
+++ b/openhands/usage/run-openhands/cli-mode.mdx
@@ -30,7 +30,7 @@ configuration format has changed.
 
     **Install OpenHands:**
     ```bash
-    uv tool install openhands
+    uv tool install --python 3.12 openhands
     ```
 
     **Run OpenHands:**
@@ -97,7 +97,7 @@ configuration format has changed.
         --add-host host.docker.internal:host-gateway \
         --name openhands-cli-$(date +%Y%m%d%H%M%S) \
         python:3.12-slim \
-        bash -c "pip install uv && uv tool install openhands && openhands"
+        bash -c "pip install uv && uv tool install --python 3.12 openhands && openhands"
     ```
 
     The `-e SANDBOX_USER_ID=$(id -u)` is passed to the Docker command to ensure the sandbox user matches the host user’s

--- a/openhands/usage/run-openhands/gui-mode.mdx
+++ b/openhands/usage/run-openhands/gui-mode.mdx
@@ -15,7 +15,7 @@ You can launch the OpenHands GUI server directly from the command line using the
 
 <Info>
 **Prerequisites**: You need to have the [OpenHands CLI installed](/usage/run-openhands/cli-mode) first, OR have `uv`
-installed and run `uv tool install openhands` and `openhands server`. Otherwise, you'll need to use Docker
+installed and run `uv tool install --python 3.12 openhands` and `openhands server`. Otherwise, you'll need to use Docker
 directly (see the [Docker section](#using-docker-directly) below).
 </Info>
 

--- a/openhands/usage/run-openhands/local-setup.mdx
+++ b/openhands/usage/run-openhands/local-setup.mdx
@@ -78,7 +78,7 @@ See the [uv installation guide](https://docs.astral.sh/uv/getting-started/instal
 
 **Install OpenHands**:
 ```bash
-uv tool install openhands
+uv tool install --python 3.12 openhands
 ```
 
 **Launch OpenHands**:

--- a/openhands/usage/windows-without-wsl.mdx
+++ b/openhands/usage/windows-without-wsl.mdx
@@ -166,7 +166,7 @@ After installation, restart your PowerShell session to ensure the environment va
 After installing the prerequisites, install OpenHands with:
 
 ```powershell
-uv tool install openhands
+uv tool install --python 3.12 openhands
 ```
 
 Then run OpenHands:


### PR DESCRIPTION
## Summary

This PR updates all documentation to explicitly specify Python 3.12 when installing OpenHands via `uv tool install`, changing from:
```bash
uv tool install openhands
```
to:
```bash
uv tool install --python 3.12 openhands
```

## Problem

Users were experiencing installation failures when `uv` defaulted to Python 3.14. The issue manifested as:
- `tiktoken==0.11.0` lacks prebuilt wheels for Python 3.14
- This caused compilation from source, requiring rust compiler installation
- Users encountered errors like "Failed to build tiktoken==0.11.0"

Reference: User reports in Slack thread where multiple users couldn't install the CLI using `uv`

## Solution

By explicitly specifying `--python 3.12` (the minimum required version per pyproject.toml), we ensure:
- Users install with a Python version that has proper wheel support for all dependencies
- Consistent installation experience across different environments
- No unexpected compilation requirements

## Files Changed

- `openhands/usage/run-openhands/cli-mode.mdx` (2 instances)
- `openhands/usage/run-openhands/local-setup.mdx` (1 instance)
- `openhands/usage/run-openhands/gui-mode.mdx` (1 instance)
- `openhands/usage/windows-without-wsl.mdx` (1 instance)

## Testing

All changes are documentation-only, updating installation commands to include the `--python 3.12` flag.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/413800b275e24744a4de26a1ba7657ff)