### PR TITLE
docs(sdk): add GPT-5 preset example page linking to code

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -252,6 +252,7 @@
                   "sdk/guides/llm-registry",
                   "sdk/guides/llm-routing",
                   "sdk/guides/llm-reasoning",
+                  "sdk/guides/gpt5-preset",
                   "sdk/guides/llm-streaming",
                   "sdk/guides/llm-image-input",
                   "sdk/guides/llm-error-handling",

--- a/sdk/guides/gpt5-preset.mdx
+++ b/sdk/guides/gpt5-preset.mdx
@@ -1,35 +1,82 @@
 ---
 title: GPT-5 Preset (ApplyPatchTool)
-description: Use the GPT-5 preset to enable ApplyPatchTool-based file editing as an opt-in alternative, mirroring the Gemini preset approach.
+description: Use the GPT-5 preset to build an agent that swaps the standard FileEditorTool for ApplyPatchTool.
 ---
 
+import RunExampleCode from "/sdk/shared-snippets/how-to-run-example.mdx";
+
+The GPT-5 preset is an opt-in agent preset for patch-based file editing. Calling `get_gpt5_agent(llm)` creates an agent that uses `ApplyPatchTool` instead of the standard `FileEditorTool`, while leaving the default preset unchanged for everything else.
+
+## Ready-to-run Example
+
 <Note>
-This example is available on GitHub: [examples/01_standalone_sdk/35_gpt5_apply_patch_preset.py](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/01_standalone_sdk/35_gpt5_apply_patch_preset.py)
+This example is available on GitHub: [examples/04_llm_specific_tools/01_gpt5_apply_patch_preset.py](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/04_llm_specific_tools/01_gpt5_apply_patch_preset.py)
 </Note>
 
-The GPT-5 preset provides an optional tool bundle that replaces the standard claude-style FileEditorTool with ApplyPatchTool, following the same pattern as the Gemini preset. This allows you to explicitly opt into ApplyPatch-based editing without changing any global defaults.
+```python icon="python" expandable examples/04_llm_specific_tools/01_gpt5_apply_patch_preset.py
+"""Example: Using GPT-5 preset with ApplyPatchTool for file editing.
 
-```python icon="python" expandable examples/01_standalone_sdk/35_gpt5_apply_patch_preset.py
-# See linked file for the full example.
+This example demonstrates how to enable the GPT-5 preset, which swaps the
+standard claude-style FileEditorTool for ApplyPatchTool.
+
+Usage:
+    export OPENAI_API_KEY=...  # or set LLM_API_KEY
+    # Optionally set a model (we recommend a mini variant if available):
+    # export LLM_MODEL=(
+    #   "openai/gpt-5.2-mini"  # or fallback: "openai/gpt-5.1-mini" or "openai/gpt-5.1"
+    # )
+
+    uv run python examples/04_llm_specific_tools/01_gpt5_apply_patch_preset.py
+"""
+
+import os
+
+from openhands.sdk import LLM, Agent, Conversation
+from openhands.tools.preset.gpt5 import get_gpt5_agent
+
+
+# Resolve API key from env
+api_key = os.getenv("LLM_API_KEY") or os.getenv("OPENAI_API_KEY")
+if not api_key:
+    raise SystemExit("Please set OPENAI_API_KEY or LLM_API_KEY to run this example.")
+
+model = os.getenv("LLM_MODEL", "openai/gpt-5.1")
+base_url = os.getenv("LLM_BASE_URL", None)
+
+llm = LLM(model=model, api_key=api_key, base_url=base_url)
+
+# Build an agent with the GPT-5 preset (ApplyPatchTool-based editing)
+agent: Agent = get_gpt5_agent(llm)
+
+# Run in the current working directory
+cwd = os.getcwd()
+conversation = Conversation(agent=agent, workspace=cwd)
+
+conversation.send_message(
+    "Create (or update) a file named GPT5_DEMO.txt at the repo root with "
+    "two short lines describing this repository."
+)
+conversation.run()
+
+# Report cost
+cost = llm.metrics.accumulated_cost
+print(f"EXAMPLE_COST: {cost}")
 ```
 
-## Running the Example
+<RunExampleCode path_to_script="examples/04_llm_specific_tools/01_gpt5_apply_patch_preset.py"/>
 
-```bash
-export OPENAI_API_KEY="your-api-key"  # or set LLM_API_KEY
-# Optionally select a model, e.g. a mini variant if available
-# export LLM_MODEL="openai/gpt-5.2-mini"  # fallback: openai/gpt-5.1-mini or openai/gpt-5.1
-cd agent-sdk
-uv run python examples/01_standalone_sdk/35_gpt5_apply_patch_preset.py
-```
+<Tip>
+You can optionally set `LLM_MODEL` to a GPT-5 variant such as `openai/gpt-5.2-mini`, `openai/gpt-5.1-mini`, or `openai/gpt-5.1`.
+</Tip>
 
-## Why this preset?
+## What this preset changes
 
-- Mirrors the Gemini preset approach (opt-in, not default)
-- Uses ApplyPatchTool for unified, patch-based edits preferred for GPT-5
-- Works with existing SDK agent flow (get_gpt5_agent)
+- Replaces the standard `FileEditorTool` with `ApplyPatchTool`
+- Keeps the GPT-5-specific configuration explicit via `get_gpt5_agent(llm)`
+- Leaves the default preset unchanged unless you opt into this one
 
-## Related
+## See Also
 
-- **Gemini preset** approach is documented in its PR; you can adopt it similarly by calling `get_gemini_agent`.
-- **Default preset**: unchanged; continues to use FileEditorTool unless you opt into this preset.
+- **[LLM Reasoning](/sdk/guides/llm-reasoning)** - Learn more about newer OpenAI model behavior and the Responses API
+- **[LLM Subscriptions](/sdk/guides/llm-subscriptions)** - Use supported OpenAI subscription-backed models without API credits
+- **[Custom Tools](/sdk/guides/custom-tools)** - Understand the standard SDK tool system and presets


### PR DESCRIPTION
## Summary

Add an SDK guide for the GPT-5 preset example. It documents `get_gpt5_agent(llm)`, which creates an agent that opts into `ApplyPatchTool`-based editing instead of the default `FileEditorTool`.

## What changed

- Added `sdk/guides/gpt5-preset.mdx`
  - Links directly to the live example in `software-agent-sdk`
  - Includes an expandable code block synced to `examples/04_llm_specific_tools/01_gpt5_apply_patch_preset.py`
  - Uses the shared run-example snippet and calls out optional `LLM_MODEL` selection
  - Explains that the preset is explicit and opt-in, leaving the default preset unchanged
- Added `sdk/guides/gpt5-preset` to the SDK sidebar under **LLM Features**

## Verification

- Cloned `OpenHands/software-agent-sdk` and verified the current example exists at `examples/04_llm_specific_tools/01_gpt5_apply_patch_preset.py`
- Confirmed `main` in this docs repo does not already document this preset

_This PR description was updated by an AI assistant (OpenHands) on behalf of the user._
