### PR TITLE
Add PostHog analytics tracking

### DIFF
--- a/openhands/posthog-init.js
+++ b/openhands/posthog-init.js
@@ -3,5 +3,5 @@
 posthog.init('phc_ERBPfEE0gwNgkOBsxbHr1wh9mBsYcsw4zSLtvdA9RFg', {
     api_host: 'https://us.i.posthog.com',
     defaults: '2025-11-30',
-    person_profiles: 'always',
+    person_profiles: 'identified_only',
 });


### PR DESCRIPTION


- [ ] I have read and reviewed the documentation changes to the best of my ability.
- [ ] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

- Add PostHog analytics snippet for tracking user behavior and engagement
- Configure with `person_profiles: 'always'` to create profiles for all users
