### PR TITLE
docs: Add command palette and model change instructions to CLI reference

### DIFF
--- a/openhands/usage/cli/command-reference.mdx
+++ b/openhands/usage/cli/command-reference.mdx
@@ -23,6 +23,7 @@ openhands [OPTIONS] [COMMAND]
 | `--json` | Enable JSONL output (requires `--headless`) |
 | `--always-approve` | Auto-approve all actions without confirmation |
 | `--llm-approve` | Use LLM-based security analyzer for action approval |
+| `--override-with-envs` | Apply environment variables (`LLM_API_KEY`, `LLM_MODEL`, `LLM_BASE_URL`) to override stored settings |
 | `--exit-without-confirmation` | Exit without showing confirmation dialog |
 
 ## Subcommands
@@ -235,12 +236,59 @@ Commands available inside the CLI (prefix with `/`):
 | `/help` | Show all available commands |
 | `/mcp` | View MCP server status |
 
+## Command Palette
+
+Press `Ctrl+P` (or `Ctrl+\`) to open the command palette for quick access to:
+
+| Option | Description |
+|--------|-------------|
+| **Settings** | Configure LLM model, API keys, and other settings |
+| **MCP** | View Model Context Protocol server status |
+| **New Conversation** | Start a new conversation |
+| **Resume** | Resume a previous conversation |
+
+## Changing Your Model
+
+### Via Settings UI
+
+1. Press `Ctrl+P` to open the command palette
+2. Select **Settings**
+3. Choose your LLM provider and model
+4. Save changes (no restart required)
+
+### Via Configuration File
+
+Edit `~/.openhands/agent_settings.json` and change the `model` field:
+
+```json
+{
+  "llm": {
+    "model": "claude-sonnet-4-5-20250929",
+    "api_key": "...",
+    "base_url": "..."
+  }
+}
+```
+
+### Via Environment Variables
+
+Temporarily override your model without changing saved configuration:
+
+```bash
+export LLM_MODEL="gpt-4o"
+export LLM_API_KEY="your-api-key"
+openhands --override-with-envs
+```
+
+Changes made with `--override-with-envs` are not persisted.
+
 ## Environment Variables
 
 | Variable | Description |
 |----------|-------------|
 | `LLM_API_KEY` | API key for your LLM provider |
-| `LLM_MODEL` | Model to use |
+| `LLM_MODEL` | Model to use (requires `--override-with-envs`) |
+| `LLM_BASE_URL` | Custom LLM base URL (requires `--override-with-envs`) |
 | `OPENHANDS_CLOUD_URL` | Default cloud server URL |
 | `OPENHANDS_VERSION` | Docker image version for `openhands serve` |
 
@@ -256,7 +304,8 @@ Commands available inside the CLI (prefix with `/`):
 
 | File | Purpose |
 |------|---------|
-| `~/.openhands/settings.json` | LLM and general settings |
+| `~/.openhands/agent_settings.json` | LLM configuration and agent settings |
+| `~/.openhands/cli_config.json` | CLI preferences (e.g., critic enabled) |
 | `~/.openhands/mcp.json` | MCP server configurations |
 | `~/.openhands/conversations/` | Conversation history |
 


### PR DESCRIPTION
## Summary

This PR adds missing documentation for the command palette feature and provides comprehensive instructions for changing the LLM model in the OpenHands CLI.

## Changes

### New Sections
- **Command Palette**: Documents the Ctrl+P / Ctrl+\ keyboard shortcuts for quick access to settings, MCP status, and more
- **Changing Your Model**: Comprehensive guide covering three methods:
  1. Via Settings UI (through command palette)
  2. Via configuration file (direct edit of agent_settings.json)
  3. Via environment variables (using --override-with-envs flag)

### Updates
- Added `--override-with-envs` flag to global options table
- Fixed configuration files section with correct filenames:
  - Changed `settings.json` → `agent_settings.json`
  - Added `cli_config.json`
- Added `LLM_BASE_URL` to environment variables table

## Motivation

The command palette feature (Ctrl+P) was already implemented in the CLI but not documented in the command reference. Users asking "how do I change my model?" had no clear documentation path.

## Testing

Verified against the openhands-cli source code:
- `openhands_cli/tui/textual_app.py` - command palette implementation
- `openhands_cli/stores/agent_store.py` - configuration file names and override logic
- `openhands_cli/README.md` - confirmed feature availability

---

**Note**: This PR is in draft status and ready for review.