### PR TITLE
docs(sdk): Update built-in subagents documentation to match current implementation

### DIFF
--- a/sdk/guides/agent-file-based.mdx
+++ b/sdk/guides/agent-file-based.mdx
@@ -124,7 +124,7 @@ By default, all agents include `finish` tool and the `think` tool.
 When `enable_browser=False`, browser-dependent agents like `web-researcher` are not registered.
 
 <Note>
-**Deprecated names:** The following legacy names are deprecated and will be removed in version 2.0.0:
+**Deprecated names:** The following legacy names are deprecated from version 1.16.1:
 - `default` → use `general-purpose`
 - `explore` → use `code-explorer`
 - `bash` → use `bash-runner`

--- a/sdk/guides/agent-file-based.mdx
+++ b/sdk/guides/agent-file-based.mdx
@@ -124,7 +124,7 @@ By default, all agents include `finish` tool and the `think` tool.
 When `enable_browser=False`, browser-dependent agents like `web-researcher` are not registered.
 
 <Note>
-**Deprecated names:** The following legacy names are deprecated from version 1.16.1:
+**Deprecated names:** The following legacy names are deprecated from version 1.12.0:
 - `default` → use `general-purpose`
 - `explore` → use `code-explorer`
 - `bash` → use `bash-runner`

--- a/sdk/guides/agent-file-based.mdx
+++ b/sdk/guides/agent-file-based.mdx
@@ -124,8 +124,9 @@ By default, all agents include `finish` tool and the `think` tool.
 When `enable_browser=False`, browser-dependent agents like `web-researcher` are not registered.
 
 <Note>
-**Deprecated names:** The following legacy names are deprecated from version 1.12.0:
+**Deprecated names:** The following legacy names are deprecated (since v1.12.0) and will be removed in version 2.0.0:
 - `default` → use `general-purpose`
+- `default cli mode` → use `general-purpose`
 - `explore` → use `code-explorer`
 - `bash` → use `bash-runner`
 </Note>

--- a/sdk/guides/agent-file-based.mdx
+++ b/sdk/guides/agent-file-based.mdx
@@ -116,12 +116,19 @@ By default, all agents include `finish` tool and the `think` tool.
 
 | Agent | Tools | Description |
 |--------|-------|-------|
-| **default** | `terminal`, `file_editor`, `task_tracker`, `browser_tool_set` | General-purpose agent. Used as the fallback when no agent name is specified. |
-| **default cli mode** | `terminal`, `file_editor`, `task_tracker` | Same as `default` but without browser tools (used in CLI mode). |
-| **explore** | `terminal` | Read-only codebase exploration agent. Finds files, searches code, reads source — never creates or modifies anything. |
-| **bash** | `terminal` | Command execution specialist. Runs shell commands, builds, tests, and git operations. |
+| **general-purpose** | `terminal`, `file_editor`, `task_tracker` | General-purpose agent for tasks requiring a combination of capabilities. Used as the fallback when no agent name is specified. |
+| **code-explorer** | `terminal` | Read-only codebase exploration agent. Finds files, searches code, reads source — never creates or modifies anything. |
+| **bash-runner** | `terminal` | Command execution specialist. Runs shell commands, builds, tests, linters, and git operations. Returns concise reports instead of raw output. |
+| **web-researcher** | `browser_tool_set` + MCP (`fetch`, `tavily`) | Web research specialist. Searches the web, navigates documentation, and extracts information from URLs. |
 
-In CLI mode, the `default` agent (with browser tools) is replaced by the `default cli mode` agent. In non-CLI mode, `default cli mode` is filtered out.
+When `enable_browser=False`, browser-dependent agents like `web-researcher` are not registered.
+
+<Note>
+**Deprecated names:** The following legacy names are deprecated and will be removed in version 2.0.0:
+- `default` → use `general-purpose`
+- `explore` → use `code-explorer`
+- `bash` → use `bash-runner`
+</Note>
 
 ### Registering Built-in Sub-Agents
 
@@ -130,11 +137,11 @@ Call `register_builtins_agents()` to register all built-in sub-agents. This is t
 ```python icon="python" focus={3-4, 6-7}
 from openhands.tools.preset.default import register_builtins_agents
 
-# Register built-in sub-agents (default, explore, bash)
+# Register all built-in sub-agents (including web-researcher)
 register_builtins_agents()
 
-# Or in CLI mode (swaps default for default cli mode — no browser)
-register_builtins_agents(cli_mode=True)
+# Or without browser-dependent agents (excludes web-researcher)
+register_builtins_agents(enable_browser=False)
 ```
 
 <Warning>


### PR DESCRIPTION
## Summary

This PR updates the built-in subagents documentation in `sdk/guides/agent-file-based.mdx` to match the current SDK implementation.

## Changes

### Agent Names Updated
The documentation was using deprecated agent names. Updated to current names:
| Old Name (Deprecated) | New Name |
|-----------------------|----------|
| `default` | `general-purpose` |
| `explore` | `code-explorer` |
| `bash` | `bash-runner` |

### Added Missing Agent
- Added documentation for `web-researcher` agent which was completely missing from the docs

### Removed Non-Existent Agent
- Removed `default cli mode` which doesn't exist as a separate agent file

### Fixed Tools List
- Corrected tools for `general-purpose`: now shows `terminal`, `file_editor`, `task_tracker` (without `browser_tool_set`)

### Fixed Function Signature
- Updated `register_builtins_agents()` parameter from `cli_mode` to `enable_browser` to match actual implementation

### Added Deprecation Notice
- Added a note about deprecated agent names being removed in version 2.0.0

## Verification
Checked against the actual implementation in `software-agent-sdk`:
- `openhands-tools/openhands/tools/preset/subagents/*.md` - actual subagent definitions
- `openhands-tools/openhands/tools/preset/default.py` - `register_builtins_agents()` function
- `openhands-sdk/openhands/sdk/subagent/registry.py` - deprecated name mappings

---
*This PR was created by an AI assistant (OpenHands) on behalf of the user.*

@VascoSch92 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/de4f1777-b553-4b15-9952-f4a4140b62d4)