### PR TITLE
[fix] maintainers

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -34885,14 +34885,14 @@ Push the boundaries of what's possible:
 
 ## Becoming a Maintainer
 
-For contributors who have made significant and sustained contributions to the project, there is a possibility of joining the maintainer team.
+For contributors who have opened three meaningful PRs, there is a possibility of joining the maintainer team.
 The process for this is as follows:
 
-1. Any contributor who has made sustained and high-quality contributions to the codebase can be nominated by any maintainer. If you feel that you may qualify you can reach out to any of the maintainers that have reviewed your PRs and ask if you can be nominated.
+1. Any contributor with three meaningful PRs can be nominated by any maintainer. If you feel that you may qualify, you can reach out to any of the maintainers who reviewed your PRs and ask if they would nominate you.
 2. Once a maintainer nominates a new maintainer, there will be a discussion period among the maintainers for at least 3 days.
 3. If no concerns are raised the nomination will be accepted by acclamation, and if concerns are raised there will be a discussion and possible vote.
 
-Note that just making many PRs does not immediately imply that you will become a maintainer. We will be looking at sustained high-quality contributions over a period of time, as well as good teamwork and adherence to our [Code of Conduct](https://github.com/OpenHands/OpenHands/blob/main/CODE_OF_CONDUCT.md).
+Meeting that threshold does not automatically make someone a maintainer. We also look for good teamwork and adherence to our [Code of Conduct](https://github.com/OpenHands/OpenHands/blob/main/CODE_OF_CONDUCT.md).
 
 ## License
 

--- a/overview/contributing.mdx
+++ b/overview/contributing.mdx
@@ -139,14 +139,14 @@ Push the boundaries of what's possible:
 
 ## Becoming a Maintainer
 
-For contributors who have made significant and sustained contributions to the project, there is a possibility of joining the maintainer team.
+For contributors who have opened three meaningful PRs, there is a possibility of joining the maintainer team.
 The process for this is as follows:
 
-1. Any contributor who has made sustained and high-quality contributions to the codebase can be nominated by any maintainer. If you feel that you may qualify you can reach out to any of the maintainers that have reviewed your PRs and ask if you can be nominated.
+1. Any contributor with three meaningful PRs can be nominated by any maintainer. If you feel that you may qualify, you can reach out to any of the maintainers who reviewed your PRs and ask if they would nominate you.
 2. Once a maintainer nominates a new maintainer, there will be a discussion period among the maintainers for at least 3 days.
 3. If no concerns are raised the nomination will be accepted by acclamation, and if concerns are raised there will be a discussion and possible vote.
 
-Note that just making many PRs does not immediately imply that you will become a maintainer. We will be looking at sustained high-quality contributions over a period of time, as well as good teamwork and adherence to our [Code of Conduct](https://github.com/OpenHands/OpenHands/blob/main/CODE_OF_CONDUCT.md).
+Meeting that threshold does not automatically make someone a maintainer. We also look for good teamwork and adherence to our [Code of Conduct](https://github.com/OpenHands/OpenHands/blob/main/CODE_OF_CONDUCT.md).
 
 ## License
 


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [ ] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

- sync local `main` with `upstream/main` and branch from the updated base
- update the maintainer eligibility language in `overview/contributing.mdx` to use "three meaningful PRs"
- mirror the same maintainer wording in `llms-full.txt`

Closes #17.
