### PR TITLE
chore: rename ALLHANDS_BOT_TOKEN to PAT_TOKEN

### DIFF
--- a/.github/workflows/sync-agent-sdk-openapi.yml
+++ b/.github/workflows/sync-agent-sdk-openapi.yml
@@ -114,21 +114,21 @@ jobs:
 
             **Note**: This is an automated pull request. Please review the changes to ensure they are correct before merging.
 
-      # Auto-approve using ALLHANDS_BOT_TOKEN (all-hands-bot). PR is created by
+      # Auto-approve using ALLHANDS_BOT_GITHUB_PAT (all-hands-bot). PR is created by
       # github-actions[bot], so a different identity (all-hands-bot) can approve it.
       - name: Auto-approve PR
-        if: steps.cpr.outputs.pull-request-url && secrets.ALLHANDS_BOT_TOKEN != ''
+        if: steps.cpr.outputs.pull-request-url && secrets.ALLHANDS_BOT_GITHUB_PAT != ''
         env:
-          GH_TOKEN: ${{ secrets.ALLHANDS_BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
         run: |
           gh pr review "${{ steps.cpr.outputs.pull-request-url }}" \
             --approve \
             --body "Auto-approving automated OpenAPI sync PR."
 
       - name: Enable auto-merge (squash)
-        if: steps.cpr.outputs.pull-request-url && secrets.ALLHANDS_BOT_TOKEN != ''
+        if: steps.cpr.outputs.pull-request-url && secrets.ALLHANDS_BOT_GITHUB_PAT != ''
         env:
-          GH_TOKEN: ${{ secrets.ALLHANDS_BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
         run: |
           PR_URL="${{ steps.cpr.outputs.pull-request-url }}"
 

--- a/.github/workflows/sync-agent-sdk-openapi.yml
+++ b/.github/workflows/sync-agent-sdk-openapi.yml
@@ -114,21 +114,21 @@ jobs:
 
             **Note**: This is an automated pull request. Please review the changes to ensure they are correct before merging.
 
-      # Auto-approve using ALLHANDS_BOT_GITHUB_PAT (all-hands-bot). PR is created by
+      # Auto-approve using PAT_TOKEN (all-hands-bot). PR is created by
       # github-actions[bot], so a different identity (all-hands-bot) can approve it.
       - name: Auto-approve PR
-        if: steps.cpr.outputs.pull-request-url && secrets.ALLHANDS_BOT_GITHUB_PAT != ''
+        if: steps.cpr.outputs.pull-request-url && secrets.PAT_TOKEN != ''
         env:
-          GH_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           gh pr review "${{ steps.cpr.outputs.pull-request-url }}" \
             --approve \
             --body "Auto-approving automated OpenAPI sync PR."
 
       - name: Enable auto-merge (squash)
-        if: steps.cpr.outputs.pull-request-url && secrets.ALLHANDS_BOT_GITHUB_PAT != ''
+        if: steps.cpr.outputs.pull-request-url && secrets.PAT_TOKEN != ''
         env:
-          GH_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           PR_URL="${{ steps.cpr.outputs.pull-request-url }}"
 

--- a/.github/workflows/sync-docs-code-blocks.yml
+++ b/.github/workflows/sync-docs-code-blocks.yml
@@ -103,21 +103,21 @@ jobs:
             - [x] I have read and reviewed the documentation changes to the best of my ability.
             - [x] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.
 
-      # Auto-approve using ALLHANDS_BOT_GITHUB_PAT (all-hands-bot). PR is created by
+      # Auto-approve using PAT_TOKEN (all-hands-bot). PR is created by
       # github-actions[bot], so a different identity (all-hands-bot) can approve it.
       - name: Auto-approve PR
-        if: steps.cpr.outputs.pull-request-url && secrets.ALLHANDS_BOT_GITHUB_PAT != ''
+        if: steps.cpr.outputs.pull-request-url && secrets.PAT_TOKEN != ''
         env:
-          GH_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           gh pr review "${{ steps.cpr.outputs.pull-request-url }}" \
             --approve \
             --body "Auto-approving automated docs sync PR."
 
       - name: Enable auto-merge (squash)
-        if: steps.cpr.outputs.pull-request-url && secrets.ALLHANDS_BOT_GITHUB_PAT != ''
+        if: steps.cpr.outputs.pull-request-url && secrets.PAT_TOKEN != ''
         env:
-          GH_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           PR_URL="${{ steps.cpr.outputs.pull-request-url }}"
 

--- a/.github/workflows/sync-docs-code-blocks.yml
+++ b/.github/workflows/sync-docs-code-blocks.yml
@@ -103,21 +103,21 @@ jobs:
             - [x] I have read and reviewed the documentation changes to the best of my ability.
             - [x] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.
 
-      # Auto-approve using ALLHANDS_BOT_TOKEN (all-hands-bot). PR is created by
+      # Auto-approve using ALLHANDS_BOT_GITHUB_PAT (all-hands-bot). PR is created by
       # github-actions[bot], so a different identity (all-hands-bot) can approve it.
       - name: Auto-approve PR
-        if: steps.cpr.outputs.pull-request-url && secrets.ALLHANDS_BOT_TOKEN != ''
+        if: steps.cpr.outputs.pull-request-url && secrets.ALLHANDS_BOT_GITHUB_PAT != ''
         env:
-          GH_TOKEN: ${{ secrets.ALLHANDS_BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
         run: |
           gh pr review "${{ steps.cpr.outputs.pull-request-url }}" \
             --approve \
             --body "Auto-approving automated docs sync PR."
 
       - name: Enable auto-merge (squash)
-        if: steps.cpr.outputs.pull-request-url && secrets.ALLHANDS_BOT_TOKEN != ''
+        if: steps.cpr.outputs.pull-request-url && secrets.ALLHANDS_BOT_GITHUB_PAT != ''
         env:
-          GH_TOKEN: ${{ secrets.ALLHANDS_BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
         run: |
           PR_URL="${{ steps.cpr.outputs.pull-request-url }}"
 


### PR DESCRIPTION
## Summary

- Renames `ALLHANDS_BOT_TOKEN` → `PAT_TOKEN` in `sync-agent-sdk-openapi.yml` and `sync-docs-code-blocks.yml`
- Both workflows use the secret to auto-approve and auto-merge sync PRs in this repo
- Standardises on the org-wide `PAT_TOKEN` secret — no separate `ALLHANDS_BOT_TOKEN` secret needed in this repo
- `PAT_TOKEN` is an organization-wide secret with enough permissions to run those workflows. This has been validated. 
