### PR TITLE
docs: document plugin enable/disable

### DIFF
--- a/sdk/guides/plugins.mdx
+++ b/sdk/guides/plugins.mdx
@@ -430,7 +430,8 @@ install_plugin(source="github:owner/repo", ref="v1.0.0")
 
 # List installed plugins (includes enabled + disabled)
 for info in list_installed_plugins():
-    print(f"{info.name} v{info.version}")
+    status = "enabled" if info.enabled else "disabled"
+    print(f"{info.name} v{info.version} ({status})")
 
 # Disable a plugin (won't be loaded until re-enabled)
 disable_plugin("plugin-name")


### PR DESCRIPTION
## Summary
- document enable/disable behavior for installed plugins
- note `.installed.json` persistence and load filtering

Ref: https://github.com/OpenHands/software-agent-sdk/pull/2336
