### PR TITLE
docs: Fix Docker volume mount path for .openhands

### DIFF
--- a/openhands/usage/run-openhands/local-setup.mdx
+++ b/openhands/usage/run-openhands/local-setup.mdx
@@ -126,7 +126,7 @@ docker run -it --rm --pull=always \
   -e AGENT_SERVER_IMAGE_TAG=1.10.0-python \
   -e LOG_ALL_EVENTS=true \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  -v ~/.openhands:/.openhands \
+  -v ~/.openhands:/root/.openhands \
   -p 3000:3000 \
   --add-host host.docker.internal:host-gateway \
   --name openhands-app \


### PR DESCRIPTION
The default location that OpenHands looks for .openhands directory has moved in recent versions but the docs were not completely updated.

- [X] I have read and reviewed the documentation changes to the best of my ability.
- [ ] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

The container can either mount at /root/.openhands or set an env var to tell location.  I went with /root to match an existing document update that shows running openhands-cli inside a docker container and also mounts at /root.

I have seen some reports in Github Issues and Slack of users confused why conversations are no longer lasting past a container restart and other confusion on behavior differences in $HOME/.openhands after upgrading.