### PR TITLE
Add example plugin cards to use case pages

### DIFF
--- a/openhands/usage/use-cases/cobol-modernization.mdx
+++ b/openhands/usage/use-cases/cobol-modernization.mdx
@@ -3,6 +3,14 @@ title: COBOL Modernization
 description: Modernizing legacy COBOL systems with OpenHands
 ---
 
+<Card
+  title="View Example Plugin"
+  icon="github"
+  href="https://github.com/OpenHands/extensions/tree/main/plugins/cobol-modernization"
+>
+  Check out the complete COBOL modernization plugin with ready-to-use code and configuration.
+</Card>
+
 Legacy COBOL systems power critical business operations across banking, insurance, government, and retail. OpenHands can help you understand, document, and modernize these systems while preserving their essential business logic.
 
 <Note>

--- a/openhands/usage/use-cases/code-review.mdx
+++ b/openhands/usage/use-cases/code-review.mdx
@@ -3,6 +3,14 @@ title: Automated Code Review
 description: Set up automated PR reviews using OpenHands and the Software Agent SDK
 ---
 
+<Card
+  title="View Example Plugin"
+  icon="github"
+  href="https://github.com/OpenHands/extensions/tree/main/plugins/pr-review"
+>
+  Check out the complete PR review plugin with ready-to-use code and configuration.
+</Card>
+
 Automated code review helps maintain code quality, catch bugs early, and enforce coding standards consistently across your team. OpenHands provides a GitHub Actions workflow powered by the [Software Agent SDK](/sdk/index) that automatically reviews pull requests and posts inline comments directly on your PRs.
 
 ## Overview

--- a/openhands/usage/use-cases/incident-triage.mdx
+++ b/openhands/usage/use-cases/incident-triage.mdx
@@ -3,6 +3,14 @@ title: Incident Triage
 description: Using OpenHands to investigate and resolve production incidents
 ---
 
+<Card
+  title="View Example Workflow"
+  icon="github"
+  href="https://github.com/OpenHands/software-agent-sdk/tree/main/examples/03_github_workflows/04_datadog_debugging"
+>
+  Check out the complete Datadog debugging workflow with ready-to-use code and configuration.
+</Card>
+
 When production incidents occur, speed matters. OpenHands can help you quickly investigate issues, analyze logs and errors, identify root causes, and generate fixes—reducing your mean time to resolution (MTTR).
 
 <Note>

--- a/openhands/usage/use-cases/spark-migrations.mdx
+++ b/openhands/usage/use-cases/spark-migrations.mdx
@@ -3,6 +3,14 @@ title: Spark Migrations
 description: Migrating Apache Spark applications with OpenHands
 ---
 
+<Card
+  title="View Example Plugin"
+  icon="github"
+  href="https://github.com/OpenHands/extensions/tree/main/plugins/migration-scoring"
+>
+  Check out the migration scoring plugin to evaluate and validate your Spark migration quality.
+</Card>
+
 Apache Spark is constantly evolving, and keeping your data pipelines up to date is essential for performance, security, and access to new features. OpenHands can help you analyze, migrate, and validate Spark applications.
 
 ## Overview

--- a/openhands/usage/use-cases/vulnerability-remediation.mdx
+++ b/openhands/usage/use-cases/vulnerability-remediation.mdx
@@ -3,6 +3,14 @@ title: Vulnerability Remediation
 description: Using OpenHands to identify and fix security vulnerabilities in your codebase
 ---
 
+<Card
+  title="View Example Plugin"
+  icon="github"
+  href="https://github.com/OpenHands/extensions/tree/main/plugins/vulnerability-remediation"
+>
+  Check out the complete vulnerability remediation plugin with ready-to-use code and configuration.
+</Card>
+
 Security vulnerabilities are a constant challenge for software teams. Every day, new security issues are discovered—from vulnerabilities in dependencies to code security flaws detected by static analysis tools. The National Vulnerability Database (NVD) reports thousands of new vulnerabilities annually, and organizations struggle to keep up with this constant influx.
 
 ## The Challenge


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [ ] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

This PR adds cards at the top of each use case page that link to relevant example plugins and workflows in the OpenHands repositories.

## Changes

Added a `<Card>` component to 5 use case pages:

| Use Case | Link | Source |
|----------|------|--------|
| **Vulnerability Remediation** | [plugins/vulnerability-remediation](https://github.com/OpenHands/extensions/tree/main/plugins/vulnerability-remediation) | Extensions repo |
| **Automated Code Review** | [plugins/pr-review](https://github.com/OpenHands/extensions/tree/main/plugins/pr-review) | Extensions repo |
| **COBOL Modernization** | [plugins/cobol-modernization](https://github.com/OpenHands/extensions/tree/main/plugins/cobol-modernization) | Extensions repo |
| **Incident Triage** | [examples/03_github_workflows/04_datadog_debugging](https://github.com/OpenHands/software-agent-sdk/tree/main/examples/03_github_workflows/04_datadog_debugging) | Software Agent SDK |
| **Spark Migrations** | [plugins/migration-scoring](https://github.com/OpenHands/extensions/tree/main/plugins/migration-scoring) | Extensions repo |

## Not Changed

- **Dependency Upgrades** - No directly matching example exists in either repository