### PR TITLE
docs: Update Cloud API documentation to use V1 endpoint

### DIFF
--- a/openhands/usage/cloud/cloud-api.mdx
+++ b/openhands/usage/cloud/cloud-api.mdx
@@ -65,9 +65,9 @@ make a POST request to the V1 app-conversations endpoint.
     print(f"Conversation Link: https://app.all-hands.dev/conversations/{conversation_id}")
     print(f"Status: {result['status']}")
     ```
-    </Tab>
-    <Tab title="TypeScript/JavaScript (with fetch)">
-        ```typescript
+  </Tab>
+  <Tab title="TypeScript/JavaScript (with fetch)">
+    ```typescript
     const apiKey = "YOUR_API_KEY";
     const url = "https://app.all-hands.dev/api/v1/app-conversations";
 
@@ -253,9 +253,9 @@ If you're running into issues and need a higher limit for your use case, please 
     print(f"Conversation Link: https://app.all-hands.dev/conversations/{conversation['conversation_id']}")
     print(f"Status: {conversation['status']}")
     ```
-    </Tab>
-    <Tab title="TypeScript/JavaScript (with fetch)">
-        ```typescript
+  </Tab>
+  <Tab title="TypeScript/JavaScript (with fetch)">
+    ```typescript
     const apiKey = "YOUR_API_KEY";
     const url = "https://app.all-hands.dev/api/conversations";
 


### PR DESCRIPTION
## Summary

This PR updates the Cloud API documentation to recommend and document the V1 API endpoint (`/api/v1/app-conversations`) instead of the deprecated V0 endpoint (`/api/conversations`).

## Changes

### New V1 API Documentation
- Updated the primary documentation to use the V1 endpoint
- Documented the new request format with `initial_message.content` array
- Documented the new response format (start task with status progression)
- Added documentation for the streaming endpoint (`/api/v1/app-conversations/stream-start`)

### Migration Guide
- Added a clear migration section explaining the differences between V0 and V1
- Provided a comparison table of field names and formats
- Listed step-by-step migration instructions

### V0 API Deprecation
- Kept the V0 API documentation but marked it as deprecated
- Added warning notices about the April 1, 2026 removal date
- Maintained backward compatibility for users still on V0

## Key Differences

| Feature | V0 API | V1 API |
|---------|--------|--------|
| Endpoint | `POST /api/conversations` | `POST /api/v1/app-conversations` |
| Message format | `initial_user_msg` (string) | `initial_message.content` (array) |
| Repository field | `repository` | `selected_repository` |
| Response | Immediate `conversation_id` | Start task with `status` and `app_conversation_id` |

## Testing

The V1 API was tested using a real API key:
- Successfully created a conversation via `POST /api/v1/app-conversations`
- Verified the response contains proper `id`, `status`, and eventually `app_conversation_id`
- Confirmed the conversation reached `READY` status and `execution_status: finished`

## References

- V1 API source: `openhands/app_server/app_conversation/app_conversation_router.py`
- V0 API source (deprecated): `openhands/server/routes/manage_conversations.py`
- V0 deprecation notice in source: "Deprecated since version 1.0.0, scheduled for removal April 1, 2026"

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)