### PR TITLE
docs: Add WSL requirement warnings for Windows users on CLI pages

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -186,6 +186,7 @@
                 "pages": [
                   "openhands/usage/run-openhands/local-setup",
                   "openhands/usage/run-openhands/gui-mode",
+                  "openhands/usage/windows-without-wsl",
                   "openhands/usage/troubleshooting/troubleshooting",
                   {
                     "group": "Sandbox Configuration",

--- a/openhands/usage/cli/ide/overview.mdx
+++ b/openhands/usage/cli/ide/overview.mdx
@@ -7,6 +7,10 @@ description: Use OpenHands directly in your favorite code editor through the Age
 IDE integration via ACP is experimental and may have limitations. Please report any issues on the [OpenHands-CLI repo](https://github.com/OpenHands/OpenHands-CLI/issues).
 </Warning>
 
+<Warning>
+**Windows Users:** IDE integrations require the OpenHands CLI, which only runs on Linux, macOS, or Windows with WSL. Please [install WSL](https://learn.microsoft.com/en-us/windows/wsl/install) and run your IDE from within WSL, or use a WSL-aware terminal configuration.
+</Warning>
+
 ## What is the Agent Client Protocol (ACP)?
 
 The [Agent Client Protocol (ACP)](https://agentclientprotocol.com/protocol/overview) is a standardized communication protocol that enables code editors and IDEs to interact with AI agents. ACP defines how clients (like code editors) and agents (like OpenHands) communicate through a JSON-RPC 2.0 interface.

--- a/openhands/usage/cli/installation.mdx
+++ b/openhands/usage/cli/installation.mdx
@@ -3,6 +3,10 @@ title: Installation
 description: Install the OpenHands CLI on your system
 ---
 
+<Warning>
+**Windows Users:** The OpenHands CLI requires WSL (Windows Subsystem for Linux). Native Windows is not officially supported. Please [install WSL](https://learn.microsoft.com/en-us/windows/wsl/install) first, then run all commands inside your WSL terminal. See [Windows Without WSL](/openhands/usage/windows-without-wsl) for an experimental, community-maintained alternative.
+</Warning>
+
 ## Installation Methods
 
 <Tabs>

--- a/openhands/usage/cli/quick-start.mdx
+++ b/openhands/usage/cli/quick-start.mdx
@@ -3,6 +3,10 @@ title: Quick Start
 description: Get started with OpenHands CLI in minutes
 ---
 
+<Note>
+**Windows Users:** The CLI requires WSL. See [Installation](/openhands/usage/cli/installation) for details.
+</Note>
+
 ## Overview
 
 The OpenHands CLI provides multiple ways to interact with the OpenHands AI agent:


### PR DESCRIPTION
## Summary

This PR addresses a documentation gap where Windows users are not clearly informed that the OpenHands CLI requires WSL (Windows Subsystem for Linux).

### Context

A customer recently attempted to install the CLI on native Windows via `uv tool install openhands --python 3.12` and received a 46KB executable that Windows couldn't run. This highlighted that:

1. The CLI installation docs had no Windows/WSL guidance
2. The IDE integration docs (which depend on the CLI) had no Windows/WSL guidance  
3. The existing `windows-without-wsl.mdx` page was not in the navigation (orphaned)

### Changes

1. **CLI Installation page** (`openhands/usage/cli/installation.mdx`)
   - Added prominent `<Warning>` about WSL requirement
   - Links to Microsoft's WSL installation guide
   - Links to the community-maintained native Windows alternative

2. **IDE Integration Overview** (`openhands/usage/cli/ide/overview.mdx`)
   - Added `<Warning>` explaining that IDE integrations require the CLI, which requires WSL on Windows

3. **CLI Quick Start page** (`openhands/usage/cli/quick-start.mdx`)
   - Added brief `<Note>` pointing Windows users to the installation page

4. **Navigation** (`docs.json`)
   - Added `windows-without-wsl.mdx` to the "Local GUI" section so it's discoverable

### Screenshots

The warnings use Mintlify's `<Warning>` component which renders prominently at the top of each page.

### Testing

- [ ] Verified changes render correctly with `mint dev` (if available locally)
- [x] Confirmed all internal links are valid
- [x] Confirmed the orphaned page is now navigable

@jpelletier1 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)