### PR TITLE
docs: require well-known CA-signed TLS certs for enterprise install

### DIFF
--- a/enterprise/quick-start.mdx
+++ b/enterprise/quick-start.mdx
@@ -126,7 +126,7 @@ You will need a VM to host OpenHands Enterprise. Choose one of the options below
     | `runtime-api.<your-domain>` | `runtime-api.openhands.example.com` |
     | `*.runtime.<your-domain>` | `*.runtime.openhands.example.com` |
 
-    **Obtain a TLS certificate signed by a well-known certificate authority (CA)**, with SANs
+    **Obtain a TLS certificate signed by a well-known certificate authority (CA) such as Let's Encrypt**, with SANs
     (Subject Alternative Names) for all of the above domains, then copy the certificate
     (`.pem` or `.crt`) and private key (`.pem` or `.key`) to the VM. Self-signed certificates
     are not supported for the OpenHands application.

--- a/enterprise/quick-start.mdx
+++ b/enterprise/quick-start.mdx
@@ -126,8 +126,10 @@ You will need a VM to host OpenHands Enterprise. Choose one of the options below
     | `runtime-api.<your-domain>` | `runtime-api.openhands.example.com` |
     | `*.runtime.<your-domain>` | `*.runtime.openhands.example.com` |
 
-    **Obtain a TLS certificate** with SANs (Subject Alternative Names) for all of the above domains,
-    then copy the certificate (`.pem` or `.crt`) and private key (`.pem` or `.key`) to the VM.
+    **Obtain a TLS certificate signed by a well-known certificate authority (CA)**, with SANs
+    (Subject Alternative Names) for all of the above domains, then copy the certificate
+    (`.pem` or `.crt`) and private key (`.pem` or `.key`) to the VM. Self-signed certificates
+    are not supported for the OpenHands application.
 
     <Warning>
       If you don't provide TLS certificates during installation, the Admin Console will use a


### PR DESCRIPTION
## Summary
- Updates the Enterprise Quick Start TLS guidance to explicitly require a certificate signed by a well-known certificate authority, and notes that self-signed certs are not supported for the OpenHands application.
- Scoped change: the existing warning about the Replicated Admin Console's hardcoded self-signed cert is left untouched since that behavior is outside our control and is factually accurate.

## Context
From a recent discussion with the field team (JM, Rajiv, Joe): since Enterprise trials are explicitly the self-hosted path, customers' network/IT teams are unlikely to issue self-signed certs, and we should steer POCs toward well-known CA-signed certs rather than leaving the door open to self-signed.

## Test plan
- [ ] Mintlify preview renders the updated TLS Setup section correctly
- [ ] Wording reads clearly for a first-time enterprise installer