### PR TITLE
chore: use docs sync token for auto-merge

### DIFF
--- a/.github/workflows/sync-agent-sdk-openapi.yml
+++ b/.github/workflows/sync-agent-sdk-openapi.yml
@@ -89,6 +89,8 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           add-paths: openapi/agent-sdk.json
+          token: ${{ secrets.DOCS_SYNC_TOKEN || github.token }}
+          branch-token: ${{ secrets.DOCS_SYNC_TOKEN || github.token }}
           commit-message: "sync(openapi): agent-sdk/${{ steps.commit_info.outputs.branch }} ${{ steps.commit_info.outputs.sha_short }}"
           branch: sync-openapi
           branch-suffix: timestamp

--- a/.github/workflows/sync-docs-code-blocks.yml
+++ b/.github/workflows/sync-docs-code-blocks.yml
@@ -76,6 +76,8 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ secrets.DOCS_SYNC_TOKEN || github.token }}
+          branch-token: ${{ secrets.DOCS_SYNC_TOKEN || github.token }}
           commit-message: |
             docs: sync code blocks and generate API reference
 


### PR DESCRIPTION
## Summary
- Use `DOCS_SYNC_TOKEN` as the token/branch-token for create-pull-request in the sync workflows.
- This makes the resulting PRs eligible to trigger checks and auto-merge immediately.

## Testing
- Not run (workflow change only).

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8ef9aef7f96843d3a2fe8a780a9cf5fb)