### PR TITLE
Release 1.2.0

### DIFF
--- a/openhands/usage/cli/installation.mdx
+++ b/openhands/usage/cli/installation.mdx
@@ -65,7 +65,7 @@ description: Install the OpenHands CLI on your system
     ```bash
     docker run -it \
         --pull=always \
-        -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:1.1-nikolaik \
+        -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:1.2-nikolaik \
         -e SANDBOX_USER_ID=$(id -u) \
         -e SANDBOX_VOLUMES=$SANDBOX_VOLUMES \
         -v /var/run/docker.sock:/var/run/docker.sock \

--- a/openhands/usage/llms/local-llms.mdx
+++ b/openhands/usage/llms/local-llms.mdx
@@ -68,23 +68,23 @@ Download and install the LM Studio desktop app from [lmstudio.ai](https://lmstud
 1. Check [the installation guide](/openhands/usage/run-openhands/local-setup) and ensure all prerequisites are met before running OpenHands, then run:
 
 ```bash
-docker pull docker.openhands.dev/openhands/runtime:1.1-nikolaik
+docker pull docker.openhands.dev/openhands/runtime:1.2-nikolaik
 
 docker run -it --rm --pull=always \
-    -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:1.1-nikolaik \
+    -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:1.2-nikolaik \
     -e LOG_ALL_EVENTS=true \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v ~/.openhands:/.openhands \
     -p 3000:3000 \
     --add-host host.docker.internal:host-gateway \
     --name openhands-app \
-    docker.openhands.dev/openhands/openhands:1.1
+    docker.openhands.dev/openhands/openhands:1.2
 ```
 
 2. Wait until the server is running (see log below):
 ```
 Digest: sha256:e72f9baecb458aedb9afc2cd5bc935118d1868719e55d50da73190d3a85c674f
-Status: Image is up to date for docker.openhands.dev/openhands/openhands:1.1
+Status: Image is up to date for docker.openhands.dev/openhands/openhands:1.2
 Starting OpenHands...
 Running OpenHands as root
 14:22:13 - openhands:INFO: server_config.py:50 - Using config class None

--- a/openhands/usage/run-openhands/local-setup.mdx
+++ b/openhands/usage/run-openhands/local-setup.mdx
@@ -121,17 +121,17 @@ Note that you'll still need `uv` installed for the default MCP servers to work p
 <Accordion title="Docker Command (Click to expand)">
 
 ```bash
-docker pull docker.openhands.dev/openhands/runtime:1.1-nikolaik
+docker pull docker.openhands.dev/openhands/runtime:1.2-nikolaik
 
 docker run -it --rm --pull=always \
-    -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:1.1-nikolaik \
+    -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:1.2-nikolaik \
     -e LOG_ALL_EVENTS=true \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v ~/.openhands:/.openhands \
     -p 3000:3000 \
     --add-host host.docker.internal:host-gateway \
     --name openhands-app \
-    docker.openhands.dev/openhands/openhands:1.1
+    docker.openhands.dev/openhands/openhands:1.2
 ```
 
 </Accordion>


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [ ] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

Release 1.2.0
