### PR TITLE
docs: Add step-by-step instructions for disabling critic feature

### DIFF
--- a/openhands/usage/cli/critic.mdx
+++ b/openhands/usage/cli/critic.mdx
@@ -35,7 +35,12 @@ The critic feature is **free during the public beta phase** for all OpenHands LL
 
 ## Disabling the Critic
 
-If you prefer not to use the critic feature, you can disable it in your settings.
+If you prefer not to use the critic feature, you can disable it in your settings:
+
+1. Open the command palette with `Ctrl+P`
+2. Select **Settings**
+3. Navigate to the **CLI Settings** tab
+4. Toggle off **Enable Critic (Experimental)**
 
 ![Critic settings in CLI](./screenshots/critic-cli-settings.png)
 


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [x] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

This PR improves the documentation for the critic feature by adding clear step-by-step instructions for users who want to disable it.

## Changes

Added navigation instructions to the "Disabling the Critic" section:
1. Open the command palette with `Ctrl+P`
2. Select **Settings**
3. Navigate to the **CLI Settings** tab
4. Toggle off **Enable Critic (Experimental)**

## Context

This addresses user feedback from issue OpenHands/OpenHands#8963 where users noted that instructions to opt-out of the critic feature were not very visible in the CLI or documentation.

## References

- Source: The navigation path was verified from the CLI codebase in `openhands_cli/tui/modals/settings/components/cli_settings_tab.py`
- Related issue: OpenHands/OpenHands#8963

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b5366d4fc0cc45ddab30ae743093e235)