### PR TITLE
Document new SDK public exports

### DIFF
--- a/sdk/api-reference/openhands.sdk.llm.mdx
+++ b/sdk/api-reference/openhands.sdk.llm.mdx
@@ -4,6 +4,17 @@ description: API reference for openhands.sdk.llm module
 ---
 
 
+## Import shortcuts
+
+`TokenUsage` is part of the public LLM metrics surface and can be imported from either `openhands.sdk.llm` or the top-level `openhands.sdk` package.
+
+```python
+from openhands.sdk.llm import TokenUsage
+# or
+from openhands.sdk import TokenUsage
+```
+
+
 ### class CredentialStore
 
 Bases: `object`

--- a/sdk/api-reference/openhands.sdk.utils.mdx
+++ b/sdk/api-reference/openhands.sdk.utils.mdx
@@ -6,6 +6,21 @@ description: API reference for openhands.sdk.utils module
 
 Utility functions for the OpenHands SDK.
 
+
+## Import shortcuts
+
+`page_iterator` is publicly exported from `openhands.sdk.utils` and from the top-level `openhands.sdk` package.
+
+```python
+from openhands.sdk.utils import page_iterator
+# or
+from openhands.sdk import page_iterator
+```
+
+### page_iterator()
+
+Iterate over items from paginated search results.
+
 ### deprecated()
 
 Return a decorator that deprecates a callable with explicit metadata.

--- a/sdk/api-reference/openhands.sdk.workspace.mdx
+++ b/sdk/api-reference/openhands.sdk.workspace.mdx
@@ -4,6 +4,17 @@ description: API reference for openhands.sdk.workspace module
 ---
 
 
+## Import shortcuts
+
+`AsyncRemoteWorkspace` is publicly exported from `openhands.sdk.workspace.remote`, `openhands.sdk.workspace`, and the top-level `openhands.sdk` package.
+
+```python
+from openhands.sdk.workspace import AsyncRemoteWorkspace
+# or
+from openhands.sdk import AsyncRemoteWorkspace
+```
+
+
 ### class BaseWorkspace
 
 Bases: `DiscriminatedUnionMixin`, `ABC`


### PR DESCRIPTION
- [ ] I have read and reviewed the documentation changes to the best of my ability.
- [ ] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

Document the new public import paths for:
- `TokenUsage`
- `page_iterator`
- `AsyncRemoteWorkspace`

This accompanies SDK PR https://github.com/OpenHands/software-agent-sdk/pull/2445 on branch `promote-sdk-public-exports-2444`.
Related issue: OpenHands/software-agent-sdk#2444
