### PR TITLE
docs: prefer .agents/skills over legacy .openhands/skills

### DIFF
--- a/overview/skills.mdx
+++ b/overview/skills.mdx
@@ -69,9 +69,8 @@ All paths are relative to the repository root; `.agents/skills/` is a subdirecto
 
 When multiple skills share the same name, OpenHands keeps the first match in this order:
 
-1. `.agents/skills/` (recommended)
-2. `.openhands/skills/` (legacy)
-3. `.openhands/microagents/` (deprecated)
+1. `.agents/skills/` (recommended; legacy repo path: `.openhands/skills/`)
+2. `.openhands/microagents/` (deprecated)
 
 
 ## Skill Types
@@ -96,9 +95,9 @@ Each skill file may include frontmatter that provides additional information. In
 
 | Platform | Support Level | Configuration Method | Implementation | Documentation |
 |----------|---------------|---------------------|----------------|---------------|
-| **CLI** | ✅ Full Support | `~/.openhands/skills/` (user-level) and `.agents/skills/` (repo-level, `.openhands/skills/` legacy) | File-based markdown | [Skills Overview](/overview/skills) |
+| **CLI** | ✅ Full Support | `~/.openhands/skills/` (user-level) and `.agents/skills/` (repo-level) | File-based markdown | [Skills Overview](/overview/skills) |
 | **SDK** | ✅ Full Support | Programmatic `Skill` objects | Code-based configuration | [SDK Skills Guide](/sdk/guides/skill) |
-| **Local GUI** | ✅ Full Support | `.agents/skills/` + UI (`.openhands/skills/` legacy) | File-based with UI management | [Local Setup](/openhands/usage/run-openhands/local-setup) |
+| **Local GUI** | ✅ Full Support | `.agents/skills/` + UI | File-based with UI management | [Local Setup](/openhands/usage/run-openhands/local-setup) |
 | **OpenHands Cloud** | ✅ Full Support | Cloud UI + repository integration | Managed skill library | [Cloud UI](/openhands/usage/cloud/cloud-ui) |
 
 ## Platform-Specific Differences

--- a/overview/skills/keyword.mdx
+++ b/overview/skills/keyword.mdx
@@ -21,7 +21,7 @@ Enclose the frontmatter in triple dashes (---) and include the following fields:
 
 ## Example
 
-Keyword-triggered skill file example located at `.agents/skills/yummy.md` (or `.openhands/skills/yummy.md` for legacy setups):
+Keyword-triggered skill file example located at `.agents/skills/yummy.md` (legacy: `.openhands/skills/yummy.md`):
 ```
 ---
 triggers:


### PR DESCRIPTION
Updates documentation to treat `.agents/skills/` as the primary **repo-level** skills directory, and to mention `.openhands/skills/` only as a legacy repo path.

Notes:
- User-level skills remain under `~/.openhands/skills/`.
- Complements PR #309 (directory rename in this repo).
