### PR TITLE
Add analytics to list of required domains for Enterprise QuickStart

### DIFF
--- a/enterprise/quick-start.mdx
+++ b/enterprise/quick-start.mdx
@@ -123,6 +123,7 @@ You will need a VM to host OpenHands Enterprise. Choose one of the options below
     | `app.<your-domain>` | `app.openhands.example.com` |
     | `auth.app.<your-domain>` | `auth.app.openhands.example.com` |
     | `llm-proxy.<your-domain>` | `llm-proxy.openhands.example.com` |
+    | `analytics.<your-domain>` | `analytics.openhands.example.com` |
     | `runtime-api.<your-domain>` | `runtime-api.openhands.example.com` |
     | `*.runtime.<your-domain>` | `*.runtime.openhands.example.com` |
 
@@ -167,6 +168,7 @@ for h in \
   "app.${BASE_DOMAIN}" \
   "auth.app.${BASE_DOMAIN}" \
   "llm-proxy.${BASE_DOMAIN}" \
+  "analytics.${BASE_DOMAIN}" \
   "runtime-api.${BASE_DOMAIN}"; do
   echo "[DNS] $h"
   getent hosts "$h" || nslookup "$h"


### PR DESCRIPTION
## Summary

Add `analytics.<your-domain>` to the list of required DNS domains for OpenHands Enterprise QuickStart, following the same pattern as `llm-proxy`.

## Changes

- Added `analytics.<your-domain>` to the DNS A records table in the Manual VM Setup section
- Added `analytics.${BASE_DOMAIN}` to the DNS test script in the Preflight Validation section

---

_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/fd56f679-e488-4315-9cc4-b7ec29a7de8b)