### PR TITLE
docs: reduce prominence of enterprise notes

### DIFF
--- a/overview/contributing.mdx
+++ b/overview/contributing.mdx
@@ -57,9 +57,7 @@ Get familiar with our architecture:
 ### Pull Request Process
 We welcome pull requests across our public repositories! Here's how we evaluate them:
 
-<Warning>
-**Enterprise Directory Restriction:** We cannot accept pull requests for changes in the `enterprise/` directory of the OpenHands repository at this time, as this part of the codebase is commercially licensed. If you have feedback or suggestions for [OpenHands Enterprise](/enterprise/index), please [create an issue](https://github.com/OpenHands/OpenHands/issues) in the OpenHands repository instead.
-</Warning>
+Note: we can't accept pull requests for changes in the `enterprise/` directory of the OpenHands repository right now, since that part of the codebase is commercially licensed. If you have feedback or suggestions for [OpenHands Enterprise](/enterprise/index), please [create an issue](https://github.com/OpenHands/OpenHands/issues) in the OpenHands repository instead.
 
 #### Small Improvements
 - Quick review and approval for obvious improvements
@@ -172,7 +170,7 @@ OpenHands is released under the **MIT License**, which means:
 
 *Full license text: [LICENSE](https://github.com/OpenHands/OpenHands/blob/main/LICENSE)*
 
-**Special Note:** Content in the `enterprise/` directory has a separate license, and we cannot accept external pull requests for changes to this directory at this time. See `enterprise/LICENSE` for details.
+Content in the `enterprise/` directory has a separate license, so we can't accept external pull requests for changes there right now. See `enterprise/LICENSE` for details.
 
 ## Ready to make your first contribution?
 

--- a/overview/contributing.mdx
+++ b/overview/contributing.mdx
@@ -170,7 +170,7 @@ OpenHands is released under the **MIT License**, which means:
 
 *Full license text: [LICENSE](https://github.com/OpenHands/OpenHands/blob/main/LICENSE)*
 
-Content in the `enterprise/` directory has a separate license, so we can't accept external pull requests for changes there right now. See `enterprise/LICENSE` for details.
+Content in the `enterprise/` directory has a separate license. See `enterprise/LICENSE` for details.
 
 ## Ready to make your first contribution?
 

--- a/overview/contributing.mdx
+++ b/overview/contributing.mdx
@@ -57,7 +57,7 @@ Get familiar with our architecture:
 ### Pull Request Process
 We welcome pull requests across our public repositories! Here's how we evaluate them:
 
-Note: we can't accept pull requests for changes in the `enterprise/` directory of the OpenHands repository right now, since that part of the codebase is commercially licensed. If you have feedback or suggestions for [OpenHands Enterprise](/enterprise/index), please [create an issue](https://github.com/OpenHands/OpenHands/issues) in the OpenHands repository instead.
+Note: we can't accept pull requests for changes in the `enterprise/` directory of the OpenHands repository right now, since that part of the codebase has a separate license. If you have feedback or suggestions for [OpenHands Enterprise](/enterprise/index), please [create an issue](https://github.com/OpenHands/OpenHands/issues) in the OpenHands repository instead.
 
 #### Small Improvements
 - Quick review and approval for obvious improvements

--- a/overview/contributing.mdx
+++ b/overview/contributing.mdx
@@ -100,7 +100,7 @@ Make OpenHands more beautiful and user-friendly:
 - **Mobile Responsiveness** - Make OpenHands work great on all devices
 - **Component Libraries** - Build reusable UI components
 
-*Small fixes are always welcome! For bigger changes, join our **#eng-ui-ux** channel in [Slack](https://openhands.dev/joinslack) first.*
+*Small fixes are always welcome! For bigger changes, join our **#proj-gui** channel in [Slack](https://openhands.dev/joinslack) first.*
 
 ### Agent Development
 Help make our AI agents smarter and more capable:

--- a/overview/contributing.mdx
+++ b/overview/contributing.mdx
@@ -57,8 +57,6 @@ Get familiar with our architecture:
 ### Pull Request Process
 We welcome pull requests across our public repositories! Here's how we evaluate them:
 
-Note: we can't accept pull requests for changes in the `enterprise/` directory of the OpenHands repository right now, since that part of the codebase has a separate license. If you have feedback or suggestions for [OpenHands Enterprise](/enterprise/index), please [create an issue](https://github.com/OpenHands/OpenHands/issues) in the OpenHands repository instead.
-
 #### Small Improvements
 - Quick review and approval for obvious improvements
 - Make sure CI tests pass
@@ -71,6 +69,8 @@ We're more careful with agent changes since they affect user experience:
 - **Code Quality** - Is the code maintainable and well-tested?
 
 *Discuss major changes in [GitHub issues](https://github.com/OpenHands/OpenHands/issues) or [Slack](https://openhands.dev/joinslack) first!*
+
+Note: we can't accept pull requests for changes in the `enterprise/` directory of the OpenHands repository right now, since that part of the codebase has a separate license. If you have feedback or suggestions for [OpenHands Enterprise](/enterprise/index), please [create an issue](https://github.com/OpenHands/OpenHands/issues) in the OpenHands repository instead.
 
 ### Pull Request Guidelines
 We recommend the following for smooth reviews but they're not required. Just know that the more you follow these guidelines, the more likely you'll get your PR reviewed faster and reduce the quantity of revisions.


### PR DESCRIPTION
## Summary
- replace the prominent enterprise restriction warning on the contributing page with regular inline copy
- soften the duplicate enterprise note in the License section

## Why
The current message is important, but the warning callout makes it more visually prominent than needed on the contributing page. This keeps the guidance while reducing emphasis.

## Notes
- no tests run; docs-only change

_This PR was created by an AI assistant (OpenHands) on behalf of the user._