### PR TITLE
docs: update skills repository URLs to OpenHands/extensions

### DIFF
--- a/openhands/usage/use-cases/code-review.mdx
+++ b/openhands/usage/use-cases/code-review.mdx
@@ -25,8 +25,8 @@ The PR review workflow uses the OpenHands Software Agent SDK to analyze your cod
    - `openhands-agent` is requested as a reviewer
 
 2. **Analysis**: The agent receives the complete PR diff and uses two skills:
-   - [**`/codereview`**](https://github.com/OpenHands/skills/tree/main/skills/codereview) or [**`/codereview-roasted`**](https://github.com/OpenHands/skills/tree/main/skills/codereview-roasted): Analyzes code for quality, security, and best practices
-   - [**`/github-pr-review`**](https://github.com/OpenHands/skills/tree/main/skills/github-pr-review): Posts structured inline comments via the GitHub API
+   - [**`/codereview`**](https://github.com/OpenHands/extensions/tree/main/skills/codereview) or [**`/codereview-roasted`**](https://github.com/OpenHands/extensions/tree/main/skills/codereview-roasted): Analyzes code for quality, security, and best practices
+   - [**`/github-pr-review`**](https://github.com/OpenHands/extensions/tree/main/skills/github-pr-review): Posts structured inline comments via the GitHub API
 
 3. **Output**: Review comments are posted directly on the PR with:
    - Priority labels (🔴 Critical, 🟠 Important, 🟡 Suggestion, 🟢 Nit)
@@ -39,8 +39,8 @@ Choose between two review styles:
 
 | Style | Description | Best For |
 |-------|-------------|----------|
-| **Standard** ([`/codereview`](https://github.com/OpenHands/skills/tree/main/skills/codereview)) | Pragmatic, constructive feedback focusing on code quality, security, and best practices | Day-to-day code reviews |
-| **Roasted** ([`/codereview-roasted`](https://github.com/OpenHands/skills/tree/main/skills/codereview-roasted)) | Linus Torvalds-style brutally honest review emphasizing "good taste", data structures, and simplicity | Critical code paths, learning opportunities |
+| **Standard** ([`/codereview`](https://github.com/OpenHands/extensions/tree/main/skills/codereview)) | Pragmatic, constructive feedback focusing on code quality, security, and best practices | Day-to-day code reviews |
+| **Roasted** ([`/codereview-roasted`](https://github.com/OpenHands/extensions/tree/main/skills/codereview-roasted)) | Linus Torvalds-style brutally honest review emphasizing "good taste", data structures, and simplicity | Critical code paths, learning opportunities |
 
 ## Quick Start
 

--- a/overview/skills.mdx
+++ b/overview/skills.mdx
@@ -11,7 +11,7 @@ OpenHands supports an **extended version** of the [AgentSkills standard](https:/
 
 ## Official Skill Registry
 
-The official global skill registry is maintained at [github.com/OpenHands/skills](https://github.com/OpenHands/skills). This repository contains community-shared skills that can be used by all OpenHands agents. You can browse available skills, contribute your own, and learn from examples created by the community.
+The official global skill registry is maintained at [github.com/OpenHands/extensions](https://github.com/OpenHands/extensions). This repository contains community-shared skills that can be used by all OpenHands agents. You can browse available skills, contribute your own, and learn from examples created by the community.
 
 ## How Skills Work
 

--- a/overview/skills/keyword.mdx
+++ b/overview/skills/keyword.mdx
@@ -32,4 +32,4 @@ triggers:
 The user has said the magic word. Respond with "That was delicious!"
 ```
 
-[See examples of keyword-triggered skills in the official OpenHands Skills Registry](https://github.com/OpenHands/skills)
+[See examples of keyword-triggered skills in the official OpenHands Skills Registry](https://github.com/OpenHands/extensions)

--- a/overview/skills/public.mdx
+++ b/overview/skills/public.mdx
@@ -1,17 +1,17 @@
 ---
 title: Global Skills
-description: Global skills are [keyword-triggered skills](/overview/skills/keyword) that apply to all OpenHands users. The official global skill registry is maintained at [github.com/OpenHands/skills](https://github.com/OpenHands/skills).
+description: Global skills are [keyword-triggered skills](/overview/skills/keyword) that apply to all OpenHands users. The official global skill registry is maintained at [github.com/OpenHands/extensions](https://github.com/OpenHands/extensions).
 ---
 
 ## Global Skill Registry
 
-The official global skill registry is hosted at [github.com/OpenHands/skills](https://github.com/OpenHands/skills). This repository contains community-shared skills that can be used by all OpenHands users.
+The official global skill registry is hosted at [github.com/OpenHands/extensions](https://github.com/OpenHands/extensions). This repository contains community-shared skills that can be used by all OpenHands users.
 
 ## Contributing a Global Skill
 
 You can create global skills and share with the community by opening a pull request to the official skill registry.
 
-See the [OpenHands Skill Registry](https://github.com/OpenHands/skills) for specific instructions on how to contribute a global skill.
+See the [OpenHands Skill Registry](https://github.com/OpenHands/extensions) for specific instructions on how to contribute a global skill.
 
 ### Global Skills Best Practices
 
@@ -35,7 +35,7 @@ Before creating a global skill, consider:
 #### 2. Create File
 
 Create a new Markdown file with a descriptive name in the official skill registry:
-[github.com/OpenHands/skills](https://github.com/OpenHands/skills)
+[github.com/OpenHands/extensions](https://github.com/OpenHands/extensions)
 
 #### 3. Testing the Global Skill
 

--- a/overview/skills/repo.mdx
+++ b/overview/skills/repo.mdx
@@ -59,4 +59,4 @@ To set it up, you can run `npm run build`.
 Always make sure the tests are passing before committing changes. You can run the tests by running `npm run test`.
 ```
 
-[See more examples of general skills at OpenHands Skills registry.](https://github.com/OpenHands/skills)
+[See more examples of general skills at OpenHands Skills registry.](https://github.com/OpenHands/extensions)

--- a/sdk/guides/github-workflows/pr-review.mdx
+++ b/sdk/guides/github-workflows/pr-review.mdx
@@ -45,7 +45,7 @@ Instead of forking the `agent_script.py`, you can customize the code review beha
 
 ### How It Works
 
-The PR review agent uses skills from the [OpenHands/skills](https://github.com/OpenHands/skills) repository by default. When you add a `.openhands/skills/code-review.md` file to your repository, it **overrides** the default skill with your custom guidelines.
+The PR review agent uses skills from the [OpenHands/extensions](https://github.com/OpenHands/extensions) repository by default. When you add a `.openhands/skills/code-review.md` file to your repository, it **overrides** the default skill with your custom guidelines.
 
 ### Example: Custom Code Review Skill
 

--- a/sdk/guides/skill.mdx
+++ b/sdk/guides/skill.mdx
@@ -201,7 +201,7 @@ agent_context = AgentContext(
     # user_message_suffix is appended to each user message
     user_message_suffix="The first character of your response should be 'I'",
     # You can also enable automatic load skills from
-    # public registry at https://github.com/OpenHands/skills
+    # public registry at https://github.com/OpenHands/extensions
     load_public_skills=True,
 )
 
@@ -588,7 +588,7 @@ When the user says "encrypt", the skill is triggered and the agent can use the p
 
 ## Loading Public Skills
 
-OpenHands maintains a [public skills repository](https://github.com/OpenHands/skills) with community-contributed skills. You can automatically load these skills without waiting for SDK updates.
+OpenHands maintains a [public skills repository](https://github.com/OpenHands/extensions) with community-contributed skills. You can automatically load these skills without waiting for SDK updates.
 
 ### Automatic Loading via AgentContext
 
@@ -655,7 +655,7 @@ The `load_public_skills()` function uses git-based caching for efficiency:
 This approach is more efficient than fetching individual skill files via HTTP and ensures you always have access to the latest community skills.
 
 <Note>
-Explore available public skills at [github.com/OpenHands/skills](https://github.com/OpenHands/skills). These skills cover various domains like GitHub integration, Python development, debugging, and more.
+Explore available public skills at [github.com/OpenHands/extensions](https://github.com/OpenHands/extensions). These skills cover various domains like GitHub integration, Python development, debugging, and more.
 </Note>
 
 ## Customizing Agent Context


### PR DESCRIPTION
## Summary

Update all documentation references from `OpenHands/skills` to `OpenHands/extensions` to support the repository rename.

## Changes

| File | Change |
|------|--------|
| `overview/skills.mdx` | Main skills overview page |
| `overview/skills/public.mdx` | Global skills documentation (multiple URLs) |
| `overview/skills/keyword.mdx` | Keyword-triggered skills docs |
| `overview/skills/repo.mdx` | Repository skills docs |
| `sdk/guides/skill.mdx` | SDK skills guide |
| `sdk/guides/github-workflows/pr-review.mdx` | PR review workflow docs |
| `openhands/usage/use-cases/code-review.mdx` | Code review use case docs |

## Merge Order

This PR can be merged **at any time** after the skills repository is renamed to `OpenHands/extensions`.

- **Before rename**: Links to `OpenHands/extensions` will be broken
- **After rename**: All links will work correctly; GitHub redirects will also work for old URLs

## Related PRs

This is part of a coordinated refactoring:

| Repository | PR | Status | Merge Order |
|------------|----|---------|----|
| **OpenHands/skills** | [#50](https://github.com/OpenHands/skills/pull/50) | Open | 1️⃣ Merge first |
| **GitHub Settings** | (manual) | Pending | 2️⃣ Rename `skills` → `extensions` |
| **OpenHands/software-agent-sdk** | [#2085](https://github.com/OpenHands/software-agent-sdk/pull/2085) | Open | 3️⃣ Merge after rename |
| **OpenHands/docs** | This PR | Open | 3️⃣ Merge after rename |

## Testing

All links will work correctly once the repository is renamed. GitHub's automatic redirects will handle any edge cases during the transition period.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)