### PR TITLE
docs: Add configurable security policy documentation

### DIFF
--- a/sdk/guides/security.mdx
+++ b/sdk/guides/security.mdx
@@ -449,14 +449,14 @@ For more details on the base class implementation, see the [source code](https:/
 Agents use security policies to guide their risk assessment of actions. The SDK provides a default security policy template, but you can customize it to match your specific security requirements and guidelines.
 
 <Note>
-Full configurable security policy example: [examples/01_standalone_sdk/28_configurable_security_policy.py](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/01_standalone_sdk/28_configurable_security_policy.py)
+Full configurable security policy example: [examples/01_standalone_sdk/31_configurable_security_policy.py](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/01_standalone_sdk/31_configurable_security_policy.py)
 </Note>
 
 ### Security Policy Example
 
 Define custom security risk guidelines for your agent:
 
-```python icon="python" expandable examples/01_standalone_sdk/28_configurable_security_policy.py
+```python icon="python" expandable examples/01_standalone_sdk/31_configurable_security_policy.py
 ```
 
 ```bash Running the Example


### PR DESCRIPTION
Add documentation for custom security policy templates that allow users to define organization-specific risk assessment guidelines.

This PR documents the new example added in OpenHands/software-agent-sdk#427, specifically the `examples/01_standalone_sdk/28_configurable_security_policy.py` example.

### Changes
- Added "Configurable Security Policy" section to `sdk/guides/security.mdx`
- Documented how to use custom security policy templates
- Added code example showing security policy customization
- Explained benefits of custom security policies

### Related
- Closes check-examples failure in OpenHands/software-agent-sdk#427