### PR TITLE
ci: reuse OpenHands PR review workflow from SDK

### DIFF
--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -22,14 +22,14 @@ permissions:
 jobs:
     pr-review:
         # Run when one of the following conditions is met:
-        #   1. A new non-draft PR is opened by a trusted contributor, OR
-        #   2. A draft PR is converted to ready for review by a trusted contributor, OR
+        #   1. A new non-draft PR is opened by a non-first-time contributor, OR
+        #   2. A draft PR is converted to ready for review by a non-first-time contributor, OR
         #   3. 'review-this' label is added, OR
         #   4. openhands-agent or all-hands-bot is requested as a reviewer
         # Note: FIRST_TIME_CONTRIBUTOR PRs require manual trigger via label/reviewer request
         if: |
-            (github.event.action == 'opened' && github.event.pull_request.draft == false && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR') ||
-            (github.event.action == 'ready_for_review' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR') ||
+            (github.event.action == 'opened' && github.event.pull_request.draft == false && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && github.event.pull_request.author_association != 'NONE') ||
+            (github.event.action == 'ready_for_review' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && github.event.pull_request.author_association != 'NONE') ||
             github.event.label.name == 'review-this' ||
             github.event.requested_reviewer.login == 'openhands-agent' ||
             github.event.requested_reviewer.login == 'all-hands-bot'


### PR DESCRIPTION
Adds the reusable OpenHands PR review workflow to this repo by reusing the composite action from `OpenHands/software-agent-sdk` (`.github/actions/pr-review`).

This matches the setup used in `OpenHands/OpenHands-CLI` and the SDK itself:
- triggers on `pull_request_target` (opened / ready_for_review / labeled / review_requested)
- supports manual trigger via `review-this` label or requesting `openhands-agent` / `all-hands-bot`

**Note:** this requires the repo secrets referenced by the workflow (`LLM_API_KEY`, `ALLHANDS_BOT_GITHUB_PAT`, optionally `LMNR_SKILLS_API_KEY`).

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c7b8ac1cab54484586d9dfbd5a0bee74)