### PR TITLE
Document bitbucket server integration as experimental

### DIFF
--- a/openhands/usage/advanced/configuration-options.mdx
+++ b/openhands/usage/advanced/configuration-options.mdx
@@ -128,6 +128,13 @@ Core configuration options can be set as environment variables by converting to 
   - Default: `""`
   - Description: Path to rewrite the workspace mount path to. You can usually ignore this, it refers to special cases of running inside another container. **Deprecated: Use `SANDBOX_VOLUMES` instead.**
 
+### Git Integrations
+- `bitbucket_mode`
+  - Type: `"cloud" | "server"`
+  - Default: `"cloud"`
+  - Description: Select the Bitbucket API to target globally. Set to `"server"` when connecting to Bitbucket Data Center/Server deployments.
+  - Environment variable: `BITBUCKET_MODE`
+
 ### Miscellaneous
 - `run_as_openhands`
   - Type: `bool`
@@ -434,6 +441,18 @@ All security configuration options can be set as environment variables by prefix
   - Type: `str`
   - Default: `""`
   - Description: The security analyzer to use
+
+## Secrets Store and Git Provider Tokens
+
+You can manage long-lived Git credentials in the `[secrets_store.provider_tokens]` section of `config.toml`.
+Each provider (`github`, `gitlab`, `bitbucket`) accepts a table with provider-specific options.
+
+To enable Bitbucket Server/Data Center support, set the global mode in the `[core]` section:
+
+```toml
+[core]
+bitbucket_mode = "server"
+```
 
 ---
 

--- a/openhands/usage/environment-variables.mdx
+++ b/openhands/usage/environment-variables.mdx
@@ -33,6 +33,7 @@ These variables correspond to the `[core]` section in `config.toml`:
 | `FILE_UPLOADS_ALLOWED_EXTENSIONS` | list | `[".*"]` | List of allowed file extensions for uploads |
 | `MAX_BUDGET_PER_TASK` | float | `0.0` | Maximum budget per task (0.0 = no limit) |
 | `MAX_ITERATIONS` | integer | `100` | Maximum number of iterations per task |
+| `BITBUCKET_MODE` | string | `"cloud"` | Bitbucket API mode (`cloud` or `server`) used for git integrations |
 | `RUNTIME` | string | `"docker"` | Runtime environment (`docker`, `local`, `cli`, etc.) |
 | `DEFAULT_AGENT` | string | `"CodeActAgent"` | Default agent class to use |
 | `JWT_SECRET` | string | auto-generated | JWT secret for authentication |

--- a/openhands/usage/settings/integrations-settings.mdx
+++ b/openhands/usage/settings/integrations-settings.mdx
@@ -117,7 +117,7 @@ OpenHands automatically exports a `GITLAB_TOKEN` to the shell environment if pro
 </Accordion>
 </AccordionGroup>
 
-#### BitBucket Setup
+#### BitBucket Cloud Setup
 <AccordionGroup>
 <Accordion title="Setting Up a Bitbucket Password">
 1. **Generate an App password**:
@@ -141,3 +141,7 @@ OpenHands automatically exports a `GITLAB_TOKEN` to the shell environment if pro
 </Accordion>
 
 </AccordionGroup>
+
+#### BitBucket Server Setup (experimental)
+
+To integrate with a BitBucket server instance, create a Personal Access Token and see the docs for [configuration options](/openhands/usage/advanced/configuration-options) under "Secrets Store and Git Provider Tokens".


### PR DESCRIPTION
- [X] I have read and reviewed the documentation changes to the best of my ability.
- [X] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

These are documentation updates associated with this OpenHands PR, which adds BitBucket Server support.

https://github.com/OpenHands/OpenHands/pull/11052

We refer to this change as experimental, because we do not currently have the ability to validate BitBucket Server integration (only Cloud), but are willing to accept community fixes.

Another PR can explain this meaning of "experimental", which we expect to be a recurring pattern. Where should that go, in FAQ?