### PR TITLE
docs: register_agent is in subagent, not in delegate

### DIFF
--- a/sdk/guides/task-tool-set.mdx
+++ b/sdk/guides/task-tool-set.mdx
@@ -63,7 +63,7 @@ sequenceDiagram
         ```python icon="python" focus={23-27}
         from openhands.sdk import LLM, Agent, AgentContext
         from openhands.sdk.context import Skill
-        from openhands.tools.delegate import register_agent
+        from openhands.sdk.subagent import register_agent
 
         def create_code_reviewer(llm: LLM) -> Agent:
             return Agent(
@@ -207,7 +207,8 @@ from pydantic import SecretStr
 
 from openhands.sdk import LLM, Agent, AgentContext, Conversation, Tool
 from openhands.sdk.context import Skill
-from openhands.tools.delegate import DelegationVisualizer, register_agent
+from openhands.sdk.subagent import register_agent
+from openhands.tools.delegate import DelegationVisualizer
 from openhands.tools.task import TaskToolSet
 
 


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [ ] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

- There is some typo related with `register_agent`.