### PR TITLE
Add Info callout to OpenHands LLM Key section

### DIFF
--- a/openhands/usage/settings/api-keys-settings.mdx
+++ b/openhands/usage/settings/api-keys-settings.mdx
@@ -14,9 +14,9 @@ OpenHands Cloud
 
 ## OpenHands LLM Key
 
-<Info>
-To ensure high availability of the OpenHands Cloud SaaS service and minimize abuse, users are required to purchase at least $10 in OpenHands Cloud credits before generating an OpenHands LLM Key.
-</Info>
+<Note>
+You must purchase at least $10 in OpenHands Cloud credits before generating an OpenHands LLM Key. To purchase credits, go to [Settings > Billing](https://app.all-hands.dev/settings/billing) in OpenHands Cloud.
+</Note>
 
 You can use the API key under `OpenHands LLM Key` with [the OpenHands CLI](/openhands/usage/run-openhands/cli-mode),
 [running OpenHands on your own](/openhands/usage/run-openhands/local-setup), or even other AI coding agents. This will


### PR DESCRIPTION
## Summary

Add an Info callout to the OpenHands LLM Key section in the API Keys Settings page explaining that users are required to purchase at least $10 in OpenHands Cloud credits before generating an OpenHands LLM Key.

## Changes

- Added `<Info>` callout to `docs/openhands/usage/settings/api-keys-settings.mdx` under the "OpenHands LLM Key" section

## Reason

To ensure high availability of the OpenHands Cloud SaaS service and minimize abuse, users need to be informed about the $10 minimum credit requirement before they can generate an OpenHands LLM Key.

@jpelletier1 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)