### PR TITLE
docs: add get_llm() and get_secrets() to OpenHands Cloud Workspace guide

### DIFF
--- a/sdk/guides/agent-server/cloud-workspace.mdx
+++ b/sdk/guides/agent-server/cloud-workspace.mdx
@@ -98,7 +98,7 @@ You can override any parameter:
 llm = workspace.get_llm(model="gpt-4o", temperature=0.5)
 ```
 
-Under the hood, `get_llm()` calls `GET /api/v1/users/me?expose_secrets=true` with dual authentication (Bearer token + session key) to securely retrieve your LLM credentials. The session key is unique per sandbox, ensuring credentials are scoped to that specific execution environment.
+Under the hood, `get_llm()` calls `GET /api/v1/users/me?expose_secrets=true` with dual authentication: the Bearer token (from your Cloud API key) in the `Authorization` header and the session key (unique per sandbox) in the `X-Session-API-Key` header.
 
 #### `get_secrets()`
 
@@ -314,10 +314,7 @@ with OpenHandsCloudWorkspace(
     # (dual auth: Bearer + session key) and returns a
     # fully configured LLM instance.
     # Override any parameter: workspace.get_llm(model="gpt-4o")
-    llm_kwargs = {}
-    if os.getenv("LLM_MODEL"):
-        llm_kwargs["model"] = os.getenv("LLM_MODEL")
-    llm = workspace.get_llm(**llm_kwargs)
+    llm = workspace.get_llm()
     logger.info(f"LLM configured: model={llm.model}")
 
     # --- Secrets from SaaS account ---
@@ -358,11 +355,8 @@ with OpenHandsCloudWorkspace(
             "Then write a short summary into SECRETS_CHECK.txt."
         )
     else:
-        prompt = (
-            "List the environment variables that start with "
-            "SECRET_ or end with _TOKEN, then write a short "
-            "summary of what you find into SECRETS_CHECK.txt."
-        )
+        # No secret was configured on OpenHands Cloud
+        prompt = "Tell me, is there any secret configured for you?"
 
     try:
         conversation.send_message(prompt)


### PR DESCRIPTION
## Summary

Updates the OpenHands Cloud Workspace documentation to cover the new `get_llm()` and `get_secrets()` methods for SaaS credential inheritance.

## Changes

### `sdk/guides/agent-server/cloud-workspace.mdx`

- **New section: "Inheriting SaaS Credentials"** — Documents `get_llm()` and `get_secrets()` methods with usage examples and security notes
  - `get_llm()`: Fetches LLM settings from the user's SaaS account and returns a ready-to-use `LLM` instance
  - `get_secrets()`: Builds `LookupSecret` references where raw values never transit through the SDK client
- **New section: "SaaS Credentials Example"** — Full expandable example (`examples/02_remote_agent_server/10_cloud_workspace_share_credentials.py`) showing the simplified flow where only `OPENHANDS_CLOUD_API_KEY` is needed
- Updated page description metadata

**Note:** A matching branch `feat/cloud-workspace-get-llm-secrets` has also been pushed to this repo so the SDK CI check (`check-examples`) can find the docs.

## Companion PR

- SDK: OpenHands/software-agent-sdk#2409 (adds the `get_llm()` and `get_secrets()` implementation)