### PR TITLE
docs: add Docker instructions for loading user skills

### DIFF
--- a/openhands/usage/troubleshooting/troubleshooting.mdx
+++ b/openhands/usage/troubleshooting/troubleshooting.mdx
@@ -115,11 +115,11 @@ machine are not loaded. The skill loader logs show `'user': 0`.
 
 **Resolution**
 
-The Docker container cannot see your host filesystem by default. Mount your local skills directory into the
-container using the `SUBVOLUME_MOUNT` environment variable:
+The agent-server container cannot see your host filesystem by default. Mount your local skills directory into the
+sandbox using the `SANDBOX_VOLUMES` environment variable:
 
 ```bash
--e SUBVOLUME_MOUNT="$HOME/.agents/skills:/home/openhands/.agents/skills"
+-e SANDBOX_VOLUMES="$HOME/.agents/skills:/home/openhands/.agents/skills:ro"
 ```
 
 <Note>

--- a/openhands/usage/troubleshooting/troubleshooting.mdx
+++ b/openhands/usage/troubleshooting/troubleshooting.mdx
@@ -106,6 +106,29 @@ To fix this:
    vscode_port = 41234
    ```
 
+### User Skills Not Loading in Docker
+
+**Description**
+
+When running OpenHands via Docker, custom skills placed in `~/.openhands/skills/` or `~/.agents/skills/` on the host
+machine are not loaded. The skill loader logs show `'user': 0`.
+
+**Resolution**
+
+The Docker container cannot see your host filesystem by default. Mount your local skills directory into the
+container using the `SUBVOLUME_MOUNT` environment variable:
+
+```bash
+-e SUBVOLUME_MOUNT="$HOME/.agents/skills:/home/openhands/.agents/skills"
+```
+
+<Note>
+  Mount into `~/.agents/skills` inside the container, not `~/.openhands/skills`. The latter would overwrite
+  the public skills cache and prevent built-in skills from loading.
+</Note>
+
+See [User Skills When Running OpenHands on Your Own](/overview/skills/org#user-skills-when-running-openhands-on-your-own) for the full Docker command.
+
 ### GitHub Organization Rename Issues
 
 **Description**

--- a/overview/skills/org.mdx
+++ b/overview/skills/org.mdx
@@ -25,11 +25,43 @@ General skill file example for organization `Great-Co` located inside the `.agen
 
 For GitLab organizations, the same skill would be located inside the `openhands-config` repository.
 
-## User Skills When Running Openhands on Your Own
+## User Skills When Running OpenHands on Your Own
 
-<Note>
-  This works with CLI, headless and development modes. It does not work out of the box when running OpenHands using the docker command.
-</Note>
+When running OpenHands on your own, you can place skills in the `~/.agents/skills/` folder on your local
+system and OpenHands will always load them for all your conversations. Repo-level overrides live in `.agents/skills/`.
 
-When running OpenHands on your own, you can place skills in the `~/.agents/skills` folder on your local
-system and OpenHands will always load it for all your conversations. Repo-level overrides live in `.agents/skills`.
+<Tabs>
+  <Tab title="CLI / Headless / Development Mode">
+    User skills from `~/.agents/skills/` are loaded automatically — no extra configuration needed.
+  </Tab>
+  <Tab title="Docker">
+    When running OpenHands via Docker, the container cannot see your host filesystem by default.
+    You need to mount your local skills directory into the container using `SUBVOLUME_MOUNT`:
+
+    ```bash
+    docker run -it --rm --pull=always \
+      -e SUBVOLUME_MOUNT="$HOME/.agents/skills:/home/openhands/.agents/skills" \
+      -e AGENT_SERVER_IMAGE_REPOSITORY=ghcr.io/openhands/agent-server \
+      -e AGENT_SERVER_IMAGE_TAG=1.15.0-python \
+      -v /var/run/docker.sock:/var/run/docker.sock \
+      -v ~/.openhands:/.openhands \
+      -p 3000:3000 \
+      --add-host host.docker.internal:host-gateway \
+      --name openhands-app \
+      docker.openhands.dev/openhands/openhands:1.6
+    ```
+
+    <Warning>
+      Mount into `~/.agents/skills` inside the container (not `~/.openhands/skills`). Mounting
+      into `~/.openhands/skills` would overwrite the public skills cache and prevent built-in
+      skills from loading.
+    </Warning>
+
+    You can store your skills in any host directory (e.g., `~/.openhands/skills/`) and mount them
+    to `~/.agents/skills` in the container:
+
+    ```bash
+    -e SUBVOLUME_MOUNT="$HOME/.openhands/skills:/home/openhands/.agents/skills"
+    ```
+  </Tab>
+</Tabs>

--- a/overview/skills/org.mdx
+++ b/overview/skills/org.mdx
@@ -35,12 +35,12 @@ system and OpenHands will always load them for all your conversations. Repo-leve
     User skills from `~/.agents/skills/` are loaded automatically — no extra configuration needed.
   </Tab>
   <Tab title="Docker">
-    When running OpenHands via Docker, the container cannot see your host filesystem by default.
-    You need to mount your local skills directory into the container using `SUBVOLUME_MOUNT`:
+    When running OpenHands via Docker, the agent-server container cannot see your host filesystem by default.
+    You need to mount your local skills directory into the sandbox using the `SANDBOX_VOLUMES` environment variable:
 
     ```bash
     docker run -it --rm --pull=always \
-      -e SUBVOLUME_MOUNT="$HOME/.agents/skills:/home/openhands/.agents/skills" \
+      -e SANDBOX_VOLUMES="$HOME/.agents/skills:/home/openhands/.agents/skills:ro" \
       -e AGENT_SERVER_IMAGE_REPOSITORY=ghcr.io/openhands/agent-server \
       -e AGENT_SERVER_IMAGE_TAG=1.15.0-python \
       -v /var/run/docker.sock:/var/run/docker.sock \
@@ -57,11 +57,20 @@ system and OpenHands will always load them for all your conversations. Repo-leve
       skills from loading.
     </Warning>
 
-    You can store your skills in any host directory (e.g., `~/.openhands/skills/`) and mount them
-    to `~/.agents/skills` in the container:
+    You can store your skills in any host directory (e.g., `~/my-skills/`) and mount them
+    to `~/.agents/skills` in the sandbox:
 
     ```bash
-    -e SUBVOLUME_MOUNT="$HOME/.openhands/skills:/home/openhands/.agents/skills"
+    -e SANDBOX_VOLUMES="$HOME/my-skills:/home/openhands/.agents/skills:ro"
     ```
+
+    If you also need to mount a workspace, use a comma-separated list:
+
+    ```bash
+    -e SANDBOX_VOLUMES="$HOME/project:/workspace:rw,$HOME/.agents/skills:/home/openhands/.agents/skills:ro"
+    ```
+
+    See the [SANDBOX_VOLUMES documentation](/openhands/usage/sandboxes/docker#using-sandbox_volumes) for more details
+    on the mount format.
   </Tab>
 </Tabs>


### PR DESCRIPTION
## Problem

Fixes OpenHands/software-agent-sdk#2417

Users running OpenHands via Docker report that custom skills placed in `~/.openhands/skills/` are not loaded. The skill loader logs show `'user': 0` skills.

The root cause is not a code bug — the SDK correctly looks for skills in `~/.agents/skills/` and `~/.openhands/skills/`. The issue is that Docker containers cannot see the host filesystem by default, so the user's local skills directory is invisible to the agent-server inside the container.

The existing documentation noted this limitation ("It does not work out of the box when running OpenHands using the docker command") but did not explain how to work around it.

## Changes

### `overview/skills/org.mdx`
- Replaced the brief note with tabbed instructions (CLI vs Docker)
- Added a complete Docker command example using `SUBVOLUME_MOUNT`
- Added a warning about mounting into `~/.agents/skills` (not `~/.openhands/skills`, which would overwrite public skills cache)
- Documented the pattern of storing skills on the host in any directory and mounting to `~/.agents/skills` in the container

### `openhands/usage/troubleshooting/troubleshooting.mdx`
- Added a "User Skills Not Loading in Docker" troubleshooting entry with description, resolution, and link to the full guide

---
_This PR was created by an AI assistant (OpenHands) on behalf of @xingyaoww._

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/6c50cce8-34bd-499c-85ed-15109c1c943f)