### PR TITLE
Document serialized events example

### DIFF
--- a/sdk/guides/convo-persistence.mdx
+++ b/sdk/guides/convo-persistence.mdx
@@ -228,6 +228,8 @@ This example is available on GitHub: [examples/01_standalone_sdk/36_event_json_t
 </Note>
 
 ```python icon="python" expandable examples/01_standalone_sdk/36_event_json_to_openai_messages.py
+"""Load persisted events and convert them into LLM-ready messages."""
+
 import json
 import os
 import uuid


### PR DESCRIPTION
## Summary
- document the serialized events example from the SDK
- add ready-to-run snippet and run command block
- include the module docstring in the snippet

## Testing
- not run (docs change only)

Related: OpenHands/software-agent-sdk#1916
