### PR TITLE
Move CLI into its own top-level tab

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -195,61 +195,10 @@
           {
             "group": "OpenHands Community",
             "pages": [
-                "overview/community",
-                "overview/contributing",
-                "overview/faqs",
-                "openhands/usage/troubleshooting/feedback"
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "CLI",
-        "pages": [
-          {
-            "group": "Getting Started",
-            "pages": [
-              "openhands/usage/cli/installation",
-              "openhands/usage/cli/quick-start"
-            ]
-          },
-          {
-            "group": "Ways to Run",
-            "pages": [
-              "openhands/usage/cli/terminal",
-              "openhands/usage/cli/headless",
-              "openhands/usage/cli/web-interface",
-              "openhands/usage/cli/gui-server",
-              {
-                "group": "IDE Integration (ACP)",
-                "pages": [
-                  "openhands/usage/cli/ide/overview",
-                  "openhands/usage/cli/ide/zed",
-                  "openhands/usage/cli/ide/toad",
-                  "openhands/usage/cli/ide/vscode",
-                  "openhands/usage/cli/ide/jetbrains"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Cloud",
-            "pages": [
-              "openhands/usage/cli/cloud"
-            ]
-          },
-          {
-            "group": "Extensions",
-            "pages": [
-              "openhands/usage/cli/mcp-servers",
-              "openhands/usage/cli/critic"
-            ]
-          },
-          {
-            "group": "Reference",
-            "pages": [
-              "openhands/usage/cli/command-reference",
-              "openhands/usage/cli/resume"
+              "overview/community",
+              "overview/contributing",
+              "overview/faqs",
+              "openhands/usage/troubleshooting/feedback"
             ]
           }
         ]
@@ -393,6 +342,57 @@
               "sdk/api-reference/openhands.sdk.tool",
               "sdk/api-reference/openhands.sdk.utils",
               "sdk/api-reference/openhands.sdk.workspace"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "CLI",
+        "pages": [
+          {
+            "group": "Getting Started",
+            "pages": [
+              "openhands/usage/cli/installation",
+              "openhands/usage/cli/quick-start"
+            ]
+          },
+          {
+            "group": "Ways to Run",
+            "pages": [
+              "openhands/usage/cli/terminal",
+              "openhands/usage/cli/headless",
+              "openhands/usage/cli/web-interface",
+              "openhands/usage/cli/gui-server",
+              {
+                "group": "IDE Integration (ACP)",
+                "pages": [
+                  "openhands/usage/cli/ide/overview",
+                  "openhands/usage/cli/ide/zed",
+                  "openhands/usage/cli/ide/toad",
+                  "openhands/usage/cli/ide/vscode",
+                  "openhands/usage/cli/ide/jetbrains"
+                ]
+              }
+            ]
+          },
+          {
+            "group": "Cloud",
+            "pages": [
+              "openhands/usage/cli/cloud"
+            ]
+          },
+          {
+            "group": "Extensions",
+            "pages": [
+              "openhands/usage/cli/mcp-servers",
+              "openhands/usage/cli/critic"
+            ]
+          },
+          {
+            "group": "Reference",
+            "pages": [
+              "openhands/usage/cli/command-reference",
+              "openhands/usage/cli/resume"
             ]
           }
         ]


### PR DESCRIPTION
Moves the existing CLI navigation group out of the Documentation tab and into a dedicated **CLI** tab (nav-only).