### PR TITLE
docs: add community-reported local LLM compatibility note (fixes #470)

### DIFF
--- a/openhands/usage/llms/local-llms.mdx
+++ b/openhands/usage/llms/local-llms.mdx
@@ -120,6 +120,19 @@ That's it! You can now start using OpenHands with the local LLM server.
 
 If you encounter any issues, let us know on [Slack](https://openhands.dev/joinslack).
 
+## Community-Reported Notes and Troubleshooting
+
+**Note:** The following observations are based on community reports, not official benchmarks.
+
+If OpenHands behaves like a plain chatbot—refusing to use tools or files, or having constant failed tool calls—with a local model, the model itself may be the problem. Context window settings matter, but even with a large context window, some models may still struggle with reliable tool use.
+
+Before assuming your setup is broken, try switching models. Recent community reports mention success with:
+
+- **[Qwen2.5-Coder-14B-Instruct](https://huggingface.co/Qwen/Qwen2.5-Coder-14B-Instruct)** — one user reported: *"The problem was with the LM. Everything works with qwen2.5-coder-14b-instruct."*
+- **[Qwopus3.5-27B-V3 Q8_0](https://huggingface.co/search?q=qwopus3.5-27b)** — another user switched to this model and reported *"a lot of success"* after experiencing constant failed tool calls with other local models.
+
+These are community-reported experiences, not guarantees—your mileage may vary.
+
 ## Advanced: Alternative LLM Backends
 
 This section describes how to run local LLMs with OpenHands using alternative backends like Ollama, SGLang, or vLLM — without relying on LM Studio.


### PR DESCRIPTION
## Summary

Adds a small note to the local LLM docs capturing community findings from the Slack channel.

## Changes

- Added new 'Community-Reported Notes and Troubleshooting' section after the Quickstart
- Documents symptoms when local models behave poorly
- Lists community-reported working models: qwen2.5-coder-14b-instruct and qwopus3.5-27b-v3 Q8_0
- Framed as community experience, not official benchmark

## Testing

This is a documentation-only change.

Closes #470
