### PR TITLE
Add --python 3.12 flag to all uv tool install/upgrade commands

### DIFF
--- a/openhands/usage/run-openhands/cli-mode.mdx
+++ b/openhands/usage/run-openhands/cli-mode.mdx
@@ -30,7 +30,7 @@ configuration format has changed.
 
     **Install OpenHands:**
     ```bash
-    uv tool install openhands
+    uv tool install openhands --python 3.12
     ```
 
     **Run OpenHands:**
@@ -40,7 +40,7 @@ configuration format has changed.
 
     **Upgrade OpenHands:**
     ```bash
-    uv tool upgrade openhands
+    uv tool upgrade openhands --python 3.12
     ```
   </Tab>
   <Tab title="Executable Binary">
@@ -97,7 +97,7 @@ configuration format has changed.
         --add-host host.docker.internal:host-gateway \
         --name openhands-cli-$(date +%Y%m%d%H%M%S) \
         python:3.12-slim \
-        bash -c "pip install uv && uv tool install openhands && openhands"
+        bash -c "pip install uv && uv tool install openhands --python 3.12 && openhands"
     ```
 
     The `-e SANDBOX_USER_ID=$(id -u)` is passed to the Docker command to ensure the sandbox user matches the host user’s

--- a/openhands/usage/run-openhands/gui-mode.mdx
+++ b/openhands/usage/run-openhands/gui-mode.mdx
@@ -15,7 +15,7 @@ You can launch the OpenHands GUI server directly from the command line using the
 
 <Info>
 **Prerequisites**: You need to have the [OpenHands CLI installed](/usage/run-openhands/cli-mode) first, OR have `uv`
-installed and run `uv tool install openhands` and `openhands server`. Otherwise, you'll need to use Docker
+installed and run `uv tool install openhands --python 3.12` and `openhands server`. Otherwise, you'll need to use Docker
 directly (see the [Docker section](#using-docker-directly) below).
 </Info>
 

--- a/openhands/usage/run-openhands/local-setup.mdx
+++ b/openhands/usage/run-openhands/local-setup.mdx
@@ -78,7 +78,7 @@ See the [uv installation guide](https://docs.astral.sh/uv/getting-started/instal
 
 **Install OpenHands**:
 ```bash
-uv tool install openhands
+uv tool install openhands --python 3.12
 ```
 
 **Launch OpenHands**:
@@ -97,7 +97,7 @@ This will automatically handle Docker requirements checking, image pulling, and 
 
 **Upgrade OpenHands**:
 ```bash
-uv tool upgrade openhands
+uv tool upgrade openhands --python 3.12
 ```
 
 <Accordion title="Alternative: Traditional pip installation">

--- a/openhands/usage/windows-without-wsl.mdx
+++ b/openhands/usage/windows-without-wsl.mdx
@@ -166,7 +166,7 @@ After installation, restart your PowerShell session to ensure the environment va
 After installing the prerequisites, install OpenHands with:
 
 ```powershell
-uv tool install openhands
+uv tool install openhands --python 3.12
 ```
 
 Then run OpenHands:
@@ -178,7 +178,7 @@ openhands
 To upgrade OpenHands in the future:
 
 ```powershell
-uv tool upgrade openhands
+uv tool upgrade openhands --python 3.12
 ```
 
 ### Troubleshooting CLI Issues


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [x] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

This PR adds the `--python 3.12` flag to all `uv tool install openhands` and `uv tool upgrade openhands` commands throughout the documentation. This ensures users install OpenHands with Python 3.12, preventing the version 0.0.0 installation issue that occurs when using unsupported Python versions (like Python 3.11).

## Changes Made

Updated 4 documentation files with 8 total changes:

1. **openhands/usage/run-openhands/cli-mode.mdx** (3 updates)
   - Install command in "Using uv (recommended)" tab
   - Upgrade command in "Using uv (recommended)" tab
   - Docker command that runs uv tool install

2. **openhands/usage/run-openhands/gui-mode.mdx** (1 update)
   - Prerequisites section mentioning quick install command

3. **openhands/usage/run-openhands/local-setup.mdx** (2 updates)
   - Install command in "Option 1: Using the CLI Launcher with uv"
   - Upgrade command in the same section

4. **openhands/usage/windows-without-wsl.mdx** (2 updates)
   - Install command for Windows without WSL
   - Upgrade command for Windows without WSL

## Context

Users have been reporting getting version 0.0.0 when installing OpenHands CLI without specifying the Python version. This issue is related to using Python versions outside the supported range. By explicitly specifying `--python 3.12`, we ensure a consistent and working installation experience for all users.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/a86567d35e264d569822e0cbd4c304ee)