### PR TITLE
Document .openhands/stop.sh repository hook

### DIFF
--- a/openhands/usage/customization/repository.mdx
+++ b/openhands/usage/customization/repository.mdx
@@ -47,9 +47,9 @@ exit 0
 ```
 
 
-## Agent Finish Script
+## Stop Script
 
-You can add a `.openhands/agent_finish.sh` file, which will run every time the agent finishes a task (i.e., when the agent emits an `AgentFinishAction` / transitions to the `FINISHED` state).
+You can add a `.openhands/stop.sh` file, which will run every time the agent finishes a task (i.e., when the agent emits an `AgentFinishAction` / transitions to the `FINISHED` state).
 
 - Runs inside the sandbox/runtime environment
 - Runs from the repository root (best-effort via `git rev-parse --show-toplevel`)


### PR DESCRIPTION
Documents the repository customization hook `.openhands/stop.sh`, which is executed whenever the agent finishes a task.