### PR TITLE
Update docs for merged code-review skill

### DIFF
--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -43,8 +43,8 @@ jobs:
               with:
                   llm-model: litellm_proxy/claude-sonnet-4-5-20250929
                   llm-base-url: https://llm-proxy.app.all-hands.dev
-                  # Review style: roasted (other option: standard)
-                  review-style: roasted
+                  # [DEPRECATED] review-style is no longer used; standard and roasted are merged
+                  # review-style: roasted
                   llm-api-key: ${{ secrets.LLM_API_KEY }}
                   github-token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
                   lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}

--- a/openhands/usage/essential-guidelines/sdlc-integration.mdx
+++ b/openhands/usage/essential-guidelines/sdlc-integration.mdx
@@ -126,7 +126,7 @@ The Software Agent SDK provides composite GitHub Actions for common workflows:
 - **[Automated PR Review](/openhands/usage/use-cases/code-review)** - Automatically review pull requests with inline comments
 - **[SDK GitHub Workflows Guide](/sdk/guides/github-workflows/pr-review)** - Build custom GitHub workflows with the SDK
 
-For example, to set up automated PR reviews, see the [Automated Code Review](/openhands/usage/use-cases/code-review) guide which uses the real `OpenHands/software-agent-sdk/.github/actions/pr-review` composite action.
+For example, to set up automated PR reviews, see the [Automated Code Review](/openhands/usage/use-cases/code-review) guide which uses the `OpenHands/extensions/plugins/pr-review` composite action.
 
 ### What You Can Automate
 

--- a/openhands/usage/use-cases/code-review.mdx
+++ b/openhands/usage/use-cases/code-review.mdx
@@ -33,7 +33,7 @@ The PR review workflow uses the OpenHands Software Agent SDK to analyze your cod
    - `openhands-agent` is requested as a reviewer
 
 2. **Analysis**: The agent receives the complete PR diff and uses two skills:
-   - [**`/codereview`**](https://github.com/OpenHands/extensions/tree/main/skills/code-review): Analyzes code for quality, security, data structures, and best practices with a focus on simplicity and pragmatism
+   - [**`/code-review`**](https://github.com/OpenHands/extensions/tree/main/skills/code-review): Analyzes code for quality, security, data structures, and best practices with a focus on simplicity and pragmatism
    - [**`/github-pr-review`**](https://github.com/OpenHands/extensions/tree/main/skills/github-pr-review): Posts structured inline comments via the GitHub API
 
 3. **Output**: Review comments are posted directly on the PR with:
@@ -133,7 +133,7 @@ Create custom review guidelines for your repository by adding a skill file at `.
 name: code-review
 description: Custom code review guidelines for this repository
 triggers:
-- /codereview
+- /code-review
 ---
 
 # Repository Code Review Guidelines
@@ -171,7 +171,7 @@ You are reviewing code for [Your Project Name]. Follow these guidelines:
 ```
 
 <Note>
-The skill file must use `/codereview` as the trigger to override the default review behavior. See the [software-agent-sdk's own code-review skill](https://github.com/OpenHands/software-agent-sdk/blob/main/.agents/skills/code-review.md) for a complete example.
+The skill file must use `/code-review` as the trigger to override the default review behavior. See the [software-agent-sdk's own code-review skill](https://github.com/OpenHands/software-agent-sdk/blob/main/.agents/skills/code-review.md) for a complete example.
 </Note>
 
 ### Workflow Configuration

--- a/openhands/usage/use-cases/code-review.mdx
+++ b/openhands/usage/use-cases/code-review.mdx
@@ -33,7 +33,7 @@ The PR review workflow uses the OpenHands Software Agent SDK to analyze your cod
    - `openhands-agent` is requested as a reviewer
 
 2. **Analysis**: The agent receives the complete PR diff and uses two skills:
-   - [**`/code-review`**](https://github.com/OpenHands/extensions/tree/main/skills/code-review): Analyzes code for quality, security, data structures, and best practices with a focus on simplicity and pragmatism
+   - [**`/codereview`**](https://github.com/OpenHands/extensions/tree/main/skills/code-review): Analyzes code for quality, security, data structures, and best practices with a focus on simplicity and pragmatism
    - [**`/github-pr-review`**](https://github.com/OpenHands/extensions/tree/main/skills/github-pr-review): Posts structured inline comments via the GitHub API
 
 3. **Output**: Review comments are posted directly on the PR with:
@@ -133,7 +133,7 @@ Create custom review guidelines for your repository by adding a skill file at `.
 name: code-review
 description: Custom code review guidelines for this repository
 triggers:
-- /code-review
+- /codereview
 ---
 
 # Repository Code Review Guidelines
@@ -171,7 +171,7 @@ You are reviewing code for [Your Project Name]. Follow these guidelines:
 ```
 
 <Note>
-The skill file must use `/code-review` as the trigger to override the default review behavior. See the [software-agent-sdk's own code-review skill](https://github.com/OpenHands/software-agent-sdk/blob/main/.agents/skills/code-review.md) for a complete example.
+The skill file must use `/codereview` as the trigger to override the default review behavior. See the [software-agent-sdk's own code-review skill](https://github.com/OpenHands/software-agent-sdk/blob/main/.agents/skills/code-review.md) for a complete example.
 </Note>
 
 ### Workflow Configuration

--- a/openhands/usage/use-cases/code-review.mdx
+++ b/openhands/usage/use-cases/code-review.mdx
@@ -33,22 +33,13 @@ The PR review workflow uses the OpenHands Software Agent SDK to analyze your cod
    - `openhands-agent` is requested as a reviewer
 
 2. **Analysis**: The agent receives the complete PR diff and uses two skills:
-   - [**`/codereview`**](https://github.com/OpenHands/extensions/tree/main/skills/codereview) or [**`/codereview-roasted`**](https://github.com/OpenHands/extensions/tree/main/skills/codereview-roasted): Analyzes code for quality, security, and best practices
+   - [**`/codereview`**](https://github.com/OpenHands/extensions/tree/main/skills/code-review): Analyzes code for quality, security, data structures, and best practices with a focus on simplicity and pragmatism
    - [**`/github-pr-review`**](https://github.com/OpenHands/extensions/tree/main/skills/github-pr-review): Posts structured inline comments via the GitHub API
 
 3. **Output**: Review comments are posted directly on the PR with:
    - Priority labels (🔴 Critical, 🟠 Important, 🟡 Suggestion, 🟢 Nit)
    - Specific line references
    - Actionable suggestions with code examples
-
-### Review Styles
-
-Choose between two review styles:
-
-| Style | Description | Best For |
-|-------|-------------|----------|
-| **Standard** ([`/codereview`](https://github.com/OpenHands/extensions/tree/main/skills/codereview)) | Pragmatic, constructive feedback focusing on code quality, security, and best practices | Day-to-day code reviews |
-| **Roasted** ([`/codereview-roasted`](https://github.com/OpenHands/extensions/tree/main/skills/codereview-roasted)) | Linus Torvalds-style brutally honest review emphasizing "good taste", data structures, and simplicity | Critical code paths, learning opportunities |
 
 ## Quick Start
 
@@ -78,10 +69,9 @@ Choose between two review styles:
         runs-on: ubuntu-latest
         steps:
           - name: Run PR Review
-            uses: OpenHands/software-agent-sdk/.github/actions/pr-review@main
+            uses: OpenHands/extensions/plugins/pr-review@main
             with:
               llm-model: anthropic/claude-sonnet-4-5-20250929
-              review-style: standard
               llm-api-key: ${{ secrets.LLM_API_KEY }}
               github-token: ${{ secrets.GITHUB_TOKEN }}
     ```
@@ -122,7 +112,7 @@ The workflow uses a reusable composite action from the Software Agent SDK that h
 |-------|-------------|----------|---------|
 | `llm-model` | LLM model to use | Yes | - |
 | `llm-base-url` | LLM base URL (for custom endpoints) | No | `''` |
-| `review-style` | Review style: `standard` or `roasted` | No | `roasted` |
+| `review-style` | **[DEPRECATED]** Previously chose between `standard` and `roasted`. Now ignored — the styles have been merged. | No | `roasted` |
 | `extensions-version` | Git ref for extensions (tag, branch, or commit SHA) | No | `main` |
 | `extensions-repo` | Extensions repository (owner/repo) | No | `OpenHands/extensions` |
 | `llm-api-key` | LLM API key | Yes | - |
@@ -190,14 +180,12 @@ Customize the workflow by modifying the action inputs:
 
 ```yaml
 - name: Run PR Review
-  uses: OpenHands/software-agent-sdk/.github/actions/pr-review@main
+  uses: OpenHands/extensions/plugins/pr-review@main
   with:
     # Change the LLM model
     llm-model: anthropic/claude-sonnet-4-5-20250929
     # Use a custom LLM endpoint
     llm-base-url: https://your-llm-proxy.example.com
-    # Switch to "roasted" style for brutally honest reviews
-    review-style: roasted
     # Pin to a specific extensions version for stability
     extensions-version: main
     # Secrets

--- a/openhands/usage/use-cases/code-review.mdx
+++ b/openhands/usage/use-cases/code-review.mdx
@@ -256,8 +256,8 @@ See real automated reviews in action on the OpenHands Software Agent SDK reposit
 
 ## Related Resources
 
-- [PR Review Workflow Reference](https://github.com/OpenHands/software-agent-sdk/tree/main/examples/03_github_workflows/02_pr_review) - Full workflow example and agent script
-- [Composite Action](https://github.com/OpenHands/software-agent-sdk/blob/main/.github/actions/pr-review/action.yml) - Reusable GitHub Action for PR reviews
+- [PR Review Plugin](https://github.com/OpenHands/extensions/tree/main/plugins/pr-review) - Full workflow example and agent script
+- [Composite Action](https://github.com/OpenHands/extensions/blob/main/plugins/pr-review/action.yml) - Reusable GitHub Action for PR reviews
 - [Software Agent SDK](/sdk/index) - Build your own AI-powered workflows
 - [GitHub Integration](/openhands/usage/cloud/github-installation) - Set up GitHub integration for OpenHands Cloud
 - [Skills Documentation](/overview/skills) - Learn more about OpenHands skills

--- a/sdk/guides/github-workflows/pr-review.mdx
+++ b/sdk/guides/github-workflows/pr-review.mdx
@@ -192,5 +192,5 @@ jobs:
 - [PR Review Plugin](https://github.com/OpenHands/extensions/tree/main/plugins/pr-review) - Complete plugin with scripts and skills (in extensions repo)
 - [Agent Script](https://github.com/OpenHands/extensions/blob/main/plugins/pr-review/scripts/agent_script.py) - Main review agent script
 - [Prompt Template](https://github.com/OpenHands/extensions/blob/main/plugins/pr-review/scripts/prompt.py) - Review prompt template
-- [Workflow File](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/03_github_workflows/02_pr_review/workflow.yml) - Example workflow
-- [Composite Action](https://github.com/OpenHands/software-agent-sdk/blob/main/.github/actions/pr-review/action.yml) - Reusable GitHub Action
+- [Example Workflow](https://github.com/OpenHands/extensions/blob/main/plugins/pr-review/workflows/pr-review-by-openhands.yml) - Example workflow
+- [Composite Action](https://github.com/OpenHands/extensions/blob/main/plugins/pr-review/action.yml) - Reusable GitHub Action

--- a/sdk/guides/github-workflows/pr-review.mdx
+++ b/sdk/guides/github-workflows/pr-review.mdx
@@ -60,7 +60,7 @@ Create `.agents/skills/custom-codereview-guide.md` in your repository:
 name: custom-codereview-guide
 description: Project-specific review guidelines for MyProject
 triggers:
-- /codereview
+- /code-review
 ---
 
 # MyProject-Specific Review Guidelines
@@ -89,7 +89,7 @@ In addition to general code review practices, check for:
 </Note>
 
 <Tip>
-**How skill merging works**: Using a unique name like `custom-codereview-guide` allows BOTH your custom skill AND the default `code-review` skill to be triggered by `/codereview`. When triggered, skill content is concatenated into the agent's context (public skills first, then your custom skills). There is no smart merging—if guidelines conflict, the agent sees both and must reconcile them.
+**How skill merging works**: Using a unique name like `custom-codereview-guide` allows BOTH your custom skill AND the default `code-review` skill to be triggered by `/code-review`. When triggered, skill content is concatenated into the agent's context (public skills first, then your custom skills). There is no smart merging—if guidelines conflict, the agent sees both and must reconcile them.
 
 If your skill has `name: code-review` (matching the public skill's name), it will completely **override** the default public skill instead of supplementing it.
 </Tip>

--- a/sdk/guides/github-workflows/pr-review.mdx
+++ b/sdk/guides/github-workflows/pr-review.mdx
@@ -166,8 +166,8 @@ jobs:
                   # - one model will be randomly selected per review
                   llm-model: anthropic/claude-sonnet-4-5-20250929
                   llm-base-url: ''
-                  # Review style: roasted (other option: standard)
-                  review-style: roasted
+                  # [DEPRECATED] review-style is no longer used; standard and roasted are merged
+                  # review-style: roasted
                   # Extensions version to use (version tag or branch name)
                   extensions-version: main
                   # Secrets
@@ -181,7 +181,7 @@ jobs:
 |-------|-------------|----------|---------|
 | `llm-model` | LLM model to use | Yes | - |
 | `llm-base-url` | LLM base URL (optional) | No | `''` |
-| `review-style` | Review style: 'standard' or 'roasted' | No | `roasted` |
+| `review-style` | **[DEPRECATED]** Previously chose between `standard` and `roasted`. Now ignored — the styles have been merged. | No | `roasted` |
 | `extensions-version` | Git ref for extensions (tag, branch, or commit SHA) | No | `main` |
 | `extensions-repo` | Extensions repository (owner/repo) | No | `OpenHands/extensions` |
 | `llm-api-key` | LLM API key | Yes | - |

--- a/sdk/guides/github-workflows/pr-review.mdx
+++ b/sdk/guides/github-workflows/pr-review.mdx
@@ -60,7 +60,7 @@ Create `.agents/skills/custom-codereview-guide.md` in your repository:
 name: custom-codereview-guide
 description: Project-specific review guidelines for MyProject
 triggers:
-- /code-review
+- /codereview
 ---
 
 # MyProject-Specific Review Guidelines
@@ -89,7 +89,7 @@ In addition to general code review practices, check for:
 </Note>
 
 <Tip>
-**How skill merging works**: Using a unique name like `custom-codereview-guide` allows BOTH your custom skill AND the default `code-review` skill to be triggered by `/code-review`. When triggered, skill content is concatenated into the agent's context (public skills first, then your custom skills). There is no smart merging—if guidelines conflict, the agent sees both and must reconcile them.
+**How skill merging works**: Using a unique name like `custom-codereview-guide` allows BOTH your custom skill AND the default `code-review` skill to be triggered by `/codereview`. When triggered, skill content is concatenated into the agent's context (public skills first, then your custom skills). There is no smart merging—if guidelines conflict, the agent sees both and must reconcile them.
 
 If your skill has `name: code-review` (matching the public skill's name), it will completely **override** the default public skill instead of supplementing it.
 </Tip>

--- a/sdk/guides/skill.mdx
+++ b/sdk/guides/skill.mdx
@@ -933,14 +933,14 @@ When enabled, the SDK will:
 **Multiple Skills with Same Trigger**: Skills with different names but the same trigger can coexist and will ALL be activated when the trigger matches. To add project-specific guidelines alongside public skills, use a unique name (e.g., `custom-codereview-guide` instead of `code-review`). Both skills will be triggered together.
 
 ```python icon="python"
-# Both skills will be triggered by "/codereview"
+# Both skills will be triggered by "/code-review"
 agent_context = AgentContext(
     load_public_skills=True,  # Loads public "code-review" skill
     skills=[
         Skill(
             name="custom-codereview-guide",  # Different name = coexists
             content="Project-specific guidelines...",
-            trigger=KeywordTrigger(keywords=["/codereview"]),
+            trigger=KeywordTrigger(keywords=["/code-review"]),
         ),
     ]
 )

--- a/sdk/guides/skill.mdx
+++ b/sdk/guides/skill.mdx
@@ -933,14 +933,14 @@ When enabled, the SDK will:
 **Multiple Skills with Same Trigger**: Skills with different names but the same trigger can coexist and will ALL be activated when the trigger matches. To add project-specific guidelines alongside public skills, use a unique name (e.g., `custom-codereview-guide` instead of `code-review`). Both skills will be triggered together.
 
 ```python icon="python"
-# Both skills will be triggered by "/code-review"
+# Both skills will be triggered by "/codereview"
 agent_context = AgentContext(
     load_public_skills=True,  # Loads public "code-review" skill
     skills=[
         Skill(
             name="custom-codereview-guide",  # Different name = coexists
             content="Project-specific guidelines...",
-            trigger=KeywordTrigger(keywords=["/code-review"]),
+            trigger=KeywordTrigger(keywords=["/codereview"]),
         ),
     ]
 )


### PR DESCRIPTION
## Summary

Companion to [OpenHands/extensions#175](https://github.com/OpenHands/extensions/pull/175) which merges the `code-review` and `codereview-roasted` skills into a single unified skill.

## Changes

- **`openhands/usage/use-cases/code-review.mdx`**: Removed 'Review Styles' section, updated skill link to point to `code-review`, marked `review-style` input as deprecated in inputs table and examples, updated workflow YAML examples to use `OpenHands/extensions/plugins/pr-review@main`
- **`sdk/guides/github-workflows/pr-review.mdx`**: Deprecated `review-style` in workflow example and inputs table
- **`.github/workflows/pr-review-by-openhands.yml`**: Commented out `review-style` usage

---
_This PR was created by an AI assistant (OpenHands) on behalf of the user._