### PR TITLE
Move Company/Blog/Cloud links to footer

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -348,26 +348,7 @@
           }
         ]
       }
-    ],
-    "global": {
-      "anchors": [
-        {
-          "anchor": "Company",
-          "href": "https://openhands.dev/",
-          "icon": "house"
-        },
-        {
-          "anchor": "Blog",
-          "href": "https://openhands.dev/blog",
-          "icon": "newspaper"
-        },
-        {
-          "anchor": "OpenHands Cloud",
-          "href": "https://app.all-hands.dev",
-          "icon": "cloud"
-        }
-      ]
-    }
+    ]
   },
   "logo": {
     "light": "/logo/light.png",
@@ -384,7 +365,26 @@
     "socials": {
       "slack": "https://openhands.dev/joinslack",
       "github": "https://github.com/OpenHands/OpenHands"
-    }
+    },
+    "links": [
+      {
+        "header": "Links",
+        "items": [
+          {
+            "label": "Company",
+            "href": "https://openhands.dev/"
+          },
+          {
+            "label": "Blog",
+            "href": "https://openhands.dev/blog"
+          },
+          {
+            "label": "OpenHands Cloud",
+            "href": "https://app.all-hands.dev"
+          }
+        ]
+      }
+    ]
   },
   "head": [
     {


### PR DESCRIPTION
HUMAN: This PR proposes to remove the sidebar global links and move them in the footer of the pages. It would look like this? 🤔 

<img width="604" height="74" alt="image" src="https://github.com/user-attachments/assets/1c326f8e-ef95-4e32-bb57-579e67700509" />


### What
- Removed the left-sidebar global anchor shortcuts (Company, Blog, OpenHands Cloud)
- Re-added those links in the footer as a "Links" column

### Why
Keeps the left navigation focused on docs while still providing quick access to external resources.

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)