### PR TITLE
docs(sdk): add conversation model switching example

### DIFF
--- a/sdk/guides/llm-profile-store.mdx
+++ b/sdk/guides/llm-profile-store.mdx
@@ -234,7 +234,6 @@ store.delete("gpt")
 
 <RunExampleCode path_to_script="examples/01_standalone_sdk/44_model_switching_in_convo.py"/>
 
-
 ## Next Steps
 
 - **[LLM Registry](/sdk/guides/llm-registry)** - Manage multiple LLMs in memory at runtime


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [ ] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

- document `examples/01_standalone_sdk/44_model_switching_in_convo.py` under the existing LLM Profile Store guide
- add an auto-synced expandable code block and run snippet for the mid-conversation `switch_profile()` flow
- keep this PR scoped to the missing example 44 docs; the lifecycle example docs remain tracked separately in OpenHands/docs#386

Related SDK example: OpenHands/software-agent-sdk/blob/main/examples/01_standalone_sdk/44_model_switching_in_convo.py
