### PR TITLE
docs(local-llms): add community-reported model compatibility note

### DIFF
--- a/openhands/usage/llms/local-llms.mdx
+++ b/openhands/usage/llms/local-llms.mdx
@@ -120,6 +120,16 @@ That's it! You can now start using OpenHands with the local LLM server.
 
 If you encounter any issues, let us know on [Slack](https://openhands.dev/joinslack).
 
+## Community-Reported Notes and Troubleshooting
+
+If OpenHands behaves like a plain chatbot, refuses to use tools or files, or has constant failed tool calls with a local model, the issue may be with the model itself rather than your setup. Even with a large context window, some local models may struggle with reliable tool use.
+
+**Community-reported working models:**
+- `qwen2.5-coder-14b-instruct` — reported to resolve chatbot-like behavior
+- `qwopus3.5-27b-v3 Q8_0` (and similar retrained qwopus variants) — reported to work well with tool calls
+
+If you're experiencing issues, try switching to one of these models before assuming the setup is broken.
+
 ## Advanced: Alternative LLM Backends
 
 This section describes how to run local LLMs with OpenHands using alternative backends like Ollama, SGLang, or vLLM — without relying on LM Studio.


### PR DESCRIPTION
## Summary of changes

Adds a "Community-Reported Notes and Troubleshooting" section to local-llms.mdx documenting community findings about local LLM model compatibility with OpenHands.

## Changes

- Added troubleshooting section explaining that if OpenHands behaves like a plain chatbot, refuses to use tools/files, or has constant failed tool calls, the model itself may be the issue
- Lists community-reported working models: qwen2.5-coder-14b-instruct and qwopus3.5-27b-v3 Q8_0
- Frames content as community-reported experience, not official benchmarks

## Checklist

- [x] I have read and reviewed the documentation changes to the best of my ability.
- [ ] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

## Fixes

Fixes OpenHands/docs#470