### PR TITLE
Document entry_command field for plugins

### DIFF
--- a/sdk/guides/plugins.mdx
+++ b/sdk/guides/plugins.mdx
@@ -65,7 +65,7 @@ The manifest file `plugin-name/.plugin/plugin.json` defines plugin metadata:
 }
 ```
 
-The optional `entry_command` field specifies the initial prompt used to execute the plugin. A common use case is invoking one of the skills included in the plugin. Access it via `plugin.entry_slash_command` which returns the full command (e.g., `/code-quality:check`) or `None` if not specified.
+The optional `entry_command` field specifies the default command name to invoke when launching the plugin. This should match a command name from the `commands/` directory (e.g., `"check"` for `commands/check.md`). Access it via `plugin.entry_slash_command` which returns the full slash command (e.g., `/code-quality:check`) or `None` if not specified.
 
 ### Skills
 

--- a/sdk/guides/plugins.mdx
+++ b/sdk/guides/plugins.mdx
@@ -60,9 +60,12 @@ The manifest file `plugin-name/.plugin/plugin.json` defines plugin metadata:
   "description": "Code quality tools and workflows",
   "author": "openhands",
   "license": "MIT",
-  "repository": "https://github.com/example/code-quality-plugin"
+  "repository": "https://github.com/example/code-quality-plugin",
+  "entry_command": "check"
 }
 ```
+
+The optional `entry_command` field specifies the initial prompt used to execute the plugin. A common use case is invoking one of the skills included in the plugin. Access it via `plugin.entry_slash_command` which returns the full command (e.g., `/code-quality:check`) or `None` if not specified.
 
 ### Skills
 
@@ -165,6 +168,10 @@ Brief explanation on how to use a plugin with an agent.
         if plugin.mcp_config:
             servers = plugin.mcp_config.get("mcpServers", {})
             print(f"MCP servers: {list(servers.keys())}")
+
+        # Entry command
+        if plugin.entry_slash_command:
+            print(f"Entry command: {plugin.entry_slash_command}")
         ```
     </Step>
     <Step>


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [ ] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

This PR adds documentation for the `entry_command` field in plugin manifests, a feature introduced in https://github.com/OpenHands/software-agent-sdk/pull/2230.

### Changes made:
- Added `entry_command` field to the plugin.json example in the Plugin Manifest section
- Documented that `entry_command` specifies the initial prompt used to execute the plugin
- Explained the common use case of invoking plugin skills
- Added example showing how to access it via `plugin.entry_slash_command` 
- Updated the "Accessing Components" code example to include entry command

The documentation is intentionally concise, focusing on the key use case of using a prompt that invokes one of the skills included in the plugin.

@jpelletier1 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8bbf0e61-b5de-41a4-a825-014340977376)