### PR TITLE
docs(code-review): fix skill naming to avoid plugin override conflict

### DIFF
--- a/openhands/usage/use-cases/code-review.mdx
+++ b/openhands/usage/use-cases/code-review.mdx
@@ -130,11 +130,11 @@ Use `extensions-version` to pin to a specific version tag (e.g., `v1.0.0`) for p
 
 ### Repository-Specific Review Guidelines
 
-Create custom review guidelines for your repository by adding a skill file at `.agents/skills/code-review.md`:
+Add repo-specific review rules by creating a skill file at `.agents/skills/custom-codereview-guide.md`:
 
 ```markdown
 ---
-name: code-review
+name: custom-codereview-guide
 description: Custom code review guidelines for this repository
 triggers:
 - /codereview
@@ -174,8 +174,12 @@ You are reviewing code for [Your Project Name]. Follow these guidelines:
 - Tests should be in [your test directory]
 ```
 
+<Warning>
+**Do not** name your skill `code-review`. The pr-review plugin ships its own `code-review` skill, and plugin skills override project skills with the same name. Use a different name (e.g. `custom-codereview-guide`) with the `/codereview` trigger so both skills are active — the plugin provides the review framework while your skill adds repo-specific rules.
+</Warning>
+
 <Note>
-The skill file must use `/codereview` as the trigger to override the default review behavior. See the [software-agent-sdk's own code-review skill](https://github.com/OpenHands/software-agent-sdk/blob/main/.agents/skills/code-review.md) for a complete example.
+The skill file must use `/codereview` as the trigger so it activates alongside the default review behavior. See the [software-agent-sdk's own custom-codereview-guide](https://github.com/OpenHands/software-agent-sdk/blob/main/.agents/skills/custom-codereview-guide.md) for a complete example.
 </Note>
 
 ### Workflow Configuration


### PR DESCRIPTION
## Problem

The [Customization section](https://docs.openhands.dev/openhands/usage/use-cases/code-review#customization) currently instructs users to create a skill file named `code-review` with `name: code-review`:

```markdown
---
name: code-review
...
```

However, the pr-review plugin ships its own `code-review` skill (symlinked from [`extensions/skills/code-review`](https://github.com/OpenHands/extensions/tree/main/skills/code-review)). During plugin loading, plugin skills **forcibly override** project skills with the same name:

```
Plugin skill 'code-review' overrides existing skill
```

This means the user's custom review guidelines are silently discarded, and the plugin's default English skill takes effect instead.

## Evidence

Observed in CI logs from a real workflow run:

```
Loaded 10 project skills: [..., 'code-review']              # ✅ project skill loaded
Skipping auto-loaded skill 'code-review' (already in explicit skills)  # ✅ public skill correctly skipped
Plugin skill 'code-review' overrides existing skill          # ❌ plugin overrides it
```

## Fix

- Rename the example skill from `code-review` to `custom-codereview-guide` — matching the pattern used by [software-agent-sdk itself](https://github.com/OpenHands/software-agent-sdk/blob/main/.agents/skills/custom-codereview-guide.md)
- Add a `<Warning>` callout explaining the naming constraint
- Update the reference link to point to the SDK's actual skill file (`custom-codereview-guide.md`, not the non-existent `code-review.md`)

With a different name, both skills coexist and activate on the `/codereview` trigger:
- Plugin's `code-review` → provides the review format and framework
- Project's `custom-codereview-guide` → adds repo-specific rules

## Note

The underlying issue is that plugin skill loading doesn't respect explicitly loaded project skills — arguably a bug in the SDK's plugin system. This docs fix is the pragmatic workaround that works today.

---

_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/281ebc79-65d4-46d7-9979-68606f28fbd2)