### PR TITLE
docs(sdk): Remove max_turns from TaskToolSet docs

### DIFF
--- a/sdk/guides/task-tool-set.mdx
+++ b/sdk/guides/task-tool-set.mdx
@@ -136,7 +136,6 @@ When the parent agent calls the task tool, it provides these parameters:
 | `subagent_type` | `str` | No | Which registered agent type to use (default: `"default"`) |
 | `description` | `str` | No | Short label (3-5 words) for display and tracking |
 | `resume` | `str` | No | Task ID from a previous invocation to continue |
-| `max_turns` | `int` | No | Maximum agent iterations before stopping (default: 500) |
 
 ## Task Observation
 


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [x] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**
Remove the `max_turns` parameter from the TaskToolSet tool parameters table, matching the SDK change in OpenHands/software-agent-sdk#2491