### PR TITLE
docs: add defense-in-depth security analyzer section

### DIFF
--- a/sdk/guides/security.mdx
+++ b/sdk/guides/security.mdx
@@ -515,6 +515,19 @@ For security-sensitive environments, lower the threshold to catch more:
 confirmation_policy = ConfirmRisky(threshold=SecurityRisk.MEDIUM)
 ```
 
+You can also require confirmation when any analyzer cannot assess risk:
+
+```python
+# If any analyzer returns UNKNOWN, require confirmation
+security_analyzer = EnsembleSecurityAnalyzer(
+    analyzers=[
+        PolicyRailSecurityAnalyzer(),
+        PatternSecurityAnalyzer(),
+    ],
+    propagate_unknown=True,
+)
+```
+
 <Warning>
 `conversation.execute_tool()` bypasses the analyzer and confirmation
 policy. These analyzers protect agent actions in the conversation
@@ -557,10 +570,12 @@ appear.
 they are correlated, not independent. The highest concrete risk wins.
 That is simpler and more auditable than probabilistic fusion.
 
-**UNKNOWN means "I don't know," not "safe."** If all analyzers return
-UNKNOWN, the ensemble preserves it. Under the default `ConfirmRisky`
-policy, UNKNOWN triggers confirmation. Promoting UNKNOWN to HIGH
-would make optional analyzers unusable.
+**UNKNOWN means "I don't know," not "safe."** By default, if all
+analyzers return UNKNOWN the ensemble preserves it, and `ConfirmRisky`
+triggers confirmation. If any analyzer returns a concrete level,
+UNKNOWN results are filtered out. For stricter environments, set
+`propagate_unknown=True` so that any single UNKNOWN triggers
+confirmation regardless of other results.
 
 **Confirm, don't block.** The analyzers return a risk level. The
 confirmation policy decides what happens. The analyzer does not


### PR DESCRIPTION
## Summary

Documents the defense-in-depth security analyzer family in `openhands.sdk.security`. Updated to match the SDK promotion in OpenHands/software-agent-sdk#2472.

### What this covers

- Three SDK analyzers: `PatternSecurityAnalyzer`, `PolicyRailSecurityAnalyzer`, `EnsembleSecurityAnalyzer`
- `EnsembleSecurityAnalyzer` lives at `openhands.sdk.security.ensemble` (top-level, composes any analyzers); pattern and rail analyzers live under `openhands.sdk.security.defense_in_depth`
- Quick start with explicit `ConfirmRisky` pairing (analyzer selection does not automatically change confirmation policy)
- Composition with `LLMSecurityAnalyzer` for deeper coverage
- Design rationale: two-corpus scanning, max-severity fusion, UNKNOWN as first-class
- Known limitations table
- Reference to thin example at `examples/01_standalone_sdk/47_defense_in_depth_security.py`

### Structure

Content follows adult learning theory: problem first, then solution, then quick start, then composition, then rationale, then limitations.

All imports use `from openhands.sdk.security import ...` — no internal module paths exposed to users.

Companion to OpenHands/software-agent-sdk#2472.