### PR TITLE
Update docs for combined code-review skill

### DIFF
--- a/openhands/usage/use-cases/code-review.mdx
+++ b/openhands/usage/use-cases/code-review.mdx
@@ -32,9 +32,9 @@ The PR review workflow uses the OpenHands Software Agent SDK to analyze your cod
    - The `review-this` label is added to a PR
    - `openhands-agent` is requested as a reviewer
 
-2. **Analysis**: The agent receives the complete PR diff and uses two skills:
-   - [**`/codereview`**](https://github.com/OpenHands/extensions/tree/main/skills/codereview) or [**`/codereview-roasted`**](https://github.com/OpenHands/extensions/tree/main/skills/codereview-roasted): Analyzes code for quality, security, and best practices
-   - [**`/github-pr-review`**](https://github.com/OpenHands/extensions/tree/main/skills/github-pr-review): Posts structured inline comments via the GitHub API
+2. **Analysis**: The agent receives the complete PR diff and uses a code review skill:
+   - [**`/codereview`**](https://github.com/OpenHands/extensions/tree/main/skills/code-review): Analyzes code for quality, security, and best practices, and posts structured inline comments via the GitHub API
+   - [**`/codereview-roasted`**](https://github.com/OpenHands/extensions/tree/main/skills/codereview-roasted): Alternative Linus Torvalds-style brutally honest review
 
 3. **Output**: Review comments are posted directly on the PR with:
    - Priority labels (🔴 Critical, 🟠 Important, 🟡 Suggestion, 🟢 Nit)
@@ -47,7 +47,7 @@ Choose between two review styles:
 
 | Style | Description | Best For |
 |-------|-------------|----------|
-| **Standard** ([`/codereview`](https://github.com/OpenHands/extensions/tree/main/skills/codereview)) | Pragmatic, constructive feedback focusing on code quality, security, and best practices | Day-to-day code reviews |
+| **Standard** ([`/codereview`](https://github.com/OpenHands/extensions/tree/main/skills/code-review)) | Pragmatic, constructive feedback focusing on code quality, security, and best practices. Includes GitHub API posting instructions. | Day-to-day code reviews |
 | **Roasted** ([`/codereview-roasted`](https://github.com/OpenHands/extensions/tree/main/skills/codereview-roasted)) | Linus Torvalds-style brutally honest review emphasizing "good taste", data structures, and simplicity | Critical code paths, learning opportunities |
 
 ## Quick Start
@@ -122,7 +122,7 @@ The workflow uses a reusable composite action from the Software Agent SDK that h
 |-------|-------------|----------|---------|
 | `llm-model` | LLM model to use | Yes | - |
 | `llm-base-url` | LLM base URL (for custom endpoints) | No | `''` |
-| `review-style` | Review style: `standard` or `roasted` | No | `roasted` |
+| `review-style` | **[Deprecated]** Review style: `standard` or `roasted`. Both styles now use the combined `code-review` skill. | No | `roasted` |
 | `extensions-version` | Git ref for extensions (tag, branch, or commit SHA) | No | `main` |
 | `extensions-repo` | Extensions repository (owner/repo) | No | `OpenHands/extensions` |
 | `llm-api-key` | LLM API key | Yes | - |

--- a/sdk/guides/github-workflows/pr-review.mdx
+++ b/sdk/guides/github-workflows/pr-review.mdx
@@ -85,7 +85,7 @@ In addition to general code review practices, check for:
 ```
 
 <Note>
-**Note**: These rules supplement the default `code-review` skill, not replace it.
+**Note**: These rules supplement the default `code-review` skill, not replace it. The `code-review` skill now includes both review guidelines and instructions for posting inline comments via the GitHub API (previously the separate `github-pr-review` skill).
 </Note>
 
 <Tip>
@@ -181,7 +181,7 @@ jobs:
 |-------|-------------|----------|---------|
 | `llm-model` | LLM model to use | Yes | - |
 | `llm-base-url` | LLM base URL (optional) | No | `''` |
-| `review-style` | Review style: 'standard' or 'roasted' | No | `roasted` |
+| `review-style` | **[Deprecated]** Review style: `standard` or `roasted`. Both styles now use the combined `code-review` skill. | No | `roasted` |
 | `extensions-version` | Git ref for extensions (tag, branch, or commit SHA) | No | `main` |
 | `extensions-repo` | Extensions repository (owner/repo) | No | `OpenHands/extensions` |
 | `llm-api-key` | LLM API key | Yes | - |


### PR DESCRIPTION
## Summary

The `code-review` and `github-pr-review` skills have been merged into a single `code-review` skill in the extensions repo. This PR updates documentation references accordingly.

**Companion PR**: https://github.com/OpenHands/extensions/pull/173

## Changes

### `openhands/usage/use-cases/code-review.mdx`
- Updated "Analysis" section to describe the combined skill instead of two separate skills
- Fixed skill links to point to `skills/code-review` (was pointing to `skills/codereview`)
- Updated review styles table with combined skill description
- Marked `review-style` action input as deprecated

### `sdk/guides/github-workflows/pr-review.mdx`
- Added note that `code-review` skill now includes GitHub API posting instructions
- Marked `review-style` action input as deprecated in action inputs table

---
_This PR was created by an AI assistant (OpenHands) on behalf of the user._