### PR TITLE
docs: update example paths after renumbering in agent-sdk

### DIFF
--- a/sdk/guides/agent-server/apptainer-sandbox.mdx
+++ b/sdk/guides/agent-server/apptainer-sandbox.mdx
@@ -8,7 +8,7 @@ The Apptainer sandboxed agent server demonstrates how to run agents in isolated 
 Apptainer (formerly Singularity) is a container runtime designed for HPC environments that doesn't require root access, making it ideal for shared computing environments, university clusters, and systems where Docker is not available.
 
 <Note>
-This example is available on GitHub: [examples/02_remote_agent_server/07_convo_with_apptainer_sandboxed_server.py](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/02_remote_agent_server/07_convo_with_apptainer_sandboxed_server.py)
+This example is available on GitHub: [examples/02_remote_agent_server/08_convo_with_apptainer_sandboxed_server.py](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/02_remote_agent_server/08_convo_with_apptainer_sandboxed_server.py)
 </Note>
 
 ## When to Use Apptainer
@@ -30,7 +30,7 @@ Before running this example, ensure you have:
 
 This example shows how to create an ApptainerWorkspace that automatically manages Apptainer containers for agent execution:
 
-```python icon="python" expandable examples/02_remote_agent_server/07_convo_with_apptainer_sandboxed_server.py
+```python icon="python" expandable examples/02_remote_agent_server/08_convo_with_apptainer_sandboxed_server.py
 import os
 import platform
 import time
@@ -145,7 +145,7 @@ with ApptainerWorkspace(
 ```bash Running the Example
 export LLM_API_KEY="your-api-key"
 cd agent-sdk
-uv run python examples/02_remote_agent_server/07_convo_with_apptainer_sandboxed_server.py
+uv run python examples/02_remote_agent_server/08_convo_with_apptainer_sandboxed_server.py
 ```
 
 ## Configuration Options

--- a/sdk/guides/agent-server/cloud-workspace.mdx
+++ b/sdk/guides/agent-server/cloud-workspace.mdx
@@ -8,19 +8,19 @@ The `OpenHandsCloudWorkspace` demonstrates how to use the [OpenHands Cloud](http
 ## Basic Example
 
 <Note>
-This example is available on GitHub: [examples/02_remote_agent_server/06_convo_with_cloud_workspace.py](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/02_remote_agent_server/06_convo_with_cloud_workspace.py)
+This example is available on GitHub: [examples/02_remote_agent_server/07_convo_with_cloud_workspace.py](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/02_remote_agent_server/07_convo_with_cloud_workspace.py)
 </Note>
 
 This example shows how to connect to OpenHands Cloud for fully managed agent execution:
 
-```python icon="python" expandable examples/02_remote_agent_server/06_convo_with_cloud_workspace.py
+```python icon="python" expandable examples/02_remote_agent_server/07_convo_with_cloud_workspace.py
 """Example: OpenHandsCloudWorkspace for OpenHands Cloud API.
 
 This example demonstrates using OpenHandsCloudWorkspace to provision a sandbox
 via OpenHands Cloud (app.all-hands.dev) and run an agent conversation.
 
 Usage:
-  uv run examples/02_remote_agent_server/06_convo_with_cloud_workspace.py
+  uv run examples/02_remote_agent_server/07_convo_with_cloud_workspace.py
 
 Requirements:
   - LLM_API_KEY: API key for direct LLM provider access (e.g., Anthropic API key)
@@ -119,7 +119,7 @@ export OPENHANDS_CLOUD_API_KEY="your-cloud-api-key"
 # Optional: specify a custom sandbox spec
 # export OPENHANDS_SANDBOX_SPEC_ID="your-sandbox-spec-id"
 cd agent-sdk
-uv run python examples/02_remote_agent_server/06_convo_with_cloud_workspace.py
+uv run python examples/02_remote_agent_server/07_convo_with_cloud_workspace.py
 ```
 
 ## Key Concepts

--- a/sdk/guides/agent-server/custom-tools.mdx
+++ b/sdk/guides/agent-server/custom-tools.mdx
@@ -12,10 +12,10 @@ For standalone custom tools (without remote agent server), see the [Custom Tools
 ## Complete Example
 
 <Note>
-This example is available on GitHub: [examples/02_remote_agent_server/05_custom_tool/](https://github.com/OpenHands/software-agent-sdk/tree/main/examples/02_remote_agent_server/05_custom_tool)
+This example is available on GitHub: [examples/02_remote_agent_server/06_custom_tool/](https://github.com/OpenHands/software-agent-sdk/tree/main/examples/02_remote_agent_server/06_custom_tool)
 </Note>
 
-```python icon="python" expandable examples/02_remote_agent_server/05_custom_tool/custom_tool_example.py
+```python icon="python" expandable examples/02_remote_agent_server/06_custom_tool/custom_tool_example.py
 """Example: Using custom tools with remote agent server.
 
 This example demonstrates how to use custom tools with a remote agent server
@@ -23,7 +23,7 @@ by building a custom base image that includes the tool implementation.
 
 Prerequisites:
     1. Build the custom base image first:
-       cd examples/02_remote_agent_server/05_custom_tool
+       cd examples/02_remote_agent_server/06_custom_tool
        ./build_custom_image.sh
 
     2. Set LLM_API_KEY environment variable
@@ -271,7 +271,7 @@ logger.info("6. Read the logged data back from the workspace")
 
 ```bash Running the Example
 # Build the custom base image first
-cd examples/02_remote_agent_server/05_custom_tool
+cd examples/02_remote_agent_server/06_custom_tool
 ./build_custom_image.sh
 
 # Run the example
@@ -292,7 +292,7 @@ uv run python custom_tool_example.py
 
 ### Custom Tool (`custom_tools/log_data.py`)
 
-```python icon="python" expandable examples/02_remote_agent_server/05_custom_tool/custom_tools/log_data.py
+```python icon="python" expandable examples/02_remote_agent_server/06_custom_tool/custom_tools/log_data.py
 """Log Data Tool - Example custom tool for logging structured data to JSON.
 
 This tool demonstrates how to create a custom tool that logs structured data

--- a/sdk/guides/agent-server/docker-sandbox.mdx
+++ b/sdk/guides/agent-server/docker-sandbox.mdx
@@ -238,12 +238,12 @@ Use `DockerWorkspace` when you can rely on the official pre-built images for the
 ## 2) VS Code in Docker Sandbox
 
 <Note>
-This example is available on GitHub: [examples/02_remote_agent_server/04_vscode_with_docker_sandboxed_server.py](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/02_remote_agent_server/04_vscode_with_docker_sandboxed_server.py)
+This example is available on GitHub: [examples/02_remote_agent_server/05_vscode_with_docker_sandboxed_server.py](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/02_remote_agent_server/05_vscode_with_docker_sandboxed_server.py)
 </Note>
 
 VS Code with Docker demonstrates how to enable VS Code Web integration in a Docker-sandboxed environment. This allows you to access a full VS Code editor running in the container, making it easy to inspect, edit, and manage files that the agent is working with.
 
-```python icon="python" expandable examples/02_remote_agent_server/04_vscode_with_docker_sandboxed_server.py
+```python icon="python" expandable examples/02_remote_agent_server/05_vscode_with_docker_sandboxed_server.py
 import os
 import time
 
@@ -358,7 +358,7 @@ with DockerWorkspace(
 ```bash Running the Example
 export LLM_API_KEY="your-api-key"
 cd agent-sdk
-uv run python examples/02_remote_agent_server/04_vscode_with_docker_sandboxed_server.py
+uv run python examples/02_remote_agent_server/05_vscode_with_docker_sandboxed_server.py
 ```
 
 ### Key Concepts


### PR DESCRIPTION
## Summary
Update documentation references to match renamed examples in the agent-sdk repository.

This PR corresponds to OpenHands/software-agent-sdk#1637 which fixes duplicate example numbering in `examples/02_remote_agent_server/`.

## Changes
Updated references in SDK documentation:
- `04_vscode_with_docker_sandboxed_server.py` → `05_vscode_with_docker_sandboxed_server.py`
- `05_custom_tool/` → `06_custom_tool/`
- `06_convo_with_cloud_workspace.py` → `07_convo_with_cloud_workspace.py`
- `07_convo_with_apptainer_sandboxed_server.py` → `08_convo_with_apptainer_sandboxed_server.py`

## Files Modified
- `sdk/guides/agent-server/docker-sandbox.mdx`
- `sdk/guides/agent-server/custom-tools.mdx`
- `sdk/guides/agent-server/cloud-workspace.mdx`
- `sdk/guides/agent-server/apptainer-sandbox.mdx`

## Related PRs
- Agent SDK: https://github.com/OpenHands/software-agent-sdk/pull/1637

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/cf0df47bfc1e488cb151229935bc6a18)