### PR TITLE
Fix python version

### DIFF
--- a/.github/workflows/sync-docs-code-blocks.yml
+++ b/.github/workflows/sync-docs-code-blocks.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install dependencies for API docs
         run: |


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [x] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

This PR proposes to fix Python version to 3.12, as that’s required for compatibility with agent-sdk. This fixes the docs sync workflow which runs both.