### PR TITLE
Add AWS Bedrock configuration guide for SDK users

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -138,6 +138,7 @@
                     "pages": [
                       "openhands/usage/llms/openhands-llms",
                       "openhands/usage/llms/azure-llms",
+                      "openhands/usage/llms/bedrock-llms",
                       "openhands/usage/llms/google-llms",
                       "openhands/usage/llms/groq",
                       "openhands/usage/llms/local-llms",
@@ -291,6 +292,12 @@
                   "sdk/guides/llm-streaming",
                   "sdk/guides/llm-image-input",
                   "sdk/guides/llm-error-handling"
+                ]
+              },
+              {
+                "group": "LLM Providers",
+                "pages": [
+                  "sdk/guides/llm-provider-bedrock"
                 ]
               },
               {

--- a/openhands/usage/llms/bedrock-llms.mdx
+++ b/openhands/usage/llms/bedrock-llms.mdx
@@ -1,0 +1,75 @@
+---
+title: AWS Bedrock
+description: OpenHands uses LiteLLM to make calls to AWS Bedrock models. You can find their documentation on using AWS Bedrock as a provider [here](https://docs.litellm.ai/docs/providers/bedrock).
+---
+
+## Prerequisites
+
+AWS Bedrock requires the `boto3` library to be installed. This is used internally by LiteLLM - you don't need to import it in your code.
+
+```bash
+pip install boto3>=1.28.57
+```
+
+## AWS Bedrock Configuration
+
+When running OpenHands, you'll need to set AWS credentials using environment variables with `-e` in the docker run command.
+
+### Authentication Options
+
+| Method | Environment Variables |
+|--------|----------------------|
+| Access Keys | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` |
+| Session Token | `AWS_SESSION_TOKEN` (in addition to access keys) |
+| AWS Profile | `AWS_PROFILE_NAME` |
+| IAM Role | `AWS_ROLE_NAME`, `AWS_WEB_IDENTITY_TOKEN` |
+| Bedrock API Key | `AWS_BEARER_TOKEN_BEDROCK` |
+
+### Example with Access Keys
+
+```bash
+docker run -it --pull=always \
+    -e AWS_ACCESS_KEY_ID="your-access-key" \
+    -e AWS_SECRET_ACCESS_KEY="your-secret-key" \
+    -e AWS_REGION_NAME="us-east-1" \
+    ...
+```
+
+Then in the OpenHands UI Settings under the `LLM` tab:
+
+1. Enable `Advanced` options.
+2. Set the following:
+   - `Custom Model` to `bedrock/<model-id>` (e.g., `bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0`)
+
+## Model Names
+
+Use the `bedrock/` prefix followed by the Bedrock model ID:
+
+| Model | Model ID |
+|-------|----------|
+| Claude 3.5 Sonnet v2 | `bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0` |
+| Claude 3 Opus | `bedrock/anthropic.claude-3-opus-20240229-v1:0` |
+| Claude 3 Haiku | `bedrock/anthropic.claude-3-haiku-20240307-v1:0` |
+| Claude 3.5 Haiku | `bedrock/anthropic.claude-3-5-haiku-20241022-v1:0` |
+
+<Note>
+You can find the full list of available Bedrock model IDs in the [AWS Bedrock documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html) or in the AWS Console under Bedrock > Model access.
+</Note>
+
+## Cross-Region Inference
+
+AWS Bedrock supports cross-region inference for improved availability. To use it, include the region in your model ID:
+
+```
+bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Access Denied**: Ensure your AWS credentials have the necessary permissions for Bedrock. You need `bedrock:InvokeModel` permission.
+
+2. **Model Not Found**: Verify that the model is enabled in your AWS account. Go to AWS Console > Bedrock > Model access to enable models.
+
+3. **Region Issues**: Make sure `AWS_REGION_NAME` is set to a region where Bedrock is available and where you have model access enabled.

--- a/openhands/usage/llms/llms.mdx
+++ b/openhands/usage/llms/llms.mdx
@@ -78,6 +78,7 @@ as environment variables (or add them to your `config.toml`) so the SDK picks th
 
 We have a few guides for running OpenHands with specific model providers:
 
+- [AWS Bedrock](/openhands/usage/llms/bedrock-llms)
 - [Azure](/openhands/usage/llms/azure-llms)
 - [Google](/openhands/usage/llms/google-llms)
 - [Groq](/openhands/usage/llms/groq)

--- a/sdk/arch/llm.mdx
+++ b/sdk/arch/llm.mdx
@@ -294,6 +294,7 @@ verbatim to SDK applications because both layers wrap the same
 | OpenHands hosted models | [/openhands/usage/llms/openhands-llms](/openhands/usage/llms/openhands-llms) |
 | OpenAI | [/openhands/usage/llms/openai-llms](/openhands/usage/llms/openai-llms) |
 | Azure OpenAI | [/openhands/usage/llms/azure-llms](/openhands/usage/llms/azure-llms) |
+| AWS Bedrock | [/openhands/usage/llms/bedrock-llms](/openhands/usage/llms/bedrock-llms) |
 | Google Gemini / Vertex | [/openhands/usage/llms/google-llms](/openhands/usage/llms/google-llms) |
 | Groq | [/openhands/usage/llms/groq](/openhands/usage/llms/groq) |
 | OpenRouter | [/openhands/usage/llms/openrouter](/openhands/usage/llms/openrouter) |

--- a/sdk/guides/llm-provider-bedrock.mdx
+++ b/sdk/guides/llm-provider-bedrock.mdx
@@ -1,0 +1,169 @@
+---
+title: AWS Bedrock
+description: Configure the SDK to use Claude and other models via AWS Bedrock.
+---
+
+> A ready-to-run example is available [here](#ready-to-run-example)!
+
+Use AWS Bedrock to access Claude and other foundation models through your AWS account.
+
+## Prerequisites
+
+AWS Bedrock requires the `boto3` library:
+
+```bash
+pip install openhands-sdk boto3>=1.28.57
+```
+
+<Note>
+`boto3` is used internally by LiteLLM - you don't need to import it in your code.
+</Note>
+
+## Authentication Options
+
+Configure AWS credentials using environment variables:
+
+| Method | Environment Variables |
+|--------|----------------------|
+| Access Keys | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` |
+| Session Token | `AWS_SESSION_TOKEN` (in addition to access keys) |
+| AWS Profile | `AWS_PROFILE_NAME` |
+| IAM Role | `AWS_ROLE_NAME`, `AWS_WEB_IDENTITY_TOKEN` |
+| Bedrock API Key | `AWS_BEARER_TOKEN_BEDROCK` |
+
+You must also set the AWS region:
+
+```bash
+export AWS_REGION_NAME="us-east-1"
+```
+
+## Model Names
+
+Use the `bedrock/` prefix followed by the Bedrock model ID:
+
+| Model | Model ID |
+|-------|----------|
+| Claude 3.5 Sonnet v2 | `bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0` |
+| Claude 3 Opus | `bedrock/anthropic.claude-3-opus-20240229-v1:0` |
+| Claude 3 Haiku | `bedrock/anthropic.claude-3-haiku-20240307-v1:0` |
+| Claude 3.5 Haiku | `bedrock/anthropic.claude-3-5-haiku-20241022-v1:0` |
+
+## Basic Usage
+
+```python icon="python" focus={7}
+import os
+from openhands.sdk import LLM, Agent, Conversation
+from openhands.sdk.tool import Tool
+from openhands.tools.terminal import TerminalTool
+from openhands.tools.file_editor import FileEditorTool
+
+llm = LLM(model="bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0")
+
+agent = Agent(
+    llm=llm,
+    tools=[
+        Tool(name=TerminalTool.name),
+        Tool(name=FileEditorTool.name),
+    ],
+)
+
+conversation = Conversation(agent=agent, workspace=os.getcwd())
+conversation.send_message("List the files in this directory")
+conversation.run()
+```
+
+## Ready-to-run Example
+
+<Note>
+Before running, ensure you have:
+1. Installed `boto3>=1.28.57`
+2. Set AWS credentials via environment variables
+3. Enabled the model in your AWS Bedrock console
+</Note>
+
+```python icon="python" expandable
+"""
+AWS Bedrock with Claude models.
+
+Prerequisites:
+    pip install openhands-sdk boto3>=1.28.57
+
+Environment variables:
+    AWS_ACCESS_KEY_ID       - Your AWS access key
+    AWS_SECRET_ACCESS_KEY   - Your AWS secret key
+    AWS_REGION_NAME         - AWS region (e.g., us-east-1)
+"""
+import os
+
+from openhands.sdk import LLM, Agent, Conversation
+from openhands.sdk.tool import Tool
+from openhands.tools.terminal import TerminalTool
+from openhands.tools.file_editor import FileEditorTool
+
+# AWS credentials are read from environment variables by LiteLLM/boto3
+# AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION_NAME
+
+llm = LLM(
+    model=os.getenv("LLM_MODEL", "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0"),
+)
+
+agent = Agent(
+    llm=llm,
+    tools=[
+        Tool(name=TerminalTool.name),
+        Tool(name=FileEditorTool.name),
+    ],
+)
+
+conversation = Conversation(agent=agent, workspace=os.getcwd())
+conversation.send_message("List the files in this directory and summarize what you see.")
+conversation.run()
+
+# Report cost
+cost = llm.metrics.accumulated_cost
+print(f"EXAMPLE_COST: {cost}")
+```
+
+### Running the Example
+
+```bash
+# Set AWS credentials
+export AWS_ACCESS_KEY_ID="your-access-key"
+export AWS_SECRET_ACCESS_KEY="your-secret-key"
+export AWS_REGION_NAME="us-east-1"
+
+# Run the example
+python bedrock_example.py
+```
+
+## Cross-Region Inference
+
+AWS Bedrock supports cross-region inference. Include the region prefix in your model ID:
+
+```python
+llm = LLM(model="bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0")
+```
+
+## Troubleshooting
+
+### Access Denied
+
+Ensure your AWS credentials have the `bedrock:InvokeModel` permission.
+
+### Model Not Found
+
+Verify the model is enabled in your AWS account:
+1. Go to AWS Console > Bedrock > Model access
+2. Enable the models you want to use
+
+### Region Issues
+
+Ensure `AWS_REGION_NAME` is set to a region where:
+- Bedrock is available
+- You have model access enabled
+
+## Next Steps
+
+- **[LLM Registry](/sdk/guides/llm-registry)** - Manage multiple LLM providers
+- **[LLM Routing](/sdk/guides/llm-routing)** - Automatically route to different models
+- **[OpenHands Bedrock Guide](/openhands/usage/llms/bedrock-llms)** - Self-hosted OpenHands configuration


### PR DESCRIPTION
- [ ] I have read and reviewed the documentation changes to the best of my ability.
- [ ] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

Closes #264

This PR adds comprehensive AWS Bedrock configuration documentation for both self-hosted OpenHands users and SDK users.

## New Files

### `openhands/usage/llms/bedrock-llms.mdx`
Self-hosted OpenHands guide covering:
- Prerequisites (boto3 installation)
- AWS authentication options (Access Keys, Session Token, Profile, IAM Role, Bearer Token)
- Docker environment variable configuration
- Model name format with `bedrock/` prefix
- Available model IDs table
- Cross-region inference
- Troubleshooting common issues

### `sdk/guides/llm-provider-bedrock.mdx`
SDK-focused guide covering:
- Prerequisites and installation
- Authentication options table
- Model names and IDs
- Basic usage code example
- Ready-to-run example with full code
- Cross-region inference
- Troubleshooting section
- Links to related guides

## Updated Files

- **`docs.json`**: Added Bedrock to Web providers list and created new "LLM Providers" group in SDK Guides section
- **`openhands/usage/llms/llms.mdx`**: Added AWS Bedrock to the LLM Provider Guides list
- **`sdk/arch/llm.mdx`**: Added AWS Bedrock to the LLM Providers table

## Navigation Structure

The new "LLM Providers" group in the SDK section can be expanded in the future for other providers with similar complexity (Vertex AI, local LLMs, etc.).

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1c968330ffbd42fabf2dd0e4401e0a21)