### PR TITLE
docs: add /launch feature documentation to API v1

### DIFF
--- a/openhands/usage/api/v1.mdx
+++ b/openhands/usage/api/v1.mdx
@@ -42,12 +42,13 @@ The V1 API is organized around a few core concepts:
 
 The `/launch` route enables users to specify a plugin location (e.g., GitHub repo) and an initial message to run within OpenHands Cloud.
 
-- **URL format (production)**: <code>/launch?plugins=BASE64_ENCODED_JSON&message=Optional%20message</code>
-- **URL format (simple)**: <code>/launch?plugin_source=github:owner/repo&plugin_ref=v1.0.0</code>
+- **URL format (production)**: <code>app.all-hands.dev/launch?plugins=BASE64_ENCODED_JSON&message=Optional%20message</code>
+- **URL format (simple)**: <code>app.all-hands.dev/launch?plugin_source=github:owner/repo&plugin_ref=v1.0.0</code>
 - **PluginSpec structure**:
   - `source` (string, required): Plugin source location (e.g., `github:owner/repo`, git URL, or local path)
   - `ref` (string, optional): Branch, tag, or commit reference
   - `repo_path` (string, optional): Subdirectory path within the repository
   - `parameters` (object, optional): User-provided configuration values
-- **Example**: <code>/launch?plugins=W3sic291cmNlIjoiZ2l0aHViOm9wZW5oYW5kcy9leGFtcGxlLXBsdWdpbiIsInJlZiI6InYxLjAuMCJ9XQ==&message=Analyze%20this%20codebase</code>
+  - `message` (string, optional): Initial message to run with the plugin
+- **Example**: <code>app.all-hands.dev/launch?plugins=W3sic291cmNlIjoiZ2l0aHViOm9wZW5oYW5kcy9leGFtcGxlLXBsdWdpbiIsInJlZiI6InYxLjAuMCJ9XQ==&message=Analyze%20this%20codebase</code>
 

--- a/openhands/usage/api/v1.mdx
+++ b/openhands/usage/api/v1.mdx
@@ -35,3 +35,19 @@ The V1 API is organized around a few core concepts:
 - **Sandbox specs**: list the available sandbox “templates” (e.g., Docker image presets).
   - <code>GET /api/v1/sandbox-specs/search</code>
 
+
+## Use Cases
+
+### Start Conversations from Plugins
+
+The `/launch` route enables users to specify a plugin location (e.g., GitHub repo) and an initial message to run within OpenHands Cloud.
+
+- **URL format (production)**: <code>/launch?plugins=BASE64_ENCODED_JSON&message=Optional%20message</code>
+- **URL format (simple)**: <code>/launch?plugin_source=github:owner/repo&plugin_ref=v1.0.0</code>
+- **PluginSpec structure**:
+  - `source` (string, required): Plugin source location (e.g., `github:owner/repo`, git URL, or local path)
+  - `ref` (string, optional): Branch, tag, or commit reference
+  - `repo_path` (string, optional): Subdirectory path within the repository
+  - `parameters` (object, optional): User-provided configuration values
+- **Example**: <code>/launch?plugins=W3sic291cmNlIjoiZ2l0aHViOm9wZW5oYW5kcy9leGFtcGxlLXBsdWdpbiIsInJlZiI6InYxLjAuMCJ9XQ==&message=Analyze%20this%20codebase</code>
+


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [ ] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

Added documentation for the `/launch` feature to the API v1 documentation page under a new **Use Cases** section titled "Start Conversations from Plugins".

The `/launch` feature enables users to specify a plugin location from a remote repository (e.g., GitHub) and an initial message to run within OpenHands Cloud.

**What's included:**
- New "Use Cases" section in `openhands/usage/api/v1.mdx`
- Documentation of URL formats:
  - Production format: Base64-encoded JSON
  - Simple format: Query parameters
- Complete PluginSpec structure with all fields:
  - `source` (required): Plugin source location
  - `ref` (optional): Branch, tag, or commit reference
  - `repo_path` (optional): Subdirectory path within repository
  - `parameters` (optional): User-provided configuration values
- Example usage demonstrating the feature

This documentation supports the `/launch` feature implemented in OpenHands/OpenHands#12699.

@jpelletier1 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7c18581a-360d-402d-a545-d5a8b6283da3)