### PR TITLE
Added Automations to comparison table

### DIFF
--- a/enterprise/enterprise-vs-oss.mdx
+++ b/enterprise/enterprise-vs-oss.mdx
@@ -14,7 +14,7 @@ The table below highlights the key differences between the OpenHands Local GUI a
 |---------|-------------------|----------------------|
 | **Full breadth of agent functionality (sub-agents, MCP, skills, model agnosticism)** | ✅ | ✅ |
 | **Where does the agent run?** | Local dev machines | Scalable, runtime sandboxes |
-| **Scalability** *Multiple concurrent agent conversations* | Limited by machine | Unlimited, on-demand |
+| **Scalability** *Run multiple concurrent agent conversations* | Limited by machine | Unlimited, on-demand |
 | **'@OpenHands' in Slack and Jira** *Important for real-time resolution of bugs and feedback* | ❌ | ✅ |
 | **'@OpenHands' in GitHub, GitLab, Bitbucket** *Important for real-time resolution of PR comments and failing tests* | ❌ | ✅ |
 | **Centralized storage of agent conversations** *Important for auditability* | ❌ | ✅ |
@@ -22,6 +22,7 @@ The table below highlights the key differences between the OpenHands Local GUI a
 | **Share conversations** *Unlock collaboration use cases* | ❌ | ✅ |
 | **Remote monitoring of agent conversations** *Enable Human-in-the-Loop operations for running agents* | ❌ Requires access to machine where agent is running | ✅ Monitor remotely from OpenHands Enterprise UI |
 | **Multi-user management and RBAC** *Roll out to several users and teams* | ❌ | ✅ |
+| **Automations** *Create scheduled and event-based workflows* | ❌ | ✅ |
 | **SAML** | ❌ | ✅ |
 | **REST APIs** | ❌ | ✅ |
 


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [x] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**
Adds the Automation feature to the Enterprise vs OSS comparison.
