### PR TITLE
docs: add preflight validation to enterprise quick start

### DIFF
--- a/enterprise/quick-start.mdx
+++ b/enterprise/quick-start.mdx
@@ -6,7 +6,7 @@ icon: rocket
 
 This guide walks you through trialing OpenHands Enterprise on your own infrastructure.
 You'll provision infrastructure (AWS Terraform or a manual VM setup), configure
-GitHub or GitLab for user authentication, and set up Anthropic as your LLM provider.
+GitHub for user authentication, and set up Anthropic as your LLM provider.
 
 ## Who This Is For
 
@@ -23,7 +23,7 @@ If you want to use OpenHands immediately without infrastructure setup:
 Before you begin, make sure you have the following ready:
 
 - **Anthropic API key** from the [Anthropic Console](https://console.anthropic.com/)
-- **A GitHub account** (or GitLab account) with permission to create integration apps
+- **A GitHub account** with permission to create GitHub Apps
 - **An AWS account** with permissions to create EC2, VPC, and Route53 resources (**if using the AWS with Terraform path**)
 
 ## Provision Infrastructure
@@ -145,7 +145,7 @@ All items below must be completed before running the installer:
 - DNS records are created and resolve from the VM
 - Inbound ports are open: `80`, `443`, and `30000`
 - Outbound domains are reachable from the VM
-- GitHub or GitLab app prerequisites are prepared if you will enable those integrations
+- GitHub App prerequisites are prepared
 
 <Warning>
   Do not run the installer until preflight checks pass.
@@ -173,7 +173,7 @@ for h in \
 done
 ```
 
-Expected: each hostname above resolves to your VM's public IP address (or your load balancer's IP, if used).
+Expected: each hostname above resolves to your VM's public IP address.
 
 Test that a runtime wildcard hostname resolves:
 
@@ -216,7 +216,6 @@ Any HTTP response code other than `000` is acceptable for reachability checks
 If any check fails, stop and resolve before continuing:
 - DNS failures: Verify records are created, point to the right target, and have finished propagating
 - Outbound connectivity failures: Check firewall egress rules, proxy settings, and TLS inspection policies
-- If all checks pass but installation still fails: run `sudo ./openhands support-bundle` and share it with support
 
 ## Reasons for Requirements
 
@@ -230,7 +229,7 @@ If any check fails, stop and resolve before continuing:
 | `images.r9...`, `charts.r9...`, `updates.r9...`, `install.r9...` | Vendor distribution image/chart/update/install endpoints |
 | `traefik.github.io` | Embedded cluster ingress chart repository |
 | `ghcr.io`, `registry-1.docker.io` | Container image pulls for platform components |
-| `github.com` | GitHub App setup/auth/webhooks (if GitHub authentication is enabled) |
+| `github.com` | GitHub App setup/auth/webhooks and downloading public agent skills |
 
 ## Run the Installer
 
@@ -257,6 +256,8 @@ The install guide provides commands to run on your VM. SSH into your VM and exec
 2. **Download the installation assets** -- copy and run the `curl` command shown
 3. **Extract the installation assets** -- run the `tar` command shown (this includes your license file)
 4. **Install** -- run the install command shown
+
+If the install command fails after preflight checks pass, run `sudo ./openhands support-bundle` and share the resulting bundle with support.
 
 <Warning>
   **We recommend providing your TLS certificates during installation.** If you used the

--- a/enterprise/quick-start.mdx
+++ b/enterprise/quick-start.mdx
@@ -4,17 +4,27 @@ description: Get started with a 30-day trial of OpenHands Enterprise.
 icon: rocket
 ---
 
-This guide walks you through trialing OpenHands Enterprise on AWS. You'll provision
-infrastructure with Terraform, configure GitHub for user authentication, and set up
-Anthropic as your LLM provider.
+This guide walks you through trialing OpenHands Enterprise on your own infrastructure.
+You'll provision infrastructure (AWS Terraform or a manual VM setup), configure
+GitHub for user authentication, and set up Anthropic as your LLM provider.
 
-## Prerequisites
+## Who This Is For
+
+This guide is **not** for single-user local laptop installs. It is for a **30-day Trial of OpenHands Enterprise** on a
+**dedicated VM/server** in your own infrastructure. The deployment requires DNS records, network, and compute setup before installation.
+
+If you want to use OpenHands immediately without infrastructure setup:
+
+- Use OpenHands Cloud (SaaS)
+- Run OpenHands open-source locally using Docker, CLI or SDK
+
+### Accounts and Credentials
 
 Before you begin, make sure you have the following ready:
 
 - **Anthropic API key** from the [Anthropic Console](https://console.anthropic.com/)
-- **A GitHub account** with permission to create GitHub Apps
-- **An AWS account** with permissions to create EC2, VPC, and Route53 resources
+- **A GitHub account** (or GitLab account) with permission to create integration apps
+- **An AWS account** with permissions to create EC2, VPC, and Route53 resources (**if using the AWS with Terraform path**)
 
 ## Provision Infrastructure
 
@@ -51,7 +61,7 @@ You will need a VM to host OpenHands Enterprise. Choose one of the options below
 
       | Port | Protocol | Purpose |
       |------|----------|---------|
-      | 80 | TCP | HTTP |
+      | 80 | TCP | HTTP ingress/redirect |
       | 443 | TCP | HTTPS |
       | 30000 | TCP | Admin Console |
 
@@ -68,8 +78,8 @@ You will need a VM to host OpenHands Enterprise. Choose one of the options below
       - `charts.r9.all-hands.dev`
       - `updates.r9.all-hands.dev`
       - `github.com`
-      - `docker.io`
-      - `docker.dev`
+      - `traefik.github.io`
+      - `registry-1.docker.io`
       - `ghcr.io`
     </Accordion>
 
@@ -127,7 +137,97 @@ You will need a VM to host OpenHands Enterprise. Choose one of the options below
   </Tab>
 </Tabs>
 
+## Preflight Validation
+
+All items below must be completed before running the installer:
+
+- VM meets CPU, memory, disk, and OS requirements
+- DNS records are created and resolve from the VM
+- Inbound ports are open: `80`, `443`, and `30000`
+- Outbound domains are reachable from the VM
+- GitHub or GitLab app prerequisites are prepared if you will enable those integrations
+
+<Warning>
+  Do not run the installer until preflight checks pass.
+</Warning>
+
+### DNS checks
+
+Run the checks below on the target VM before opening the installer dashboard.
+
+Export your base domain:
+
+```bash
+export BASE_DOMAIN="openhands.example.com"
+```
+Test DNS:
+```bash
+for h in \
+  "${BASE_DOMAIN}" \
+  "app.${BASE_DOMAIN}" \
+  "auth.app.${BASE_DOMAIN}" \
+  "llm-proxy.${BASE_DOMAIN}" \
+  "runtime-api.${BASE_DOMAIN}"; do
+  echo "[DNS] $h"
+  getent hosts "$h" || nslookup "$h"
+done
+```
+
+Test that a runtime wildcard hostname resolves:
+
+```bash
+getent hosts "test.runtime.${BASE_DOMAIN}" || nslookup "test.runtime.${BASE_DOMAIN}"
+```
+
+### Outbound connectivity checks
+
+```bash
+urls=(
+  "https://replicated.app"
+  "https://proxy.replicated.com/v2/"
+  "https://images.r9.all-hands.dev/v2/"
+  "https://install.r9.all-hands.dev"
+  "https://charts.r9.all-hands.dev"
+  "https://updates.r9.all-hands.dev"
+  "https://github.com"
+  "https://traefik.github.io/charts/index.yaml"
+  "https://registry-1.docker.io/v2/"
+  "https://ghcr.io/v2/"
+)
+
+for u in "${urls[@]}"; do
+  code=$(curl -sSIL --max-time 15 -o /dev/null -w "%{http_code}" "$u" || true)
+  if [ "$code" = "000" ]; then
+    echo "FAIL $u"
+  else
+    echo "OK   $u (HTTP $code)"
+  fi
+done
+```
+
+If any check fails, stop and resolve before continuing. If installation still fails after
+network and DNS fixes, run `sudo ./openhands support-bundle` and share the resulting bundle
+with support.
+
+## Reasons for Requirements
+
+| Requirement | Why It Exists |
+|------------|----------------|
+| `443/TCP` inbound | Primary HTTPS entrypoint for users and service hostnames |
+| `30000/TCP` inbound | Replicated/KOTS Admin Console for install and configuration |
+| `80/TCP` inbound | HTTP entrypoint used for ingress/redirect behavior |
+| `*.runtime.<domain>` DNS + cert SAN | Runtime sandboxes are addressed by dynamic runtime-specific hostnames |
+| `replicated.app`, `proxy.replicated.com` | Replicated control-plane/license/install paths |
+| `images.r9...`, `charts.r9...`, `updates.r9...`, `install.r9...` | Vendor distribution image/chart/update/install endpoints |
+| `traefik.github.io` | Embedded cluster ingress chart repository |
+| `ghcr.io`, `registry-1.docker.io` | Container image pulls for platform components |
+| `github.com` | GitHub App setup/auth/webhooks (when GitHub integration is enabled) |
+
 ## Run the Installer
+
+<Warning>
+  Do not run the installer until preflight checks pass.
+</Warning>
 
 ### 1. Access the Installer Dashboard
 

--- a/enterprise/quick-start.mdx
+++ b/enterprise/quick-start.mdx
@@ -235,7 +235,7 @@ If any check fails, stop and resolve before continuing:
 
 ### 1. Access the Installer Dashboard
 
-Once preflight checks pass, [register for a free 30-day trial](https://install.r9.all-hands.dev/openhands/signup), then
+After preflight validation checks have passed, [register for a free 30-day trial](https://install.r9.all-hands.dev/openhands/signup), then
 log in to the installer dashboard. You will see the dashboard below.
 Click **"View install guide"** in the Install tile.
 

--- a/enterprise/quick-start.mdx
+++ b/enterprise/quick-start.mdx
@@ -10,8 +10,8 @@ GitHub for user authentication, and set up Anthropic as your LLM provider.
 
 ## Who This Is For
 
-This guide is **not** for single-user local laptop installs. It is for a **30-day Trial of OpenHands Enterprise** on a
-**dedicated VM/server** in your own infrastructure. The deployment requires DNS records, network, and compute setup before installation.
+This guide is **not** for single-user local laptop installs. It is for a **30-day trial of OpenHands Enterprise** on a
+**dedicated VM/server** on your own infrastructure. The deployment requires DNS records, network, and compute setup before installation.
 
 If you want to use OpenHands immediately without infrastructure setup:
 
@@ -235,7 +235,7 @@ If any check fails, stop and resolve before continuing:
 
 ### 1. Access the Installer Dashboard
 
-[Register for a free 30-day trial](https://install.r9.all-hands.dev/openhands/signup), then
+Once preflight checks pass, [register for a free 30-day trial](https://install.r9.all-hands.dev/openhands/signup), then
 log in to the installer dashboard. You will see the dashboard below.
 Click **"View install guide"** in the Install tile.
 

--- a/enterprise/quick-start.mdx
+++ b/enterprise/quick-start.mdx
@@ -6,7 +6,7 @@ icon: rocket
 
 This guide walks you through trialing OpenHands Enterprise on your own infrastructure.
 You'll provision infrastructure (AWS Terraform or a manual VM setup), configure
-GitHub for user authentication, and set up Anthropic as your LLM provider.
+GitHub or GitLab for user authentication, and set up Anthropic as your LLM provider.
 
 ## Who This Is For
 
@@ -173,11 +173,15 @@ for h in \
 done
 ```
 
+Expected: each hostname above resolves to your VM's public IP address (or your load balancer's IP, if used).
+
 Test that a runtime wildcard hostname resolves:
 
 ```bash
 getent hosts "test.runtime.${BASE_DOMAIN}" || nslookup "test.runtime.${BASE_DOMAIN}"
 ```
+
+Expected: `test.runtime.${BASE_DOMAIN}` resolves to the same target as `${BASE_DOMAIN}`.
 
 ### Outbound connectivity checks
 
@@ -196,6 +200,7 @@ urls=(
 )
 
 for u in "${urls[@]}"; do
+  # HTTP 000 means connection failure (DNS failure, timeout, or blocked network path).
   code=$(curl -sSIL --max-time 15 -o /dev/null -w "%{http_code}" "$u" || true)
   if [ "$code" = "000" ]; then
     echo "FAIL $u"
@@ -205,9 +210,13 @@ for u in "${urls[@]}"; do
 done
 ```
 
-If any check fails, stop and resolve before continuing. If installation still fails after
-network and DNS fixes, run `sudo ./openhands support-bundle` and share the resulting bundle
-with support.
+Any HTTP response code other than `000` is acceptable for reachability checks
+(for example `200`, `301`, `302`, `401`, `403`, `405`).
+
+If any check fails, stop and resolve before continuing:
+- DNS failures: Verify records are created, point to the right target, and have finished propagating
+- Outbound connectivity failures: Check firewall egress rules, proxy settings, and TLS inspection policies
+- If all checks pass but installation still fails: run `sudo ./openhands support-bundle` and share it with support
 
 ## Reasons for Requirements
 
@@ -221,13 +230,9 @@ with support.
 | `images.r9...`, `charts.r9...`, `updates.r9...`, `install.r9...` | Vendor distribution image/chart/update/install endpoints |
 | `traefik.github.io` | Embedded cluster ingress chart repository |
 | `ghcr.io`, `registry-1.docker.io` | Container image pulls for platform components |
-| `github.com` | GitHub App setup/auth/webhooks (when GitHub integration is enabled) |
+| `github.com` | GitHub App setup/auth/webhooks (if GitHub authentication is enabled) |
 
 ## Run the Installer
-
-<Warning>
-  Do not run the installer until preflight checks pass.
-</Warning>
 
 ### 1. Access the Installer Dashboard
 


### PR DESCRIPTION
- [x ] I have read and reviewed the documentation changes to the best of my ability.
- [ x] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**
  We’ve seen Enterprise trial installs fail because users start the Replicated installer before required DNS/network prerequisites are fully set up. This PR updates the Quick Start to make preflight requirements explicit and front-loaded, and adds IT-facing rationale for required ports/domains so teams can request approvals more effectively.