### PR TITLE
DRAFT - Work in Process - Reorganize navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -65,7 +65,7 @@
         ]
       },
       {
-        "tab": "Web",
+        "tab": "Documentation",
         "pages": [
           {
             "group": "Key Features",
@@ -74,26 +74,49 @@
             ]
           },
           {
-            "group": "OpenHands Cloud",
+            "group": "Getting Started",
             "pages": [
-              "openhands/usage/cloud/openhands-cloud",
+              "openhands/usage/cli/installation",
+              "openhands/usage/cli/quick-start"
+            ]
+          },
+          {
+            "group": "Ways to Run",
+            "pages": [
+              "openhands/usage/cli/terminal",
+              "openhands/usage/cli/headless",
+              "openhands/usage/cli/web-interface",
+              "openhands/usage/cli/gui-server",
               {
-                "group": "Integrations",
+                "group": "IDE Integration (ACP)",
                 "pages": [
-                  "openhands/usage/cloud/bitbucket-installation",
-                  "openhands/usage/cloud/github-installation",
-                  "openhands/usage/cloud/gitlab-installation",
-                  "openhands/usage/cloud/slack-installation",
-                  {
-                    "group": "Project Management Tools",
-                    "pages": [
-                      "openhands/usage/cloud/project-management/jira-integration"
-                    ]
-                  }
+                  "openhands/usage/cli/ide/overview",
+                  "openhands/usage/cli/ide/zed",
+                  "openhands/usage/cli/ide/toad",
+                  "openhands/usage/cli/ide/vscode",
+                  "openhands/usage/cli/ide/jetbrains"
                 ]
-              },
-              "openhands/usage/cloud/cloud-ui",
-              "openhands/usage/cloud/cloud-api"
+              }
+            ]
+          },
+          {
+            "group": "Cloud",
+            "pages": [
+              "openhands/usage/cli/cloud"
+            ]
+          },
+          {
+            "group": "Extensions",
+            "pages": [
+              "openhands/usage/cli/mcp-servers",
+              "openhands/usage/cli/critic"
+            ]
+          },
+          {
+            "group": "Reference",
+            "pages": [
+              "openhands/usage/cli/command-reference",
+              "openhands/usage/cli/resume"
             ]
           },
           {
@@ -102,10 +125,6 @@
               "openhands/usage/run-openhands/local-setup",
               "openhands/usage/run-openhands/gui-mode"
             ]
-          },
-          {
-            "group": "REST API",
-            "openapi": "openapi/openapi.json"
           },
           {
             "group": "Customizations & Settings",
@@ -178,53 +197,39 @@
         ]
       },
       {
-        "tab": "CLI",
+        "tab": "OpenHands Cloud",
         "pages": [
           {
-            "group": "Getting Started",
+            "group": "OpenHands Cloud",
             "pages": [
-              "openhands/usage/cli/installation",
-              "openhands/usage/cli/quick-start"
-            ]
-          },
-          {
-            "group": "Ways to Run",
-            "pages": [
-              "openhands/usage/cli/terminal",
-              "openhands/usage/cli/headless",
-              "openhands/usage/cli/web-interface",
-              "openhands/usage/cli/gui-server",
+              "openhands/usage/cloud/openhands-cloud",
               {
-                "group": "IDE Integration (ACP)",
+                "group": "Integrations",
                 "pages": [
-                  "openhands/usage/cli/ide/overview",
-                  "openhands/usage/cli/ide/zed",
-                  "openhands/usage/cli/ide/toad",
-                  "openhands/usage/cli/ide/vscode",
-                  "openhands/usage/cli/ide/jetbrains"
+                  "openhands/usage/cloud/bitbucket-installation",
+                  "openhands/usage/cloud/github-installation",
+                  "openhands/usage/cloud/gitlab-installation",
+                  "openhands/usage/cloud/slack-installation",
+                  {
+                    "group": "Project Management Tools",
+                    "pages": [
+                      "openhands/usage/cloud/project-management/jira-integration"
+                    ]
+                  }
                 ]
-              }
+              },
+              "openhands/usage/cloud/cloud-ui",
+              "openhands/usage/cloud/cloud-api"
             ]
-          },
+          }
+        ]
+      },
+      {
+        "tab": "REST API",
+        "pages": [
           {
-            "group": "Cloud",
-            "pages": [
-              "openhands/usage/cli/cloud"
-            ]
-          },
-          {
-            "group": "Extensions",
-            "pages": [
-              "openhands/usage/cli/mcp-servers",
-              "openhands/usage/cli/critic"
-            ]
-          },
-          {
-            "group": "Reference",
-            "pages": [
-              "openhands/usage/cli/command-reference",
-              "openhands/usage/cli/resume"
-            ]
+            "group": "REST API",
+            "openapi": "openapi/openapi.json"
           }
         ]
       },


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [ ] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

This PR reorganizes the documentation navigation structure:

1. **Renamed "Web" to "Documentation"** - The main documentation tab is now called "Documentation"

2. **Moved CLI sections into Documentation** - All navigation sections previously under CLI (Getting Started, Ways to Run, Cloud, Extensions, Reference) are now consolidated into the Documentation tab

3. **Created "OpenHands Cloud" as a top-level section** - The OpenHands Cloud content (with its Integrations subgroup) now has its own dedicated tab for better visibility

4. **Created "REST API" as a top-level section** - The REST API reference now has its own dedicated tab

The final tab order is:
- Overview
- Documentation (formerly "Web" + CLI content merged)
- OpenHands Cloud (new top-level)
- REST API (new top-level)
- SDK

@jpelletier1 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)