### PR TITLE
Update Enterprise comparison table

### DIFF
--- a/enterprise/enterprise-vs-oss.mdx
+++ b/enterprise/enterprise-vs-oss.mdx
@@ -17,8 +17,7 @@ The table below highlights the key differences between the OpenHands Local GUI a
 | **Scalability** *Run multiple concurrent agent conversations* | Limited by machine | Unlimited, on-demand |
 | **'@OpenHands' in Slack and Jira** *Important for real-time resolution of bugs and feedback* | ❌ | ✅ |
 | **'@OpenHands' in GitHub, GitLab, Bitbucket** *Important for real-time resolution of PR comments and failing tests* | ❌ | ✅ |
-| **Centralized storage of agent conversations** *Important for auditability* | ❌ | ✅ |
-| **Manage multiple agent conversations in one place** *Give users centralized visibility into all agent conversations* | ❌ | ✅ |
+| **Multiple agent conversations in one place** *Give users visibility into all agent conversations* | ✅ | ✅ |
 | **Share conversations** *Unlock collaboration use cases* | ❌ | ✅ |
 | **Remote monitoring of agent conversations** *Enable Human-in-the-Loop operations for running agents* | ❌ Requires access to machine where agent is running | ✅ Monitor remotely from OpenHands Enterprise UI |
 | **Multi-user management and RBAC** *Roll out to several users and teams* | ❌ | ✅ |


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [ ] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

- remove the Enterprise-only row for centralized storage of agent conversations
- rename the multi-conversation row to "Multiple agent conversations in one place"
- mark that capability as available in both Local GUI and OpenHands Enterprise

This is a small docs-only table update, so I did not run the documentation site locally.

_This PR was created by an AI assistant (OpenHands) on behalf of the user._
