### PR TITLE
Add guide: app-server + custom agent integration

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -244,6 +244,7 @@
                 "pages": [
                   "sdk/guides/agent-server/overview",
                   "sdk/guides/agent-server/local-server",
+                  "sdk/guides/agent-server/app-integration",
                   "sdk/guides/agent-server/docker-sandbox",
                   "sdk/guides/agent-server/api-sandbox",
                   {

--- a/docs.json
+++ b/docs.json
@@ -104,12 +104,6 @@
             ]
           },
           {
-            "group": "Developers",
-            "pages": [
-              "openhands/usage/developers/v1-local-agent-server"
-            ]
-          },
-          {
             "group": "REST API",
             "openapi": "openapi/openapi.json"
           },
@@ -178,7 +172,8 @@
               },
               "openhands/usage/advanced/configuration-options",
               "openhands/usage/advanced/custom-sandbox-guide",
-              "openhands/usage/advanced/search-engine-setup"
+              "openhands/usage/advanced/search-engine-setup",
+              "openhands/usage/developers/v1-local-agent-server"
             ]
           }
         ]

--- a/docs.json
+++ b/docs.json
@@ -104,6 +104,12 @@
             ]
           },
           {
+            "group": "Developers",
+            "pages": [
+              "openhands/usage/developers/v1-local-agent-server"
+            ]
+          },
+          {
             "group": "REST API",
             "openapi": "openapi/openapi.json"
           },

--- a/openhands/usage/developers/v1-local-agent-server.mdx
+++ b/openhands/usage/developers/v1-local-agent-server.mdx
@@ -30,7 +30,7 @@ By default V1 is enabled (unless <code>ENABLE_V1=0</code>). Ensure you’re on P
 
 ```bash Build
 export INSTALL_DOCKER=0         # No Docker for this guide
-export RUNTIME=local            # Force process-based sandbox (spawns local agent-server)
+export RUNTIME=process            # Force process-based sandbox (spawns sub-process agent-server)
 # optional: export ENABLE_V1=1  # V1 is enabled by default; set explicitly if you disabled it elsewhere
 
 make build

--- a/openhands/usage/developers/v1-local-agent-server.mdx
+++ b/openhands/usage/developers/v1-local-agent-server.mdx
@@ -1,5 +1,5 @@
 ---
-title: Run OpenHands V1 App-Server with Local SDK Agent-Server (No Docker) and Integrate a Custom Agent
+title: Run OpenHands App-Server with Local SDK Agent-Server and Custom Agent
 description: Run the OpenHands V1 app-server backed by a purely local agent-server from software-agent-sdk, and learn multiple ways to integrate a custom SDK agent.
 ---
 

--- a/openhands/usage/developers/v1-local-agent-server.mdx
+++ b/openhands/usage/developers/v1-local-agent-server.mdx
@@ -1,0 +1,124 @@
+---
+title: Run OpenHands V1 app-server with a local SDK agent-server (no Docker) and integrate a custom agent
+description: Step-by-step guide to run the OpenHands V1 app-server backed by a purely local agent-server from software-agent-sdk, plus multiple ways to integrate a custom SDK agent
+---
+
+This guide shows how to:
+- Run the OpenHands V1 app-server while spawning a fully local agent-server process (no Docker, no remote runtime)
+- Build a custom agent with software-agent-sdk and integrate it into the locally running app-server
+
+The instructions below are grounded in code from OpenHands V1 app-server and software-agent-sdk. Direct source links to the relevant files are included.
+
+Prerequisites
+- Python 3.12, Node 22.x, Poetry 1.8+
+- OpenHands repo checked out
+- software-agent-sdk is an install-time dependency of OpenHands (see pyproject), and the agent-server binary entrypoint is provided by that package
+
+Where V1 lives (execution path overview)
+OpenHands V1 exposes its API under /api/v1 and keeps the V1 server logic in app_server/:
+- The FastAPI app includes V1 only when ENABLE_V1 != '0'. See [server/app.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/server/app.py#L90-L98).
+- The V1 router aggregates app_server endpoints. See [v1_router.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/v1_router.py).
+- For a “local” runtime, the app-server launches a separate agent-server process (from software-agent-sdk) on a free localhost port. This is done by the process sandbox service: [process_sandbox_service](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/sandbox/process_sandbox_service.py#L113-L154) which executes python -m openhands.agent_server and then probes /alive.
+- That default choice comes from env → config wiring. When RUNTIME is local or process, the injectors select the process-based sandbox and spec: see [app_server/config.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/config.py#L102-L160) and [process_sandbox_spec_service.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/sandbox/process_sandbox_spec_service.py#L17-L34).
+- On the SDK side, the agent-server exposes /alive and /health (and /api/*). See [server_details_router.py](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/server_details_router.py#L27-L41) and the FastAPI app bootstrap in [agent_server/__main__.py](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/__main__.py#L1-L40).
+- The app-server talks to the agent-server using AsyncRemoteWorkspace and the agent-server REST/WebSocket API. See [AsyncRemoteWorkspace](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-sdk/openhands/sdk/workspace/remote/async_remote_workspace.py) and where the app-server builds conversation requests in [live_status_app_conversation_service._build_start_conversation_request_for_user](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/live_status_app_conversation_service.py#L929-L1014).
+
+Part 1 — Run OpenHands app-server with a purely local agent-server
+1) Build OpenHands and enable V1
+- By default V1 is enabled (unless ENABLE_V1=0). Ensure you’re on Python 3.12 and have Poetry and Node installed, then:
+
+```bash
+export INSTALL_DOCKER=0         # we won’t use Docker
+export RUNTIME=local            # force process-based sandbox (spawns local agent-server)
+# optional: export ENABLE_V1=1 # V1 is enabled by default; set explicitly if you disabled it elsewhere
+
+make build
+```
+
+2) Run backend + frontend
+- For local dev, either:
+
+```bash
+# Full app (backend + frontend). Adjust ports/hosts if you’re on a remote machine.
+make run FRONTEND_PORT=12000 FRONTEND_HOST=0.0.0.0 BACKEND_HOST=0.0.0.0
+```
+
+or start servers individually:
+
+```bash
+make start-backend
+make start-frontend
+```
+
+3) Start a V1 conversation to spawn the local agent-server
+- From the UI (Chat → Start), or via the V1 endpoints under /api/v1, create a new conversation. The app-server will:
+  - Start a “sandbox” using the process sandbox service, which launches a local agent-server process via python -m openhands.agent_server
+  - Poll the agent-server /alive endpoint until it reports status ok
+  - Store the agent-server URL and a per-sandbox session API key, then use it for subsequent operations
+
+4) Verify the local agent-server
+- You can list sandboxes via V1 API and find the exposed agent-server URL; the name in the response is "agent-server". The health checks are:
+  - GET {agent_server_url}/alive → {"status":"ok"} (see [server_details_router.py](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/server_details_router.py#L27-L41))
+  - GET {agent_server_url}/server_info for uptime/idle info
+
+5) How the app-server talks to the agent-server
+- When reading/writing files or executing commands in the conversation’s workspace, the app-server uses AsyncRemoteWorkspace that targets the agent-server. Example usage in the app-server: [app_conversation_router.read_conversation_file](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/app_conversation_router.py#L335-L409) and throughout [live_status_app_conversation_service](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/live_status_app_conversation_service.py).
+
+Part 2 — Build a custom agent with the SDK and integrate it locally
+There are two practical paths, depending on how much you want to change.
+
+A) Zero-code integration via Skills and MCP servers (recommended)
+- V1 lets you customize the agent that runs inside the agent-server by layering skills and MCP servers. The app-server automatically loads:
+  - User skills from ~/.openhands/skills and ~/.openhands/microagents/ via the SDK’s loader (see [load_user_skills](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-sdk/openhands/sdk/context/skills.py)) which the app-server calls in [skill loading](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/app_conversation_service_base.py#L56-L104).
+  - Org/repo skills from your target repository via [skill_loader.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/skill_loader.py).
+  - MCP servers: the app-server assembles an SDK-compatible mcpServers config (default OpenHands server + Tavily if available, and any custom MCP servers you set in user settings). See [_configure_llm_and_mcp](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/live_status_app_conversation_service.py#L804-L865).
+
+Example: add a user skill
+1. Create a file ~/.openhands/skills/security_expert.md
+
+```markdown
+---
+triggers:
+- security
+---
+# Security Expert
+You are a cybersecurity expert. Always consider security implications.
+```
+
+2. Start a V1 conversation and include the word “security” in your ask. The skill is merged into the agent’s context by the app-server (see [merge path](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/app_conversation_service_base.py#L84-L115)).
+
+B) Build a custom SDK Agent and run it through the app-server
+- The agent-server API accepts a full Agent specification (LLM, tools, context, etc.) as part of StartConversationRequest (see [agent-server conversation_router](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/conversation_router.py#L67-L105)).
+- In OpenHands V1, the app-server constructs this Agent for you based on AgentType (DEFAULT or PLAN), LLM settings, MCP config, and merged skills. See [LiveStatusAppConversationService._create_agent_with_context](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/live_status_app_conversation_service.py#L866-L923) and how it finishes the request in [_finalize_conversation_request](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/live_status_app_conversation_service.py#L1016-L1082).
+
+You can customize behavior without forking by:
+- Switching AgentType between DEFAULT and PLAN via the Start request (UI or API) to change tool presets (see [tool presets](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-tools/openhands/tools/preset)).
+- Supplying skills and MCP servers as described above.
+
+Advanced: add a new "agent type" to OpenHands
+If you want the UI and app-server to create your own agent layout (custom tools/system prompt/etc.), extend OpenHands:
+1) Add a new enum to [AgentType](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/app_conversation_models.py#L18-L26).
+2) Update [LiveStatusAppConversationService._create_agent_with_context](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/live_status_app_conversation_service.py#L866-L923) to construct your Agent when your new type is selected.
+3) Optionally expose the type in the frontend to make it selectable.
+
+C) Test your custom agent directly with the SDK (optional but useful)
+- The SDK ships standalone examples you can run locally to validate your Agent design before wiring through OpenHands. See the “Local Agent Server” guide: [/sdk/guides/agent-server/local-server](/sdk/guides/agent-server/local-server) and examples under software-agent-sdk/examples.
+
+Troubleshooting tips
+- If no agent-server starts when you create a V1 conversation, ensure:
+  - ENABLE_V1 is not '0' (V1 router included): [server/app.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/server/app.py#L90-L98)
+  - RUNTIME=local or process so process sandbox is selected: [config_from_env](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/config.py#L102-L160)
+  - The spawned server is probing /alive: [process_sandbox_service](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/sandbox/process_sandbox_service.py#L155-L200)
+- To inspect the agent-server API, open its Swagger at {agent_server_url}/docs (the server is started via uvicorn in [__main__.py](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/__main__.py#L1-L40)).
+
+References (source of truth)
+- OpenHands V1 app-server boot and routing: [server/app.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/server/app.py#L90-L98), [v1_router.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/v1_router.py)
+- Sandbox process service (spawns local agent-server): [process_sandbox_service.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/sandbox/process_sandbox_service.py#L113-L200)
+- Env→injector selection for local runtime: [config.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/config.py#L102-L160)
+- Default command and env to start agent-server: [process_sandbox_spec_service.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/sandbox/process_sandbox_spec_service.py#L17-L34)
+- Agent-server app and health endpoints: [__main__.py](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/__main__.py#L1-L40), [server_details_router.py](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/server_details_router.py#L27-L41)
+- Agent-server conversation API: [conversation_router.py](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/conversation_router.py)
+- AsyncRemoteWorkspace client: [async_remote_workspace.py](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-sdk/openhands/sdk/workspace/remote/async_remote_workspace.py)
+- V1 agent composition in app-server: [live_status_app_conversation_service.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/live_status_app_conversation_service.py)
+- Skills loading and merge points: [app_conversation_service_base.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/app_conversation_service_base.py#L56-L115), [skill_loader.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/skill_loader.py)
+- SDK documentation on agent-server modes: [/sdk/guides/agent-server/overview](/sdk/guides/agent-server/overview), [/sdk/guides/agent-server/local-server](/sdk/guides/agent-server/local-server)

--- a/openhands/usage/developers/v1-local-agent-server.mdx
+++ b/openhands/usage/developers/v1-local-agent-server.mdx
@@ -25,7 +25,7 @@ OpenHands V1 exposes its API under <code>/api/v1</code> and keeps the V1 server 
 - On the SDK side, the agent-server exposes <code>/alive</code> and <code>/health</code> (and <code>/api/*</code>). See [server_details_router.py](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/server_details_router.py#L27-L41) and bootstrap in [agent_server/__main__.py](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/__main__.py#L1-L40).
 - The app-server talks to the agent-server using <code>AsyncRemoteWorkspace</code> and the agent-server REST/WebSocket API. See [AsyncRemoteWorkspace](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-sdk/openhands/sdk/workspace/remote/async_remote_workspace.py) and where the app-server builds conversation requests in <code>_build_start_conversation_request_for_user</code> ([source](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/live_status_app_conversation_service.py#L929-L1014)).
 
-## Part 1 — Run App-Server with a Purely Local Agent-Server
+## Part 1 — Run App-Server with a Local Agent-Server
 
 ### 1) Build OpenHands and Enable V1
 By default V1 is enabled (unless <code>ENABLE_V1=0</code>). Ensure you’re on Python 3.12 and have Poetry and Node installed, then:

--- a/openhands/usage/developers/v1-local-agent-server.mdx
+++ b/openhands/usage/developers/v1-local-agent-server.mdx
@@ -58,8 +58,8 @@ make start-frontend
 
 4) Verify the local agent-server
 - You can list sandboxes via V1 API and find the exposed agent-server URL; the name in the response is "agent-server". The health checks are:
-  - GET {agent_server_url}/alive → {"status":"ok"} (see [server_details_router.py](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/server_details_router.py#L27-L41))
-  - GET {agent_server_url}/server_info for uptime/idle info
+  - GET `{agent_server_url}/alive` → `{"status":"ok"}` (see [server_details_router.py](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/server_details_router.py#L27-L41))
+  - GET `{agent_server_url}/server_info` for uptime/idle info
 
 5) How the app-server talks to the agent-server
 - When reading/writing files or executing commands in the conversation’s workspace, the app-server uses AsyncRemoteWorkspace that targets the agent-server. Example usage in the app-server: [app_conversation_router.read_conversation_file](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/app_conversation_router.py#L335-L409) and throughout [live_status_app_conversation_service](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/live_status_app_conversation_service.py).

--- a/openhands/usage/developers/v1-local-agent-server.mdx
+++ b/openhands/usage/developers/v1-local-agent-server.mdx
@@ -61,8 +61,8 @@ From the UI (Chat → Start) or via the V1 endpoints under <code>/api/v1</code>,
 
 ### 4) Verify the Local Agent-Server
 You can list sandboxes via V1 API and find the exposed agent-server URL; the name in the response is <code>"agent-server"</code>. The health checks are:
-- GET <code>{agent_server_url}/alive</code> → <code>{"status":"ok"}</code> (see [server_details_router.py](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/server_details_router.py#L27-L41))
-- GET <code>{agent_server_url}/server_info</code> for uptime/idle info
+- GET `{agent_server_url}/alive` → `{"status":"ok"}` (see [server_details_router.py](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/server_details_router.py#L27-L41))
+- GET `{agent_server_url}/server_info` for uptime/idle info
 
 ### 5) How the App-Server Talks to the Agent-Server
 When reading/writing files or executing commands in the conversation’s workspace, the app-server uses <code>AsyncRemoteWorkspace</code> that targets the agent-server. Example usage: [app_conversation_router.read_conversation_file](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/app_conversation_router.py#L335-L409) and throughout [live_status_app_conversation_service](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/live_status_app_conversation_service.py).
@@ -114,7 +114,7 @@ The SDK ships standalone examples you can run locally to validate your Agent des
   - <code>ENABLE_V1</code> is not <code>"0"</code> (V1 router included): [server/app.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/server/app.py#L90-L98)
   - <code>RUNTIME</code> = <code>local</code> or <code>process</code> so the process sandbox is selected: [config_from_env](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/config.py#L102-L160)
   - The spawned server is probed via <code>/alive</code>: [process_sandbox_service](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/sandbox/process_sandbox_service.py#L155-L200)
-- To inspect the agent-server API, open its Swagger at <code>{agent_server_url}/docs</code> (the server is started via uvicorn in [__main__.py](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/__main__.py#L1-L40)).
+- To inspect the agent-server API, open its Swagger at `{agent_server_url}/docs` (the server is started via uvicorn in [__main__.py](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/__main__.py#L1-L40)).
 
 ## References
 - OpenHands V1 app-server boot and routing: [server/app.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/server/app.py#L90-L98), [v1_router.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/v1_router.py)

--- a/openhands/usage/developers/v1-local-agent-server.mdx
+++ b/openhands/usage/developers/v1-local-agent-server.mdx
@@ -1,82 +1,85 @@
 ---
-title: Run OpenHands V1 app-server with a local SDK agent-server (no Docker) and integrate a custom agent
-description: Step-by-step guide to run the OpenHands V1 app-server backed by a purely local agent-server from software-agent-sdk, plus multiple ways to integrate a custom SDK agent
+title: Run OpenHands V1 App-Server with Local SDK Agent-Server (No Docker) and Integrate a Custom Agent
+description: Run the OpenHands V1 app-server backed by a purely local agent-server from software-agent-sdk, and learn multiple ways to integrate a custom SDK agent.
 ---
 
 This guide shows how to:
 - Run the OpenHands V1 app-server while spawning a fully local agent-server process (no Docker, no remote runtime)
 - Build a custom agent with software-agent-sdk and integrate it into the locally running app-server
 
-The instructions below are grounded in code from OpenHands V1 app-server and software-agent-sdk. Direct source links to the relevant files are included.
+<Note>
+Applies to the V1 app-server path enabled under <code>/api/v1</code>.
+</Note>
 
-Prerequisites
+## Prerequisites
 - Python 3.12, Node 22.x, Poetry 1.8+
-- OpenHands repo checked out
-- software-agent-sdk is an install-time dependency of OpenHands (see pyproject), and the agent-server binary entrypoint is provided by that package
+- OpenHands repository checked out
+- <code>software-agent-sdk</code> is an install-time dependency of OpenHands (see <code>pyproject.toml</code>), and provides the <code>openhands.agent_server</code> entrypoint
 
-Where V1 lives (execution path overview)
-OpenHands V1 exposes its API under /api/v1 and keeps the V1 server logic in app_server/:
-- The FastAPI app includes V1 only when ENABLE_V1 != '0'. See [server/app.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/server/app.py#L90-L98).
-- The V1 router aggregates app_server endpoints. See [v1_router.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/v1_router.py).
-- For a “local” runtime, the app-server launches a separate agent-server process (from software-agent-sdk) on a free localhost port. This is done by the process sandbox service: [process_sandbox_service](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/sandbox/process_sandbox_service.py#L113-L154) which executes python -m openhands.agent_server and then probes /alive.
-- That default choice comes from env → config wiring. When RUNTIME is local or process, the injectors select the process-based sandbox and spec: see [app_server/config.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/config.py#L102-L160) and [process_sandbox_spec_service.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/sandbox/process_sandbox_spec_service.py#L17-L34).
-- On the SDK side, the agent-server exposes /alive and /health (and /api/*). See [server_details_router.py](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/server_details_router.py#L27-L41) and the FastAPI app bootstrap in [agent_server/__main__.py](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/__main__.py#L1-L40).
-- The app-server talks to the agent-server using AsyncRemoteWorkspace and the agent-server REST/WebSocket API. See [AsyncRemoteWorkspace](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-sdk/openhands/sdk/workspace/remote/async_remote_workspace.py) and where the app-server builds conversation requests in [live_status_app_conversation_service._build_start_conversation_request_for_user](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/live_status_app_conversation_service.py#L929-L1014).
+## Where V1 Lives (Execution Path Overview)
+OpenHands V1 exposes its API under <code>/api/v1</code> and keeps the V1 server logic in <code>app_server/</code>:
+- The FastAPI app includes V1 only when <code>ENABLE_V1</code> != <code>"0"</code>. See [server/app.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/server/app.py#L90-L98).
+- The V1 router aggregates <code>app_server</code> endpoints. See [v1_router.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/v1_router.py).
+- For a local runtime, the app-server launches a separate agent-server process (from software-agent-sdk) on a free localhost port via the process sandbox: [process_sandbox_service](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/sandbox/process_sandbox_service.py#L113-L154). It executes <code>python -m openhands.agent_server</code> and probes <code>/alive</code>.
+- This selection comes from env→config wiring. When <code>RUNTIME</code> is <code>local</code> or <code>process</code>, injectors select the process-based sandbox/spec: see [app_server/config.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/config.py#L102-L160) and [process_sandbox_spec_service.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/sandbox/process_sandbox_spec_service.py#L17-L34).
+- On the SDK side, the agent-server exposes <code>/alive</code> and <code>/health</code> (and <code>/api/*</code>). See [server_details_router.py](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/server_details_router.py#L27-L41) and bootstrap in [agent_server/__main__.py](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/__main__.py#L1-L40).
+- The app-server talks to the agent-server using <code>AsyncRemoteWorkspace</code> and the agent-server REST/WebSocket API. See [AsyncRemoteWorkspace](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-sdk/openhands/sdk/workspace/remote/async_remote_workspace.py) and where the app-server builds conversation requests in <code>_build_start_conversation_request_for_user</code> ([source](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/live_status_app_conversation_service.py#L929-L1014)).
 
-Part 1 — Run OpenHands app-server with a purely local agent-server
-1) Build OpenHands and enable V1
-- By default V1 is enabled (unless ENABLE_V1=0). Ensure you’re on Python 3.12 and have Poetry and Node installed, then:
+## Part 1 — Run App-Server with a Purely Local Agent-Server
 
-```bash
-export INSTALL_DOCKER=0         # we won’t use Docker
-export RUNTIME=local            # force process-based sandbox (spawns local agent-server)
-# optional: export ENABLE_V1=1 # V1 is enabled by default; set explicitly if you disabled it elsewhere
+### 1) Build OpenHands and Enable V1
+By default V1 is enabled (unless <code>ENABLE_V1=0</code>). Ensure you’re on Python 3.12 and have Poetry and Node installed, then:
+
+```bash Build
+export INSTALL_DOCKER=0         # No Docker for this guide
+export RUNTIME=local            # Force process-based sandbox (spawns local agent-server)
+# optional: export ENABLE_V1=1  # V1 is enabled by default; set explicitly if you disabled it elsewhere
 
 make build
 ```
 
-2) Run backend + frontend
-- For local dev, either:
+### 2) Run Backend and Frontend
+For local development, either run everything together or separately.
 
-```bash
-# Full app (backend + frontend). Adjust ports/hosts if you’re on a remote machine.
+```bash Full App (Backend + Frontend)
+# Adjust ports/hosts if you’re on a remote machine.
 make run FRONTEND_PORT=12000 FRONTEND_HOST=0.0.0.0 BACKEND_HOST=0.0.0.0
 ```
 
 or start servers individually:
 
-```bash
+```bash Separate Servers
 make start-backend
 make start-frontend
 ```
 
-3) Start a V1 conversation to spawn the local agent-server
-- From the UI (Chat → Start), or via the V1 endpoints under /api/v1, create a new conversation. The app-server will:
-  - Start a “sandbox” using the process sandbox service, which launches a local agent-server process via python -m openhands.agent_server
-  - Poll the agent-server /alive endpoint until it reports status ok
-  - Store the agent-server URL and a per-sandbox session API key, then use it for subsequent operations
+### 3) Start a V1 Conversation (Spawns Local Agent-Server)
+From the UI (Chat → Start) or via the V1 endpoints under <code>/api/v1</code>, create a new conversation. The app-server will:
+- Start a sandbox using the process sandbox service, which launches a local agent-server process via <code>python -m openhands.agent_server</code>
+- Poll the agent-server <code>/alive</code> endpoint until it reports status <code>ok</code>
+- Store the agent-server URL and a per-sandbox session API key, then reuse it for subsequent operations
 
-4) Verify the local agent-server
-- You can list sandboxes via V1 API and find the exposed agent-server URL; the name in the response is "agent-server". The health checks are:
-  - GET `{agent_server_url}/alive` → `{"status":"ok"}` (see [server_details_router.py](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/server_details_router.py#L27-L41))
-  - GET `{agent_server_url}/server_info` for uptime/idle info
+### 4) Verify the Local Agent-Server
+You can list sandboxes via V1 API and find the exposed agent-server URL; the name in the response is <code>"agent-server"</code>. The health checks are:
+- GET <code>{agent_server_url}/alive</code> → <code>{"status":"ok"}</code> (see [server_details_router.py](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/server_details_router.py#L27-L41))
+- GET <code>{agent_server_url}/server_info</code> for uptime/idle info
 
-5) How the app-server talks to the agent-server
-- When reading/writing files or executing commands in the conversation’s workspace, the app-server uses AsyncRemoteWorkspace that targets the agent-server. Example usage in the app-server: [app_conversation_router.read_conversation_file](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/app_conversation_router.py#L335-L409) and throughout [live_status_app_conversation_service](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/live_status_app_conversation_service.py).
+### 5) How the App-Server Talks to the Agent-Server
+When reading/writing files or executing commands in the conversation’s workspace, the app-server uses <code>AsyncRemoteWorkspace</code> that targets the agent-server. Example usage: [app_conversation_router.read_conversation_file](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/app_conversation_router.py#L335-L409) and throughout [live_status_app_conversation_service](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/live_status_app_conversation_service.py).
 
-Part 2 — Build a custom agent with the SDK and integrate it locally
+## Part 2 — Build a Custom Agent with the SDK and Integrate Locally
 There are two practical paths, depending on how much you want to change.
 
-A) Zero-code integration via Skills and MCP servers (recommended)
-- V1 lets you customize the agent that runs inside the agent-server by layering skills and MCP servers. The app-server automatically loads:
-  - User skills from ~/.openhands/skills and ~/.openhands/microagents/ via the SDK’s loader (see [load_user_skills](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-sdk/openhands/sdk/context/skills.py)) which the app-server calls in [skill loading](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/app_conversation_service_base.py#L56-L104).
-  - Org/repo skills from your target repository via [skill_loader.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/skill_loader.py).
-  - MCP servers: the app-server assembles an SDK-compatible mcpServers config (default OpenHands server + Tavily if available, and any custom MCP servers you set in user settings). See [_configure_llm_and_mcp](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/live_status_app_conversation_service.py#L804-L865).
+### Path A — Skills and MCP Servers (No-Code)
+V1 lets you customize the agent that runs inside the agent-server by layering skills and MCP servers. The app-server automatically loads:
+- User skills from <code>~/.openhands/skills</code> and <code>~/.openhands/microagents/</code> via the SDK’s loader (see [load_user_skills](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-sdk/openhands/sdk/context/skills.py)), which the app-server calls in [skill loading](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/app_conversation_service_base.py#L56-L104).
+- Org/repo skills from your target repository via [skill_loader.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/skill_loader.py).
+- MCP servers: the app-server assembles an SDK-compatible <code>mcpServers</code> config (default OpenHands server + Tavily if available, and any custom MCP servers you set in user settings). See <code>_configure_llm_and_mcp</code> ([source](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/live_status_app_conversation_service.py#L804-L865)).
 
-Example: add a user skill
-1. Create a file ~/.openhands/skills/security_expert.md
+<strong>Example: Add a User Skill</strong>
+1. Create a file <code>~/.openhands/skills/security_expert.md</code>
 
-```markdown
+```markdown Skill: security_expert.md
 ---
 triggers:
 - security
@@ -87,31 +90,33 @@ You are a cybersecurity expert. Always consider security implications.
 
 2. Start a V1 conversation and include the word “security” in your ask. The skill is merged into the agent’s context by the app-server (see [merge path](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/app_conversation_service_base.py#L84-L115)).
 
-B) Build a custom SDK Agent and run it through the app-server
-- The agent-server API accepts a full Agent specification (LLM, tools, context, etc.) as part of StartConversationRequest (see [agent-server conversation_router](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/conversation_router.py#L67-L105)).
-- In OpenHands V1, the app-server constructs this Agent for you based on AgentType (DEFAULT or PLAN), LLM settings, MCP config, and merged skills. See [LiveStatusAppConversationService._create_agent_with_context](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/live_status_app_conversation_service.py#L866-L923) and how it finishes the request in [_finalize_conversation_request](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/live_status_app_conversation_service.py#L1016-L1082).
+### Path B — Custom SDK Agent via App-Server
+- The agent-server API accepts a full Agent specification (LLM, tools, context, etc.) as part of <code>StartConversationRequest</code> (see [conversation_router](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/conversation_router.py#L67-L105)).
+- In OpenHands V1, the app-server constructs this Agent for you based on <code>AgentType</code> (<code>DEFAULT</code> or <code>PLAN</code>), LLM settings, MCP config, and merged skills. See <code>_create_agent_with_context</code> ([source](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/live_status_app_conversation_service.py#L866-L923)) and how it finishes the request in <code>_finalize_conversation_request</code> ([source](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/live_status_app_conversation_service.py#L1016-L1082)).
 
 You can customize behavior without forking by:
-- Switching AgentType between DEFAULT and PLAN via the Start request (UI or API) to change tool presets (see [tool presets](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-tools/openhands/tools/preset)).
+- Switching <code>AgentType</code> between <code>DEFAULT</code> and <code>PLAN</code> via the Start request (UI or API) to change tool presets (see [tool presets](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-tools/openhands/tools/preset)).
 - Supplying skills and MCP servers as described above.
 
-Advanced: add a new "agent type" to OpenHands
+<strong>Advanced: Add a New Agent Type to OpenHands</strong>
 If you want the UI and app-server to create your own agent layout (custom tools/system prompt/etc.), extend OpenHands:
-1) Add a new enum to [AgentType](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/app_conversation_models.py#L18-L26).
-2) Update [LiveStatusAppConversationService._create_agent_with_context](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/live_status_app_conversation_service.py#L866-L923) to construct your Agent when your new type is selected.
-3) Optionally expose the type in the frontend to make it selectable.
+1. Add a new enum to [AgentType](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/app_conversation_models.py#L18-L26).
+2. Update <code>_create_agent_with_context</code> ([source](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/live_status_app_conversation_service.py#L866-L923)) to construct your Agent when your new type is selected.
+3. Optionally expose the type in the frontend to make it selectable.
 
-C) Test your custom agent directly with the SDK (optional but useful)
-- The SDK ships standalone examples you can run locally to validate your Agent design before wiring through OpenHands. See the “Local Agent Server” guide: [/sdk/guides/agent-server/local-server](/sdk/guides/agent-server/local-server) and examples under software-agent-sdk/examples.
+### Path C — Test with the SDK Directly (Optional but Useful)
+The SDK ships standalone examples you can run locally to validate your Agent design before wiring through OpenHands. See:
+- **[Local Agent Server](/sdk/guides/agent-server/local-server)**
+- **[Agent Server Overview](/sdk/guides/agent-server/overview)**
 
-Troubleshooting tips
+## Troubleshooting
 - If no agent-server starts when you create a V1 conversation, ensure:
-  - ENABLE_V1 is not '0' (V1 router included): [server/app.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/server/app.py#L90-L98)
-  - RUNTIME=local or process so process sandbox is selected: [config_from_env](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/config.py#L102-L160)
-  - The spawned server is probing /alive: [process_sandbox_service](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/sandbox/process_sandbox_service.py#L155-L200)
-- To inspect the agent-server API, open its Swagger at {agent_server_url}/docs (the server is started via uvicorn in [__main__.py](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/__main__.py#L1-L40)).
+  - <code>ENABLE_V1</code> is not <code>"0"</code> (V1 router included): [server/app.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/server/app.py#L90-L98)
+  - <code>RUNTIME</code> = <code>local</code> or <code>process</code> so the process sandbox is selected: [config_from_env](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/config.py#L102-L160)
+  - The spawned server is probed via <code>/alive</code>: [process_sandbox_service](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/sandbox/process_sandbox_service.py#L155-L200)
+- To inspect the agent-server API, open its Swagger at <code>{agent_server_url}/docs</code> (the server is started via uvicorn in [__main__.py](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/__main__.py#L1-L40)).
 
-References (source of truth)
+## References
 - OpenHands V1 app-server boot and routing: [server/app.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/server/app.py#L90-L98), [v1_router.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/v1_router.py)
 - Sandbox process service (spawns local agent-server): [process_sandbox_service.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/sandbox/process_sandbox_service.py#L113-L200)
 - Env→injector selection for local runtime: [config.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/config.py#L102-L160)

--- a/openhands/usage/developers/v1-local-agent-server.mdx
+++ b/openhands/usage/developers/v1-local-agent-server.mdx
@@ -1,11 +1,9 @@
 ---
-title: Run OpenHands App-Server with Local SDK Agent-Server and Custom Agent
-description: Run the OpenHands V1 app-server backed by a purely local agent-server from software-agent-sdk, and learn multiple ways to integrate a custom SDK agent.
+title: Run OpenHands App-Server with Local SDK Agent-Server
+description: Run the OpenHands V1 app-server backed by a purely local SDK agent-server, no Docker or remote runtime required.
 ---
 
-This guide shows how to:
-- Run the OpenHands V1 app-server while spawning a fully local agent-server process (no Docker, no remote runtime)
-- Build a custom agent with software-agent-sdk and integrate it into the locally running app-server
+This guide shows how to run the OpenHands V1 app-server while spawning a fully local agent-server process (no Docker, no remote runtime).
 
 <Note>
 Applies to the V1 app-server path enabled under <code>/api/v1</code>.
@@ -25,7 +23,7 @@ OpenHands V1 exposes its API under <code>/api/v1</code> and keeps the V1 server 
 - On the SDK side, the agent-server exposes <code>/alive</code> and <code>/health</code> (and <code>/api/*</code>). See [server_details_router.py](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/server_details_router.py#L27-L41) and bootstrap in [agent_server/__main__.py](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/__main__.py#L1-L40).
 - The app-server talks to the agent-server using <code>AsyncRemoteWorkspace</code> and the agent-server REST/WebSocket API. See [AsyncRemoteWorkspace](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-sdk/openhands/sdk/workspace/remote/async_remote_workspace.py) and where the app-server builds conversation requests in <code>_build_start_conversation_request_for_user</code> ([source](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/live_status_app_conversation_service.py#L929-L1014)).
 
-## Part 1 — Run App-Server with a Local Agent-Server
+## Run App-Server with a Local Agent-Server
 
 ### 1) Build OpenHands and Enable V1
 By default V1 is enabled (unless <code>ENABLE_V1=0</code>). Ensure you’re on Python 3.12 and have Poetry and Node installed, then:
@@ -67,47 +65,12 @@ You can list sandboxes via V1 API and find the exposed agent-server URL; the nam
 ### 5) How the App-Server Talks to the Agent-Server
 When reading/writing files or executing commands in the conversation’s workspace, the app-server uses <code>AsyncRemoteWorkspace</code> that targets the agent-server. Example usage: [app_conversation_router.read_conversation_file](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/app_conversation_router.py#L335-L409) and throughout [live_status_app_conversation_service](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/live_status_app_conversation_service.py).
 
-## Part 2 — Build a Custom Agent with the SDK and Integrate Locally
-There are two practical paths, depending on how much you want to change.
+## Customize the Agent Loaded by the GUI
 
-### Path A — Skills and MCP Servers (No-Code)
-V1 lets you customize the agent that runs inside the agent-server by layering skills and MCP servers. The app-server automatically loads:
-- User skills from <code>~/.openhands/skills</code> and <code>~/.openhands/microagents/</code> via the SDK’s loader (see [load_user_skills](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-sdk/openhands/sdk/context/skills.py)), which the app-server calls in [skill loading](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/app_conversation_service_base.py#L56-L104).
-- Org/repo skills from your target repository via [skill_loader.py](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/skill_loader.py).
-- MCP servers: the app-server assembles an SDK-compatible <code>mcpServers</code> config (default OpenHands server + Tavily if available, and any custom MCP servers you set in user settings). See <code>_configure_llm_and_mcp</code> ([source](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/live_status_app_conversation_service.py#L804-L865)).
-
-<strong>Example: Add a User Skill</strong>
-1. Create a file <code>~/.openhands/skills/security_expert.md</code>
-
-```markdown Skill: security_expert.md
----
-triggers:
-- security
----
-# Security Expert
-You are a cybersecurity expert. Always consider security implications.
-```
-
-2. Start a V1 conversation and include the word “security” in your ask. The skill is merged into the agent’s context by the app-server (see [merge path](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/app_conversation_service_base.py#L84-L115)).
-
-### Path B — Custom SDK Agent via App-Server
-- The agent-server API accepts a full Agent specification (LLM, tools, context, etc.) as part of <code>StartConversationRequest</code> (see [conversation_router](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/conversation_router.py#L67-L105)).
-- In OpenHands V1, the app-server constructs this Agent for you based on <code>AgentType</code> (<code>DEFAULT</code> or <code>PLAN</code>), LLM settings, MCP config, and merged skills. See <code>_create_agent_with_context</code> ([source](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/live_status_app_conversation_service.py#L866-L923)) and how it finishes the request in <code>_finalize_conversation_request</code> ([source](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/live_status_app_conversation_service.py#L1016-L1082)).
-
-You can customize behavior without forking by:
-- Switching <code>AgentType</code> between <code>DEFAULT</code> and <code>PLAN</code> via the Start request (UI or API) to change tool presets (see [tool presets](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-tools/openhands/tools/preset)).
-- Supplying skills and MCP servers as described above.
-
-<strong>Advanced: Add a New Agent Type to OpenHands</strong>
-If you want the UI and app-server to create your own agent layout (custom tools/system prompt/etc.), extend OpenHands:
-1. Add a new enum to [AgentType](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/app_conversation_models.py#L18-L26).
-2. Update <code>_create_agent_with_context</code> ([source](https://github.com/OpenHands/OpenHands/blob/main/openhands/app_server/app_conversation/live_status_app_conversation_service.py#L866-L923)) to construct your Agent when your new type is selected.
-3. Optionally expose the type in the frontend to make it selectable.
-
-### Path C — Test with the SDK Directly (Optional but Useful)
-The SDK ships standalone examples you can run locally to validate your Agent design before wiring through OpenHands. See:
-- **[Local Agent Server](/sdk/guides/agent-server/local-server)**
-- **[Agent Server Overview](/sdk/guides/agent-server/overview)**
+For customization paths (skills/MCP, agent presets, or defining a new Agent type the app can instantiate), see:
+- /sdk/guides/agent-server/app-integration
+- /sdk/guides/agent-custom
+- /sdk/guides/custom-tools
 
 ## Troubleshooting
 - If no agent-server starts when you create a V1 conversation, ensure:

--- a/sdk/guides/agent-server/app-integration.mdx
+++ b/sdk/guides/agent-server/app-integration.mdx
@@ -15,7 +15,7 @@ Best read alongside: <br/>
 ## How the App Loads an SDK Agent
 
 When you start a V1 conversation from the GUI, the app-server:
-- Launches an SDK Agent Server (locally or via the configured runtime)
+- Launches an SDK Agent Server (locally or via the configured host)
 - Builds a StartConversationRequest that includes an Agent specification
 - Sends that request to the Agent Server's conversation API
 

--- a/sdk/guides/agent-server/app-integration.mdx
+++ b/sdk/guides/agent-server/app-integration.mdx
@@ -1,0 +1,64 @@
+---
+title: Integrate SDK Agents with the OpenHands App
+description: How the OpenHands app uses the SDK Agent Server and where to customize the agent that the GUI loads
+---
+
+This guide explains how the OpenHands app (V1) composes an SDK Agent when you start a conversation in the GUI, and where you can customize behavior using the SDK.
+
+<Note>
+Best read alongside: <br/>
+- <a href="/sdk/guides/agent-server/overview">Agent Server Overview</a><br/>
+- <a href="/sdk/guides/agent-server/local-server">Run a Local Agent Server</a><br/>
+- <a href="/sdk/guides/agent-custom">Creating Custom Agent</a>
+</Note>
+
+## How the App Loads an SDK Agent
+
+When you start a V1 conversation from the GUI, the app-server:
+- Launches an SDK Agent Server (locally or via the configured runtime)
+- Builds a StartConversationRequest that includes an Agent specification
+- Sends that request to the Agent Server's conversation API
+
+Key references:
+- App builds the V1 router only if V1 is enabled: server/app.py
+- Conversation request assembly: live_status_app_conversation_service.py
+- Agent Server endpoints: conversation_router.py, server_details_router.py
+
+## Customization Paths
+
+### 1) Skills and MCP (No-Code)
+The app merges skills and MCP server config into the agent context:
+- User skills from ~/.openhands/skills and ~/.openhands/microagents/
+- Repo/org skills resolved from your working repository
+- MCP servers from settings and defaults (OpenHands + Tavily)
+
+This path lets you steer agent behavior without changing code.
+
+### 2) Agent Type Selection (Low-Code)
+The app selects an Agent preset based on AgentType (DEFAULT or PLAN). You can:
+- Toggle the AgentType in the Start request (UI or API)
+- Adjust LLM and MCP settings in the UI
+
+See also SDK presets for default and planning agents.
+
+### 3) Define a New Agent Type in the App (Advanced)
+If you need the GUI to instantiate a different agent layout (custom tools, system prompt, etc.):
+1. Add a new enum value to AgentType in the app
+2. Extend the builder to construct your custom Agent for that type
+3. Optionally expose it in the frontend for selection
+
+This keeps the App as the source of truth for Agent construction while leveraging SDK components.
+
+## Validate with the SDK First
+
+Before wiring into the App, validate your design directly with the SDK:
+- Run the Local Agent Server guide to test endpoints
+- Use the Creating Custom Agent guide to build presets and behaviors
+
+## See Also
+
+- /sdk/guides/agent-custom
+- /sdk/guides/custom-tools
+- /sdk/guides/mcp
+- /sdk/guides/agent-server/overview
+- /sdk/guides/agent-server/local-server

--- a/sdk/guides/agent-server/app-integration.mdx
+++ b/sdk/guides/agent-server/app-integration.mdx
@@ -28,7 +28,7 @@ Key references:
 
 ### 1) Skills and MCP (No-Code)
 The app merges skills and MCP server config into the agent context:
-- User skills from ~/.openhands/skills and ~/.openhands/microagents/
+- User skills from `~/.openhands/skills` and `~/.openhands/microagents/`
 - Repo/org skills resolved from your working repository
 - MCP servers from settings and defaults (OpenHands + Tavily)
 


### PR DESCRIPTION
This PR adds a new guide that explains how to:

1) Run the OpenHands V1 app-server while spawning a local agent-server process from software-agent-sdk (no Docker, no remote runtime)
2) Build a custom agent using the SDK and integrate it with the app-server running locally

The guide is grounded in source code with inline links to the relevant modules and functions. 
Key references include:
- app-server V1 routing and enablement
- process-based sandbox that launches `python -m openhands.agent_server`
- `AsyncRemoteWorkspace` used by the app-server to talk to the agent-server
- agent-server health endpoints and bootstrap
- building Agent for `StartConversationRequest` in the V1 service

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/bfdc09469dbf4752a02fa7017cda2c80)