### PR TITLE
Add documentation for resuming CLI conversations

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -182,6 +182,7 @@
         "pages": [
           "openhands/usage/run-openhands/cli-mode",
           "openhands/usage/run-openhands/cli-settings",
+          "openhands/usage/run-openhands/cli/resume",
           "openhands/usage/run-openhands/headless-mode",
           "openhands/usage/run-openhands/github-action",
           "openhands/usage/run-openhands/acp"

--- a/openhands/usage/run-openhands/acp.mdx
+++ b/openhands/usage/run-openhands/acp.mdx
@@ -64,10 +64,6 @@ toad acp "openhands acp --llm-approve"
 
 This allows you to use OpenHands CLI flags like `--llm-approve` for automatic LLM approval mode.
 
-<Note>
-Some OpenHands CLI flags like `--resume` and `--last` are not yet supported in ACP mode. See [this issue](https://github.com/OpenHands/OpenHands-CLI/issues/260) for updates.
-</Note>
-
 ### Zed IDE
 
 <video
@@ -178,9 +174,81 @@ For example, if `which openhands` returns `/Users/username/.local/bin/openhands`
 Make sure you have JetBrains AI Assistant enabled in your IDE. The AI Assistant is available in JetBrains IDEs version 2024.3 or later.
 </Note>
 
+## Resuming Conversations
+
+You can resume previous conversations when using OpenHands in ACP mode. This is useful when you want to continue working on a task from a previous session.
+
+### Finding Your Conversation ID
+
+Since ACP mode doesn't display an interactive conversation list, you need to first find your conversation ID using the standard CLI:
+
+```bash
+openhands --resume
+```
+
+This displays a list of your recent conversations with their IDs:
+
+```
+Recent Conversations:
+--------------------------------------------------------------------------------
+ 1. abc123def456 (2h ago)
+    Fix the login bug in auth.py
+
+ 2. xyz789ghi012 (yesterday)
+    Add unit tests for the user service
+--------------------------------------------------------------------------------
+To resume a conversation, use: openhands --resume <conversation-id>
+```
+
+### Resuming in ACP Mode
+
+Once you have the conversation ID, you can resume it in ACP mode:
+
+```bash
+openhands acp --resume <conversation-id>
+```
+
+For example, with Toad:
+
+```bash
+toad acp "openhands acp --resume abc123def456"
+```
+
+Or in your Zed configuration:
+
+```json
+{
+  "agent_servers": {
+    "OpenHands (Resume)": {
+      "command": "uvx",
+      "args": [
+        "openhands",
+        "acp",
+        "--resume",
+        "abc123def456"
+      ],
+      "env": {}
+    }
+  }
+}
+```
+
+### Resuming the Latest Conversation
+
+To resume your most recent conversation without looking up the ID:
+
+```bash
+openhands acp --resume --last
+```
+
+<Note>
+The `--resume` flag without a conversation ID will display the conversation list and exit. This is useful for finding conversation IDs, but won't start the ACP server. Always provide a conversation ID or use `--last` when starting ACP mode.
+</Note>
+
 ## See Also
 
 - [CLI Mode](/openhands/usage/run-openhands/cli-mode) - Learn about using OpenHands CLI interactively
+- [CLI Resume](/openhands/usage/run-openhands/cli/resume) - Detailed guide on resuming conversations
 - [ACP Documentation](https://agentclientprotocol.com/protocol/overview) - Full Agent Client Protocol specification
 - [Toad Documentation](https://www.batrachian.ai/) - Learn more about using Toad terminal interface
 - [Zed Documentation](https://zed.dev/docs) - Learn more about using Zed editor

--- a/openhands/usage/run-openhands/cli/resume.mdx
+++ b/openhands/usage/run-openhands/cli/resume.mdx
@@ -1,0 +1,88 @@
+---
+title: Resume Conversations
+description: How to resume previous conversations in the OpenHands CLI
+---
+
+## Overview
+
+OpenHands CLI automatically saves your conversation history in `~/.openhands/conversations`. You can resume any previous conversation to continue where you left off.
+
+## Listing Previous Conversations
+
+To see a list of your recent conversations, run:
+
+```bash
+openhands --resume
+```
+
+This displays up to 15 recent conversations with their IDs, timestamps, and a preview of the first user message:
+
+```
+Recent Conversations:
+--------------------------------------------------------------------------------
+ 1. abc123def456 (2h ago)
+    Fix the login bug in auth.py
+
+ 2. xyz789ghi012 (yesterday)
+    Add unit tests for the user service
+
+ 3. mno345pqr678 (3 days ago)
+    Refactor the database connection module
+--------------------------------------------------------------------------------
+To resume a conversation, use: openhands --resume <conversation-id>
+```
+
+## Resuming a Specific Conversation
+
+To resume a specific conversation, use the `--resume` flag with the conversation ID:
+
+```bash
+openhands --resume <conversation-id>
+```
+
+For example:
+
+```bash
+openhands --resume abc123def456
+```
+
+## Resuming the Latest Conversation
+
+To quickly resume your most recent conversation without looking up the ID, use the `--last` flag:
+
+```bash
+openhands --resume --last
+```
+
+This automatically finds and resumes the most recent conversation.
+
+## How It Works
+
+When you resume a conversation:
+
+1. OpenHands loads the full conversation history from disk
+2. The agent has access to all previous context, including:
+   - Your previous messages and requests
+   - The agent's responses and actions
+   - Any files that were created or modified
+3. You can continue the conversation as if you never left
+
+<Note>
+The conversation history is stored locally on your machine. If you delete the `~/.openhands/conversations` directory, your conversation history will be lost.
+</Note>
+
+## Tips
+
+- **Copy the conversation ID**: When you exit a conversation, OpenHands displays the conversation ID. You can copy this for later use.
+- **Use descriptive first messages**: The conversation list shows a preview of your first message, so starting with a clear description helps you identify conversations later.
+- **Combine with other flags**: You can combine `--resume` with other flags like `--always-approve` or `--llm-approve`:
+
+```bash
+openhands --resume abc123def456 --llm-approve
+```
+
+## See Also
+
+- [CLI Mode](/openhands/usage/run-openhands/cli-mode) - Getting started with the OpenHands CLI
+- [CLI Settings](/openhands/usage/run-openhands/cli-settings) - Configuration and command reference
+- [ACP Resume](/openhands/usage/run-openhands/acp#resuming-conversations) - Resuming conversations in ACP mode


### PR DESCRIPTION
## Summary

This PR adds documentation for the conversation resume feature in the OpenHands CLI, addressing the need to document how users can resume previous conversations.

## Changes

### New Page: CLI Resume Documentation
- Added `openhands/usage/run-openhands/cli/resume.mdx` with comprehensive documentation on:
  - Listing previous conversations with `openhands --resume`
  - Resuming a specific conversation with `openhands --resume <conversation-id>`
  - Resuming the latest conversation with `openhands --resume --last`
  - How conversation persistence works
  - Tips for managing conversations

### Updated: ACP Documentation
- Added a new "Resuming Conversations" section to `openhands/usage/run-openhands/acp.mdx` explaining:
  - How to find conversation IDs using the standard CLI (since ACP mode doesn't show an interactive list)
  - How to resume conversations in ACP mode with `openhands acp --resume <conversation-id>`
  - Examples for Toad and Zed configurations
  - How to resume the latest conversation with `openhands acp --resume --last`
- Removed the outdated note about resume not being supported in ACP mode (it's now supported via [OpenHands-CLI PR #265](https://github.com/OpenHands/OpenHands-CLI/pull/265))

### Navigation Update
- Added the new resume page to the CLI tab in `docs.json`

## Related

- OpenHands-CLI PR #265: Add --resume and --last flags support to openhands acp command
- OpenHands-CLI Issue #260: `openhands acp --resume --last` fails

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/5dd45ee53b4148d0b357b16e52787a4d)