### PR TITLE
docs: Update plugin loading documentation for Conversation-based approach

### DIFF
--- a/sdk/guides/plugins.mdx
+++ b/sdk/guides/plugins.mdx
@@ -17,7 +17,7 @@ The plugin format is compatible with the [Claude Code plugin structure](https://
 
 The recommended way to load plugins is via the `plugins` parameter on `Conversation`. This approach:
 
-- **Automatic Loading**: Plugins are fetched and loaded automatically
+- **Lazy Loading**: Plugins are fetched and loaded on first `send_message()` or `run()` call
 - **Automatic Merging**: Skills, MCP configs, and hooks are merged correctly
 - **Multi-Plugin Support**: Load multiple plugins with proper conflict resolution
 - **Git Support**: Use GitHub shorthand, git URLs, or local paths
@@ -124,14 +124,16 @@ plugins = [
 llm = LLM(usage_id="demo", model="anthropic/claude-sonnet-4-5-20250929", api_key=api_key)
 agent = Agent(llm=llm, tools=[Tool(name=TerminalTool.name)])
 
-# Create conversation - plugins are loaded and merged automatically
+# Create conversation with plugins
+# Note: Plugins are loaded lazily on first send_message() or run() call
 conversation = Conversation(
     agent=agent,
     workspace="./workspace",
     plugins=plugins,
 )
 
-# Skills from plugins are now available to the agent
+# This first send_message() triggers plugin loading
+# Skills from plugins are then available to the agent
 conversation.send_message("How do I lint Python code?")
 conversation.run()
 ```


### PR DESCRIPTION
## Summary

Update documentation to reflect the actual plugin loading implementation in software-agent-sdk#1651.

## Changes

- Update "Recommended" section to use `plugins` parameter on `Conversation` (not `AgentContext.plugin_source`)
- Use `PluginSource` model for specifying plugins
- Update example path from `03_plugin_via_agent_context` to `03_plugin_via_conversation`
- Update Quick Reference section
- Fix anchor link in Manual Plugin Loading note

## The Recommended Pattern

```python
from openhands.sdk.plugin import PluginSource

conversation = Conversation(
    agent=agent,
    workspace="./workspace",
    plugins=[
        PluginSource(source="github:org/security-plugin", ref="v2.0.0"),
        PluginSource(source="github:org/monorepo", repo_path="plugins/audit"),
        PluginSource(source="/local/custom-plugin"),
    ],
)
```

## Related

- OpenHands/software-agent-sdk#1651 - Plugin loading support in agent-server