### PR TITLE
fix: Fix GitHub Actions workflow syntax for secrets access

### DIFF
--- a/.github/workflows/sync-agent-sdk-openapi.yml
+++ b/.github/workflows/sync-agent-sdk-openapi.yml
@@ -112,22 +112,26 @@ jobs:
             **Note**: This is an automated pull request. Please review the changes to ensure they are correct before merging.
 
       - name: Auto-approve PR
-        if: steps.cpr.outputs.pull-request-url && secrets.DOCS_SYNC_TOKEN
+        if: steps.cpr.outputs.pull-request-url
         env:
           GH_TOKEN: ${{ secrets.DOCS_SYNC_TOKEN }}
         run: |
-          gh pr review "${{ steps.cpr.outputs.pull-request-url }}" \
-            --approve \
-            --body "Auto-approving automated OpenAPI sync PR."
+          if [ -n "$GH_TOKEN" ]; then
+            gh pr review "${{ steps.cpr.outputs.pull-request-url }}" \
+              --approve \
+              --body "Auto-approving automated OpenAPI sync PR."
+          fi
 
       - name: Enable auto-merge (squash)
-        if: steps.cpr.outputs.pull-request-url && secrets.DOCS_SYNC_TOKEN
+        if: steps.cpr.outputs.pull-request-url
         env:
           GH_TOKEN: ${{ secrets.DOCS_SYNC_TOKEN }}
         run: |
-          PR_URL="${{ steps.cpr.outputs.pull-request-url }}"
+          if [ -n "$GH_TOKEN" ]; then
+            PR_URL="${{ steps.cpr.outputs.pull-request-url }}"
 
-          # Prefer auto-merge (merges when required checks finish).
-          # If auto-merge isn't enabled for the repo, fall back to attempting an immediate merge.
-          gh pr merge "$PR_URL" --auto --delete-branch --squash \
-            || gh pr merge "$PR_URL" --delete-branch --squash
+            # Prefer auto-merge (merges when required checks finish).
+            # If auto-merge isn't enabled for the repo, fall back to attempting an immediate merge.
+            gh pr merge "$PR_URL" --auto --delete-branch --squash \
+              || gh pr merge "$PR_URL" --delete-branch --squash
+          fi

--- a/.github/workflows/sync-docs-code-blocks.yml
+++ b/.github/workflows/sync-docs-code-blocks.yml
@@ -101,22 +101,26 @@ jobs:
             - [x] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.
 
       - name: Auto-approve PR
-        if: steps.cpr.outputs.pull-request-url && secrets.DOCS_SYNC_TOKEN
+        if: steps.cpr.outputs.pull-request-url
         env:
           GH_TOKEN: ${{ secrets.DOCS_SYNC_TOKEN }}
         run: |
-          gh pr review "${{ steps.cpr.outputs.pull-request-url }}" \
-            --approve \
-            --body "Auto-approving automated docs sync PR."
+          if [ -n "$GH_TOKEN" ]; then
+            gh pr review "${{ steps.cpr.outputs.pull-request-url }}" \
+              --approve \
+              --body "Auto-approving automated docs sync PR."
+          fi
 
       - name: Enable auto-merge (squash)
-        if: steps.cpr.outputs.pull-request-url && secrets.DOCS_SYNC_TOKEN
+        if: steps.cpr.outputs.pull-request-url
         env:
           GH_TOKEN: ${{ secrets.DOCS_SYNC_TOKEN }}
         run: |
-          PR_URL="${{ steps.cpr.outputs.pull-request-url }}"
+          if [ -n "$GH_TOKEN" ]; then
+            PR_URL="${{ steps.cpr.outputs.pull-request-url }}"
 
-          # Prefer auto-merge (merges when required checks finish).
-          # If auto-merge isn't enabled for the repo, fall back to attempting an immediate merge.
-          gh pr merge "$PR_URL" --auto --delete-branch --squash \
-            || gh pr merge "$PR_URL" --delete-branch --squash
+            # Prefer auto-merge (merges when required checks finish).
+            # If auto-merge isn't enabled for the repo, fall back to attempting an immediate merge.
+            gh pr merge "$PR_URL" --auto --delete-branch --squash \
+              || gh pr merge "$PR_URL" --delete-branch --squash
+          fi


### PR DESCRIPTION
## Summary of changes

This PR fixes a syntax error in two GitHub Actions workflow files that was causing them to fail on every push event.

### Problem

The workflows `sync-docs-code-blocks.yml` and `sync-agent-sdk-openapi.yml` were failing with:
```
Invalid workflow file: Unrecognized named-value: 'secrets'. Located at position 39 within expression: steps.cpr.outputs.pull-request-url && secrets.DOCS_SYNC_TOKEN
```

### Root Cause

The `secrets` context cannot be accessed in GitHub Actions `if:` conditions because secrets aren't available during the workflow parsing/evaluation phase. The original code tried to check `secrets.DOCS_SYNC_TOKEN` directly in the `if:` condition:

```yaml
if: steps.cpr.outputs.pull-request-url && secrets.DOCS_SYNC_TOKEN  # ❌ Invalid
```

### Solution

Move the secret availability check from the `if:` condition to runtime within the shell script:

```yaml
if: steps.cpr.outputs.pull-request-url  # ✅ Valid - only checks step output
env:
  GH_TOKEN: ${{ secrets.DOCS_SYNC_TOKEN }}
run: |
  if [ -n "$GH_TOKEN" ]; then  # ✅ Check secret at runtime
    # ... commands using GH_TOKEN
  fi
```

### Files Changed
- `.github/workflows/sync-docs-code-blocks.yml`
- `.github/workflows/sync-agent-sdk-openapi.yml`

### Checklist
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [x] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)