### PR TITLE
Add documentation for mlflow tracing integration

### DIFF
--- a/sdk/guides/observability.mdx
+++ b/sdk/guides/observability.mdx
@@ -1,6 +1,6 @@
 ---
 title: Observability & Tracing
-description: Enable OpenTelemetry tracing to monitor and debug your agent's execution with tools like Laminar, Honeycomb, or any OTLP-compatible backend.
+description: Enable OpenTelemetry tracing to monitor and debug your agent's execution with tools like Laminar, MLflow, Honeycomb, or any OTLP-compatible backend.
 ---
 
 > A full setup example is available [here](#example:-full-setup)!
@@ -10,6 +10,7 @@ description: Enable OpenTelemetry tracing to monitor and debug your agent's exec
 The OpenHands SDK provides built-in OpenTelemetry (OTEL) tracing support, allowing you to monitor and debug your agent's execution in real-time. You can send traces to any OTLP-compatible observability platform including:
 
 - **[Laminar](https://laminar.sh/)** - AI-focused observability with browser session replay support
+- **[MLflow](https://mlflow.org/)** - Open-source AI platform with tracing, evaluation, and LLM governance
 - **[Honeycomb](https://www.honeycomb.io/)** - High-performance distributed tracing
 - **Any OTLP-compatible backend** - Including Jaeger, Datadog, New Relic, and more
 
@@ -35,20 +36,27 @@ export LMNR_PROJECT_API_KEY="your-laminar-api-key"
 
 That's it! Run your agent code normally and traces will be sent to Laminar automatically.
 
-### Using Honeycomb or Other OTLP Backends
+### Using OpenTelemetry (OTLP) Backends
 
-For Honeycomb, Jaeger, or any other OTLP-compatible backend:
+For OpenTelemetry (OTLP) compatible backends, set the following environment variables:
 
 ```bash icon="terminal" wrap
 # Required: Set the OTLP endpoint
-export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="https://api.honeycomb.io:443/v1/traces"
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="https://your-otlp-backend/v1/traces"
 
-# Required: Set authentication headers (format: comma-separated key=value pairs, URL-encoded)
-export OTEL_EXPORTER_OTLP_TRACES_HEADERS="x-honeycomb-team=your-api-key"
+# Required: Set additional headers required by your backend (format: comma-separated key=value pairs, URL-encoded)
+export OTEL_EXPORTER_OTLP_TRACES_HEADERS="key=value,key2=value2"
 
 # Recommended: Explicitly set the protocol (most OTLP backends require HTTP)
 export OTEL_EXPORTER_OTLP_TRACES_PROTOCOL="http/protobuf"  # use "grpc" only if your backend supports it
 ```
+
+View the platform-specific configuration sections below for which values to use.
+
+- **[MLflow](#mlflow-setup)** - Open-source AI platform with tracing, evaluation, and governance
+- **[Honeycomb](#honeycomb-setup)** - High-performance distributed tracing
+- **[Jaeger](#jaeger-setup)** - Open-source distributed tracing
+- **[Generic OTLP Collector](#generic-otlp-collector)** - For other backends
 
 ### Alternative Configuration Methods
 
@@ -157,6 +165,30 @@ export LMNR_PROJECT_API_KEY="your-laminar-api-key"
 ```
 
 **Browser Session Replay**: When using Laminar with browser-use tools, session replays are automatically captured, allowing you to see exactly what the browser automation did.
+
+### MLflow Setup
+
+[MLflow](https://mlflow.org/) is an open-source AI platform that accepts OpenTelemetry traces out of the box, alongside evaluation and LLM governance capabilities.
+
+1. Start your MLflow tracking server:
+
+```bash icon="terminal" wrap
+uvx mlflow server
+```
+
+<Note>
+For other deployment options (pip, Docker Compose, etc.), see [Set Up MLflow Server](https://mlflow.org/docs/latest/genai/getting-started/connect-environment/).
+</Note>
+
+2. Configure the environment variables:
+
+```bash icon="terminal" wrap
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:5000"
+export OTEL_EXPORTER_OTLP_HEADERS="x-mlflow-experiment-id=123"  # Replace "123" with your MLflow experiment ID
+export OTEL_EXPORTER_OTLP_TRACES_PROTOCOL="http/protobuf"
+```
+
+Navigate to the MLflow UI (e.g., `http://localhost:5000`), select the experiment, and open the **Traces** tab to view the recorded traces.
 
 ### Honeycomb Setup
 


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [x] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

Adding MLflow tracing setup through OTLP ingestion, similarly to other providers.

This integration will be promoted through blogs and the OpenHands meetup event on March 26th, so it would be great if the official doc have the dedicated instruction. Similar guide will be added on MLflow will documentation.
