### PR TITLE
Add documentation for skill packages

### DIFF
--- a/sdk/guides/skill-packages.mdx
+++ b/sdk/guides/skill-packages.mdx
@@ -18,7 +18,7 @@ and reuse collections of skills across projects.
 
 Prerequisites:
     1. Install a skill package:
-       pip install openhands-simple-code-review
+       uv pip install openhands-simple-code-review
 
     2. Configure packages to load:
        Create .openhands/packages.yaml with:
@@ -26,9 +26,6 @@ Prerequisites:
            - simple-code-review
 
     3. Or use the package loading functions directly in code.
-
-For more information on creating skill packages, see:
-    https://github.com/OpenHands/package-poc
 """
 
 import asyncio
@@ -53,7 +50,7 @@ async def list_available_packages():
     if not packages:
         print("No skill packages installed.")
         print("\nTo install a skill package:")
-        print("  pip install openhands-simple-code-review")
+        print("  uv pip install openhands-simple-code-review")
         return
 
     for pkg in packages:
@@ -245,18 +242,12 @@ async def main():
     print("=" * 60)
     print("""
 1. Install skill packages:
-   pip install openhands-simple-code-review
+   uv pip install openhands-simple-code-review
 
 2. Configure which packages to load:
    Edit .openhands/packages.yaml and add package names
 
 3. Run this example again to see loaded skills
-
-4. Create your own skill packages:
-   See: https://github.com/OpenHands/package-poc
-
-For more information on skill packages:
-   https://github.com/OpenHands/package-poc/blob/main/doc/tutorial-flow.md
 """)
 
 
@@ -271,10 +262,10 @@ uv run python examples/01_standalone_sdk/31_use_skill_packages.py
 
 ## Installing Skill Packages
 
-Skill packages are distributed as Python packages. Install them using pip:
+Skill packages are distributed as Python packages. Install them using uv:
 
 ```bash
-pip install openhands-simple-code-review
+uv pip install openhands-simple-code-review
 ```
 
 Skill packages follow naming conventions with an `openhands-` prefix but use shorter entry point names (e.g., `simple-code-review`).
@@ -376,17 +367,13 @@ Skill packages follow the OpenHands manifest format, which aligns with standards
 
 ## Creating Your Own Skill Packages
 
-You can create custom skill packages for your organization or projects. See the [OpenHands Package PoC](https://github.com/OpenHands/package-poc) repository for:
-
-- Package creation tutorial
-- Template and examples
-- Publishing guidelines
+You can create custom skill packages for your organization or projects.
 
 Key steps:
 1. Create skill files (markdown format)
 2. Define `manifest.json` with skill metadata
 3. Package using Python's entry points system
-4. Install via pip
+4. Install via uv
 
 ## Inspecting Package Details
 
@@ -439,4 +426,3 @@ agent_context = AgentContext(
 
 - **[Agent Skills & Context](/sdk/guides/skill)** - Learn about basic skills and triggers
 - **[Custom Tools](/sdk/guides/custom-tools)** - Create specialized tools
-- **[OpenHands Package PoC](https://github.com/OpenHands/package-poc)** - Create your own skill packages


### PR DESCRIPTION
This PR adds comprehensive documentation for the new skill packages feature introduced in the Agent SDK.

## Changes
- Added  with complete documentation covering:
  - Installing skill packages
  - Discovering and inspecting packages
  - Loading skills from packages (configuration-based and programmatic)
  - Package manifest format
  - Creating custom packages
  - Integration with AgentContext

## Related PRs
- Agent SDK PR: https://github.com/OpenHands/software-agent-sdk/pull/1399

This documentation resolves the failing check in PR #1399 which requires all examples to be documented.