### PR TITLE
docs: Add Toad terminal interface to ACP documentation

### DIFF
--- a/openhands/usage/run-openhands/acp.mdx
+++ b/openhands/usage/run-openhands/acp.mdx
@@ -115,7 +115,7 @@ To configure OpenHands CLI with Zed:
 
 ![Zed Use OpenHands Agent](/openhands/static/img/acp-zed-use-openhands.png)
 
-### Troubleshooting
+#### Troubleshooting
 
 If you encounter issues while using OpenHands in Zed with the ACP plugin, you can access detailed debug logs:
 


### PR DESCRIPTION
## Summary

This PR adds documentation for [Toad](https://github.com/Textualize/toad), a universal terminal interface for AI agents, to the ACP documentation page.

## Changes

- Added Toad section under "ACP Integration" with:
  - Description of Toad and its benefits (no flickering, working scrollback, unified experience)
  - Installation instructions using `uvx batrachian-toad`
  - Step-by-step guide for using OpenHands with Toad
  - Documentation for passing command line arguments (e.g., `toad acp "openhands acp --llm-approve"`)
  - Note about `--resume` flag limitation with link to [issue #260](https://github.com/OpenHands/OpenHands-CLI/issues/260)
- Added Toad Documentation link to "See Also" section

## Related

- Blog post: https://www.openhands.dev/blog/20251218-openhands-toad-collaboration
- Issue for --resume support: https://github.com/OpenHands/OpenHands-CLI/issues/260

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ecf106f1c5d2421cbfe3afa74300752b)