### PR TITLE
ci: allow scheduled docs sync to run

### DIFF
--- a/.github/workflows/sync-docs-code-blocks.yml
+++ b/.github/workflows/sync-docs-code-blocks.yml
@@ -18,7 +18,6 @@ permissions:
 jobs:
   sync-code-blocks:
     runs-on: ubuntu-latest
-    if: github.actor != 'github-actions[bot]'
     steps:
       - name: Checkout docs repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Summary

The scheduled docs sync was not running at 2:00 AM UTC because the job-level guard `if: github.actor != 'github-actions[bot]'` prevented cron-triggered runs (which execute as `github-actions[bot]`). This PR removes that guard so the workflow can execute on schedule.

Change

- .github/workflows/sync-docs-code-blocks.yml
  - Remove the job-level `if: github.actor != 'github-actions[bot]'`

Why

- Cron jobs run as `github-actions[bot]`. The existing guard skipped the entire job, so no sync or PR creation happened despite the schedule.

Impact

- The daily 2:00 AM UTC sync will now execute as intended.
- Manual `workflow_dispatch` continues to work as before.

Notes

- This PR intentionally makes the minimal change requested. We can consider adding `pull_request`/`push` triggers in a follow-up if desired.


@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/a44049b29e154270bfffd0396b34dbcc)