### PR TITLE
docs(sdk): add MCP server env variable resolution for file-based agents

### DIFF
--- a/sdk/guides/agent-file-based.mdx
+++ b/sdk/guides/agent-file-based.mdx
@@ -344,6 +344,34 @@ Use the fetch tool to retrieve web content and save findings to files.
 
 The `mcp_servers` field uses the same format as the [MCP configuration](/sdk/guides/mcp) — each key is a server name, and the value contains `command` and `args` for launching the server.
 
+#### Environment Variable Resolution
+
+All string values in MCP server configurations support `${VAR}` (and `$VAR`) environment variable references, which are resolved from `os.environ` at load time. This lets you forward secrets and dynamic paths without hard-coding them in Markdown:
+
+```markdown icon="markdown"
+---
+name: api-agent
+description: Agent with MCP server using environment-based secrets.
+mcp_servers:
+  my-server:
+    command: ${PLUGIN_ROOT}/bin/server
+    args:
+      - --config
+      - ${PLUGIN_ROOT}/config.json
+    env:
+      API_KEY: ${MY_API_KEY}
+  remote:
+    type: http
+    url: ${API_BASE}/mcp
+    headers:
+      Authorization: Bearer ${AUTH_TOKEN}
+---
+
+An agent that connects to MCP servers configured via environment variables.
+```
+
+Environment variable resolution applies recursively to all string fields — `command`, `args`, `url`, `headers`, `env`, and any other string values in the server config. If a referenced variable is not set, the placeholder is left unchanged (e.g., `${NONEXISTENT_VAR}` stays as-is).
+
 ### Hooks
 
 File-based agents can define [lifecycle hooks](/sdk/guides/hooks) that run at specific points during execution:


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [x] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

- Document ${VAR} environment variable resolution in MCP server configs for file-based agents, following OpenHands/software-agent-sdk#2492