### PR TITLE
Apply suggestion to clarify parallel tool calling behavior in FAQ

### DIFF
--- a/sdk/faq.mdx
+++ b/sdk/faq.mdx
@@ -8,7 +8,7 @@ icon: question
 
 **Yes, the OpenHands SDK supports parallel tool calling by default.**
 
-The SDK automatically handles parallel tool calls when the underlying LLM (like Claude or GPT-4) returns multiple tool calls in a single response. This allows agents to execute multiple independent actions simultaneously, improving efficiency.
+The SDK automatically handles parallel tool calls when the underlying LLM (like Claude or GPT-4) returns multiple tool calls in a single response. This allows agents to execute multiple independent actions before the next LLM call.
 
 <Accordion title="How it works" icon="gear">
 When the LLM generates multiple tool calls in parallel, the SDK groups them using a shared `llm_response_id`:


### PR DESCRIPTION
## Summary

This PR applies @enyst's suggestion from PR #149 to improve the clarity of the parallel tool calling explanation in the SDK FAQ.

### Changes Made

Modified `sdk/faq.mdx` line 11 to clarify when parallel actions are executed:
- **Before**: "This allows agents to execute multiple independent actions simultaneously, improving efficiency."
- **After**: "This allows agents to execute multiple independent actions before the next LLM call."

### Why This Change?

The updated wording is more technically accurate and clearer:
- "Before the next LLM call" precisely describes the execution timing
- Removes ambiguity about whether actions run truly "simultaneously" (in parallel threads) vs. sequentially within the same LLM response cycle
- Focuses on the key benefit: reducing round-trips to the LLM

### Related

- Applies suggestion from PR #149
- Co-authored with @enyst

---

**Checklist:**
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [x] The change is minor and doesn't require running the documentation site locally.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/eed2c40197414a9a993b283779d27273)