### PR TITLE
SDK: document Event.source vs LLM role

### DIFF
--- a/sdk/arch/events.mdx
+++ b/sdk/arch/events.mdx
@@ -160,9 +160,12 @@ Events often carry **two different concepts** that are easy to confuse:
 - **`Event.source`**: where the event *originated* (`user`, `agent`, or `environment`). This is about attribution.
 - **LLM `role`** (e.g. `Message.role` / `MessageEvent.llm_message.role`): how the event should be represented to the LLM (`system`, `user`, `assistant`, `tool`). This is about LLM formatting.
 
-These fields are **intentionally independent**. In particular, the SDK may emit events with:
+These fields are **intentionally independent**.
 
-- `source="environment"` but an LLM `role="user"` (e.g. system/framework-injected feedback intended for the agent to read as a user-visible message).
+Common examples include:
+
+- **Observations**: tool results are typically `source="environment"` and represented to the LLM with `role="tool"`.
+- **Synthetic framework messages**: the SDK may inject feedback or control messages (e.g. from hooks) as `source="environment"` while still using an LLM `role="user"` so the agent reads it as a user-facing instruction.
 
 **Do not infer event origin from LLM role.** If you need to distinguish real user input from synthetic/framework messages, rely on `Event.source` (and any explicit metadata fields on the event), not the LLM role.
 


### PR DESCRIPTION
Documents the contract that `Event.source` is **event origin attribution** (user/agent/environment) while the LLM message `role` is **LLM formatting**.

Adds a short section to `sdk/arch/events.mdx` clarifying that these are intentionally independent (e.g. `source="environment"` with `role="user"` for framework-injected messages such as hook feedback).

Context: follow-up to SDK PR discussion about distinguishing hook-synthesized messages without string-prefix hacks.

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c7b8ac1cab54484586d9dfbd5a0bee74)