### PR TITLE
Fix broken tools source link in custom-tools guide

### DIFF
--- a/sdk/guides/custom-tools.mdx
+++ b/sdk/guides/custom-tools.mdx
@@ -18,7 +18,7 @@ agent = Agent(llm=llm, tools=tools)
 ```
 
 <Note>
-See [source code](https://github.com/OpenHands/software-agent-sdk/tree/main/openhands-sdk/openhands/tools) for the complete list of available tools and design philosophy.
+See [source code](https://github.com/OpenHands/software-agent-sdk/tree/main/openhands-tools/openhands/tools) for the complete list of available tools and design philosophy.
 </Note>
 
 ## Understanding the Tool System
@@ -29,7 +29,7 @@ The SDK's tool system is built around three core components:
 2. **Observation** - Defines output data (what the tool returns)
 3. **Executor** - Implements the tool's logic (what the tool does)
 
-These components are tied together by a **ToolDefinition** that registers the tool with the agent. The tools package ([source code](https://github.com/OpenHands/software-agent-sdk/tree/main/openhands-sdk/openhands/tools)) provides built-in tools that follow these patterns.
+These components are tied together by a **ToolDefinition** that registers the tool with the agent. The tools package ([source code](https://github.com/OpenHands/software-agent-sdk/tree/main/openhands-tools/openhands/tools)) provides built-in tools that follow these patterns.
 
 ## Creating a Custom Tool
 
@@ -347,4 +347,4 @@ Create custom tools when you need to:
 ## Next Steps
 
 - **[Model Context Protocol (MCP) Integration](/sdk/guides/mcp)** - Use Model Context Protocol servers
-- **[Tools Package Source Code](https://github.com/OpenHands/software-agent-sdk/tree/main/openhands-sdk/openhands/tools)** - Built-in tools implementation
+- **[Tools Package Source Code](https://github.com/OpenHands/software-agent-sdk/tree/main/openhands-tools/openhands/tools)** - Built-in tools implementation


### PR DESCRIPTION
Summary of Change

Fixes #257 

This PR updates the Custom Tools guide to point to the correct source directory for the built-in tools.

The previous links referenced a non-existent path (`openhands-sdk/openhands/tools`) and returned 404.
They have been updated to the correct location under `openhands-tools/openhands/tools`.

No other content or behavior is changed.


- [x] I have read and reviewed the documentation changes to the best of my ability.
- [x] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**
