### PR TITLE
docs: update skills overview with AgentSkills SKILL.md

### DIFF
--- a/overview/skills.mdx
+++ b/overview/skills.mdx
@@ -36,8 +36,8 @@ We also support model-specific variants:
 
 To add optional skills that are loaded on demand:
 
-- **Legacy/OpenHands format (simple)**: put markdown files in `.openhands/skills/*.md`.
 - **AgentSkills standard (recommended for progressive disclosure)**: create one directory per skill and add a `SKILL.md` file.
+- **Legacy/OpenHands format (simple)**: put markdown files in `.openhands/skills/*.md`.
 
 <Note>
 Loaded skills take up space in the context window. On-demand skills help keep the system prompt smaller because the agent sees a summary first and reads the full content only when needed.
@@ -50,14 +50,17 @@ some-repository/
 ├── AGENTS.md                       # Permanent repository guidelines (recommended)
 └── .openhands/
     └── skills/
-        ├── trigger_this.md         # Legacy/OpenHands format (keyword-triggered)
-        ├── trigger_that.md         # Legacy/OpenHands format (keyword-triggered)
-        └── rot13-encryption/       # AgentSkills standard (progressive disclosure)
-            ├── SKILL.md
-            ├── scripts/
-            │   └── rot13.sh
-            └── references/
-                └── README.md
+        ├── rot13-encryption/       # AgentSkills standard (progressive disclosure)
+        │   ├── SKILL.md
+        │   ├── scripts/
+        │   │   └── rot13.sh
+        │   └── references/
+        │       └── README.md
+        ├── another-agentskill/     # AgentSkills standard (progressive disclosure)
+        │   ├── SKILL.md
+        │   └── scripts/
+        │       └── placeholder.sh
+        └── legacy_trigger_this.md  # Legacy/OpenHands format (keyword-triggered)
 ```
 
 ## Skill Types


### PR DESCRIPTION
Updates the overview skills documentation to reflect both supported on-demand skill formats:

- AgentSkills standard `.openhands/skills/<skill>/SKILL.md` (progressive disclosure)
- Legacy/OpenHands `.openhands/skills/*.md`

Also clarifies the high-level loading model distinction between always-on context (AGENTS.md) vs on-demand skills.

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f49ab1b00d08429cbf376a037bb4560d)