### PR TITLE
docs: add enterprise directory PR restriction notice

### DIFF
--- a/overview/contributing.mdx
+++ b/overview/contributing.mdx
@@ -55,7 +55,7 @@ Get familiar with our architecture:
 - **[Evaluation](https://github.com/OpenHands/benchmarks)** - Testing and benchmarks
 
 ### Pull Request Process
-We welcome all pull requests! Here's how we evaluate them:
+We welcome pull requests across our public repositories! Here's how we evaluate them:
 
 <Warning>
 **Enterprise Directory Restriction:** We cannot accept pull requests for changes in the `enterprise/` directory of the OpenHands repository at this time, as this part of the codebase is commercially licensed. If you have feedback or suggestions for [OpenHands Enterprise](/enterprise/index), please [create an issue](https://github.com/OpenHands/OpenHands/issues) in the OpenHands repository instead.
@@ -172,7 +172,7 @@ OpenHands is released under the **MIT License**, which means:
 
 *Full license text: [LICENSE](https://github.com/OpenHands/OpenHands/blob/main/LICENSE)*
 
-**Special Note:** Content in the `enterprise/` directory has a separate license. See `enterprise/LICENSE` for details.
+**Special Note:** Content in the `enterprise/` directory has a separate license, and we cannot accept external pull requests for changes to this directory at this time. See `enterprise/LICENSE` for details.
 
 ## Ready to make your first contribution?
 

--- a/overview/contributing.mdx
+++ b/overview/contributing.mdx
@@ -57,6 +57,10 @@ Get familiar with our architecture:
 ### Pull Request Process
 We welcome all pull requests! Here's how we evaluate them:
 
+<Warning>
+**Enterprise Directory Restriction:** We cannot accept pull requests for changes in the `enterprise/` directory of the OpenHands repository at this time, as this part of the codebase is commercially licensed. If you have feedback or suggestions for [OpenHands Enterprise](/enterprise/index), please [create an issue](https://github.com/OpenHands/OpenHands/issues) in the OpenHands repository instead.
+</Warning>
+
 #### Small Improvements
 - Quick review and approval for obvious improvements
 - Make sure CI tests pass


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [ ] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

Adds a warning notice under the "Pull Request Process" section of the contributing page explaining that:

1. Pull requests for changes in the `enterprise/` directory of the OpenHands/OpenHands repository cannot be accepted at this time, as this part of the codebase is commercially licensed
2. Users are encouraged to provide feedback for OpenHands Enterprise by creating an issue in the OpenHands repository instead

The warning includes links to:
- [OpenHands Enterprise docs](/enterprise/index)
- [Create an issue](https://github.com/OpenHands/OpenHands/issues)

---

*This PR was created by an AI assistant (OpenHands) on behalf of the user.*

@jpelletier1 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3cf95ff2-0153-44ca-8172-34f3444f8d66)