### PR TITLE
chore: rename ALLHANDS_BOT_GITHUB_PAT to PAT_TOKEN

### DIFF
--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -46,5 +46,5 @@ jobs:
                   # [DEPRECATED] review-style is no longer used; standard and roasted are merged
                   # review-style: roasted
                   llm-api-key: ${{ secrets.LLM_API_KEY }}
-                  github-token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  github-token: ${{ secrets.PAT_TOKEN }}
                   lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}


### PR DESCRIPTION
## Summary

Renames \`ALLHANDS_BOT_GITHUB_PAT\` → \`PAT_TOKEN\` in workflow files to standardise on the org-wide \`PAT_TOKEN\` secret name.

This is a mechanical rename only — no behaviour changes. Part of OpenHands/evaluation#428 (PAT_TOKEN blast radius reduction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)