### PR TITLE
ci: use github-actions for PR creation and all-hands-bot for auto-merge

### DIFF
--- a/.github/workflows/sync-agent-sdk-openapi.yml
+++ b/.github/workflows/sync-agent-sdk-openapi.yml
@@ -89,8 +89,9 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           add-paths: openapi/agent-sdk.json
-          token: ${{ secrets.DOCS_SYNC_TOKEN || github.token }}
-          branch-token: ${{ secrets.DOCS_SYNC_TOKEN || github.token }}
+          # Use github.token to create PR as github-actions[bot]
+          token: ${{ github.token }}
+          branch-token: ${{ github.token }}
           commit-message: "sync(openapi): agent-sdk/${{ steps.commit_info.outputs.branch }} ${{ steps.commit_info.outputs.sha_short }}"
           branch: sync-openapi
           branch-suffix: timestamp
@@ -113,30 +114,21 @@ jobs:
 
             **Note**: This is an automated pull request. Please review the changes to ensure they are correct before merging.
 
-      # Auto-approve using GITHUB_TOKEN (github-actions[bot]) when PR was created
-      # by a different identity (DOCS_SYNC_TOKEN). GitHub does not allow self-approval,
-      # so we need different identities for PR creation vs approval.
+      # Auto-approve using ALLHANDS_BOT_TOKEN (all-hands-bot). PR is created by
+      # github-actions[bot], so a different identity (all-hands-bot) can approve it.
       - name: Auto-approve PR
-        if: steps.cpr.outputs.pull-request-url
+        if: steps.cpr.outputs.pull-request-url && secrets.ALLHANDS_BOT_TOKEN != ''
         env:
-          GH_TOKEN: ${{ github.token }}
-          HAS_SYNC_TOKEN: ${{ secrets.DOCS_SYNC_TOKEN != '' }}
+          GH_TOKEN: ${{ secrets.ALLHANDS_BOT_TOKEN }}
         run: |
-          # Only approve if DOCS_SYNC_TOKEN was used to create the PR (different identity).
-          # If DOCS_SYNC_TOKEN is not set, the PR was created by github-actions[bot],
-          # and we cannot self-approve.
-          if [ "$HAS_SYNC_TOKEN" = "true" ]; then
-            gh pr review "${{ steps.cpr.outputs.pull-request-url }}" \
-              --approve \
-              --body "Auto-approving automated OpenAPI sync PR."
-          else
-            echo "Skipping auto-approve: DOCS_SYNC_TOKEN not set, cannot self-approve."
-          fi
+          gh pr review "${{ steps.cpr.outputs.pull-request-url }}" \
+            --approve \
+            --body "Auto-approving automated OpenAPI sync PR."
 
       - name: Enable auto-merge (squash)
-        if: steps.cpr.outputs.pull-request-url
+        if: steps.cpr.outputs.pull-request-url && secrets.ALLHANDS_BOT_TOKEN != ''
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.ALLHANDS_BOT_TOKEN }}
         run: |
           PR_URL="${{ steps.cpr.outputs.pull-request-url }}"
 

--- a/.github/workflows/sync-docs-code-blocks.yml
+++ b/.github/workflows/sync-docs-code-blocks.yml
@@ -76,8 +76,9 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.DOCS_SYNC_TOKEN || github.token }}
-          branch-token: ${{ secrets.DOCS_SYNC_TOKEN || github.token }}
+          # Use github.token to create PR as github-actions[bot]
+          token: ${{ github.token }}
+          branch-token: ${{ github.token }}
           commit-message: |
             docs: sync code blocks and generate API reference
 
@@ -102,30 +103,21 @@ jobs:
             - [x] I have read and reviewed the documentation changes to the best of my ability.
             - [x] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.
 
-      # Auto-approve using GITHUB_TOKEN (github-actions[bot]) when PR was created
-      # by a different identity (DOCS_SYNC_TOKEN). GitHub does not allow self-approval,
-      # so we need different identities for PR creation vs approval.
+      # Auto-approve using ALLHANDS_BOT_TOKEN (all-hands-bot). PR is created by
+      # github-actions[bot], so a different identity (all-hands-bot) can approve it.
       - name: Auto-approve PR
-        if: steps.cpr.outputs.pull-request-url
+        if: steps.cpr.outputs.pull-request-url && secrets.ALLHANDS_BOT_TOKEN != ''
         env:
-          GH_TOKEN: ${{ github.token }}
-          HAS_SYNC_TOKEN: ${{ secrets.DOCS_SYNC_TOKEN != '' }}
+          GH_TOKEN: ${{ secrets.ALLHANDS_BOT_TOKEN }}
         run: |
-          # Only approve if DOCS_SYNC_TOKEN was used to create the PR (different identity).
-          # If DOCS_SYNC_TOKEN is not set, the PR was created by github-actions[bot],
-          # and we cannot self-approve.
-          if [ "$HAS_SYNC_TOKEN" = "true" ]; then
-            gh pr review "${{ steps.cpr.outputs.pull-request-url }}" \
-              --approve \
-              --body "Auto-approving automated docs sync PR."
-          else
-            echo "Skipping auto-approve: DOCS_SYNC_TOKEN not set, cannot self-approve."
-          fi
+          gh pr review "${{ steps.cpr.outputs.pull-request-url }}" \
+            --approve \
+            --body "Auto-approving automated docs sync PR."
 
       - name: Enable auto-merge (squash)
-        if: steps.cpr.outputs.pull-request-url
+        if: steps.cpr.outputs.pull-request-url && secrets.ALLHANDS_BOT_TOKEN != ''
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.ALLHANDS_BOT_TOKEN }}
         run: |
           PR_URL="${{ steps.cpr.outputs.pull-request-url }}"
 


### PR DESCRIPTION
## Summary of changes

Update sync workflows to use different identities for PR creation vs approval/merge:

- **PR creation**: `github.token` (creates PR as `github-actions[bot]`)
- **Auto-approve**: `ALLHANDS_BOT_TOKEN` (approves as `all-hands-bot`)
- **Auto-merge**: `ALLHANDS_BOT_TOKEN` (merges as `all-hands-bot`)

This enables auto-approve since GitHub requires different identities for PR creation vs approval.

## Files Changed

- `.github/workflows/sync-docs-code-blocks.yml`
- `.github/workflows/sync-agent-sdk-openapi.yml`

## Why?

The previous setup used `DOCS_SYNC_TOKEN` which wasn't available on this repo. This change simplifies the workflow by:
1. Always using `github.token` for PR creation (no fallback needed)
2. Using `ALLHANDS_BOT_TOKEN` for approval and merge operations

## Setup Required

Ensure `ALLHANDS_BOT_TOKEN` secret is configured in the repository settings.

## Checklist
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [x] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)