### PR TITLE
Clarify repo skills vs legacy repo.md in SDK docs

### DIFF
--- a/sdk/guides/skill.mdx
+++ b/sdk/guides/skill.mdx
@@ -173,14 +173,14 @@ tools = [
 agent_context = AgentContext(
     skills=[
         Skill(
-            name="repo.md",
+            name="grumpy-cat",
             content="When you see this message, you should reply like "
             "you are a grumpy cat forced to use the internet.",
             # source is optional - identifies where the skill came from
             # You can set it to be the path of a file that contains the skill content
             source=None,
             # trigger determines when the skill is active
-            # trigger=None means always active (repo skill)
+            # trigger=None means always active (permanent/repo context)
             trigger=None,
         ),
         Skill(
@@ -514,8 +514,8 @@ from openhands.sdk.context.skills import load_skills_from_dir
 repo_skills, knowledge_skills, agent_skills = load_skills_from_dir(skills_dir)
 ```
 
-- **repo_skills**: Skills from `repo.md` files (always active)
-- **knowledge_skills**: Skills from `knowledge/` subdirectories
+- **repo_skills**: Skills with `trigger=None` (always active). These typically come from `.openhands/skills/*.md` files without triggers (some legacy examples used a file named `repo.md`).
+- **knowledge_skills**: Skills with a trigger (e.g., `KeywordTrigger` or `TaskTrigger`) that are injected when triggered
 - **agent_skills**: Skills from `SKILL.md` files (AgentSkills standard)
 
 #### `discover_skill_resources()`


### PR DESCRIPTION
Updates `sdk/guides/skill.mdx` to avoid implying that `repo.md` (or `.openhands/skills/repo.md`) is a canonical mechanism.

- Example Skill name changed from `repo.md` to `grumpy-cat` (name can be any identifier)
- Clarifies `repo_skills` are skills with `trigger=None`
- Clarifies `knowledge_skills` are triggered skills, not tied to a `knowledge/` subdirectory

Context: we removed the `.openhands/skills/repo.md -> AGENTS.md` symlink in agent-sdk and OpenHands-CLI to prevent duplicate loading of `AGENTS.md`.

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)