### PR TITLE
chore: use OPENHANDS_BOT_GITHUB_PAT_PUBLIC in pr-review-by-openhands.yml

### DIFF
--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -46,5 +46,5 @@ jobs:
                   # [DEPRECATED] review-style is no longer used; standard and roasted are merged
                   # review-style: roasted
                   llm-api-key: ${{ secrets.LLM_API_KEY }}
-                  github-token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  github-token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
                   lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}


### PR DESCRIPTION
Part of [OpenHands/evaluation#428](https://github.com/OpenHands/evaluation/issues/428) (PAT blast-radius reduction).

Replaces `secrets.ALLHANDS_BOT_GITHUB_PAT` → `secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC` on L49. The `ALLHANDS_BOT_GITHUB_PAT` is the shared bot token with write access to private repos; `OPENHANDS_BOT_GITHUB_PAT_PUBLIC` is a fine-grained PAT scoped only to public OpenHands repos (`contents+pull-requests+issues:write`). This matches the pattern already used in the other repos' `pr-review-by-openhands.yml` workflows.

## Prerequisites

- [ ] `OPENHANDS_BOT_GITHUB_PAT_PUBLIC` secret added to `OpenHands/docs` repository secrets (if not already present from #473)
- [ ] `OpenHands/docs` on the `PAT_PUBLIC` fine-grained PAT allowlist (should already be, from #473)