### PR TITLE
chore: use OPENHANDS_BOT_GITHUB_PAT_PUBLIC in sync workflows

### DIFF
--- a/.github/workflows/sync-agent-sdk-openapi.yml
+++ b/.github/workflows/sync-agent-sdk-openapi.yml
@@ -114,21 +114,21 @@ jobs:
 
             **Note**: This is an automated pull request. Please review the changes to ensure they are correct before merging.
 
-      # Auto-approve using PAT_TOKEN (all-hands-bot). PR is created by
+      # Auto-approve using OPENHANDS_BOT_GITHUB_PAT_PUBLIC (all-hands-bot). PR is created by
       # github-actions[bot], so a different identity (all-hands-bot) can approve it.
       - name: Auto-approve PR
-        if: steps.cpr.outputs.pull-request-url && secrets.PAT_TOKEN != ''
+        if: steps.cpr.outputs.pull-request-url && secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC != ''
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
         run: |
           gh pr review "${{ steps.cpr.outputs.pull-request-url }}" \
             --approve \
             --body "Auto-approving automated OpenAPI sync PR."
 
       - name: Enable auto-merge (squash)
-        if: steps.cpr.outputs.pull-request-url && secrets.PAT_TOKEN != ''
+        if: steps.cpr.outputs.pull-request-url && secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC != ''
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
         run: |
           PR_URL="${{ steps.cpr.outputs.pull-request-url }}"
 

--- a/.github/workflows/sync-docs-code-blocks.yml
+++ b/.github/workflows/sync-docs-code-blocks.yml
@@ -103,21 +103,21 @@ jobs:
             - [x] I have read and reviewed the documentation changes to the best of my ability.
             - [x] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.
 
-      # Auto-approve using PAT_TOKEN (all-hands-bot). PR is created by
+      # Auto-approve using OPENHANDS_BOT_GITHUB_PAT_PUBLIC (all-hands-bot). PR is created by
       # github-actions[bot], so a different identity (all-hands-bot) can approve it.
       - name: Auto-approve PR
-        if: steps.cpr.outputs.pull-request-url && secrets.PAT_TOKEN != ''
+        if: steps.cpr.outputs.pull-request-url && secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC != ''
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
         run: |
           gh pr review "${{ steps.cpr.outputs.pull-request-url }}" \
             --approve \
             --body "Auto-approving automated docs sync PR."
 
       - name: Enable auto-merge (squash)
-        if: steps.cpr.outputs.pull-request-url && secrets.PAT_TOKEN != ''
+        if: steps.cpr.outputs.pull-request-url && secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC != ''
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
         run: |
           PR_URL="${{ steps.cpr.outputs.pull-request-url }}"
 


### PR DESCRIPTION
Part of [OpenHands/evaluation#428](https://github.com/OpenHands/evaluation/issues/428) (PAT blast-radius reduction).

Replaces `secrets.PAT_TOKEN` → `secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC` in the two auto-approve workflows:

- `.github/workflows/sync-docs-code-blocks.yml`
- `.github/workflows/sync-agent-sdk-openapi.yml`

The `OPENHANDS_BOT_GITHUB_PAT_PUBLIC` token is a fine-grained PAT scoped only to public OpenHands repos with the narrowest permissions needed to approve these bot-authored PRs — tighter than the shared `PAT_TOKEN` it replaces.

## Prerequisites

- [ ] `OpenHands/docs` added to the `OPENHANDS_BOT_GITHUB_PAT_PUBLIC` fine-grained PAT repo allowlist
- [ ] `OPENHANDS_BOT_GITHUB_PAT_PUBLIC` secret added to `OpenHands/docs` repository secrets