### PR TITLE
Add warning to API-based Sandbox page about production use

### DIFF
--- a/sdk/guides/agent-server/api-sandbox.mdx
+++ b/sdk/guides/agent-server/api-sandbox.mdx
@@ -6,7 +6,7 @@ description: Connect to hosted API-based agent server for fully managed infrastr
 > A ready-to-run example is available [here](#ready-to-run-example)!
 
 <Warning>
-The [Runtime API](https://runtime.all-hands.dev/) (`runtime.all-hands.dev`) is designed primarily for **community benchmark evaluation at scale**, not for building production applications. If you are building a production application with the SDK, use the **[OpenHands Cloud Workspace](/sdk/guides/agent-server/cloud-workspace)** instead, which provides fully managed sandbox environments with SaaS credential support.
+The [Runtime API](https://runtime.all-hands.dev/) (`runtime.all-hands.dev`) is designed primarily for **benchmark evaluation at scale**, not for building production applications. If you are building a production application with the SDK, use the **[OpenHands Cloud Workspace](/sdk/guides/agent-server/cloud-workspace)** instead, which provides fully managed sandbox environments with SaaS credential support.
 </Warning>
 
 The API-sandboxed agent server demonstrates how to use `APIRemoteWorkspace` to connect to a [OpenHands runtime API service](https://runtime.all-hands.dev/). This eliminates the need to manage your own infrastructure, providing automatic scaling, monitoring, and secure sandboxed execution.

--- a/sdk/guides/agent-server/api-sandbox.mdx
+++ b/sdk/guides/agent-server/api-sandbox.mdx
@@ -5,6 +5,9 @@ description: Connect to hosted API-based agent server for fully managed infrastr
 
 > A ready-to-run example is available [here](#ready-to-run-example)!
 
+<Warning>
+The [Runtime API](https://runtime.all-hands.dev/) (`runtime.all-hands.dev`) is designed primarily for **community benchmark evaluation at scale**, not for building production applications. If you are building a production application with the SDK, use the **[OpenHands Cloud Workspace](/sdk/guides/agent-server/cloud-workspace)** instead, which provides fully managed sandbox environments with SaaS credential support.
+</Warning>
 
 The API-sandboxed agent server demonstrates how to use `APIRemoteWorkspace` to connect to a [OpenHands runtime API service](https://runtime.all-hands.dev/). This eliminates the need to manage your own infrastructure, providing automatic scaling, monitoring, and secure sandboxed execution.
 

--- a/sdk/guides/agent-server/api-sandbox.mdx
+++ b/sdk/guides/agent-server/api-sandbox.mdx
@@ -6,7 +6,7 @@ description: Connect to hosted API-based agent server for fully managed infrastr
 > A ready-to-run example is available [here](#ready-to-run-example)!
 
 <Warning>
-The [Runtime API](https://runtime.all-hands.dev/) (`runtime.all-hands.dev`) is designed primarily for **[benchmark evaluation at scale](https://github.com/OpenHands/benchmarks)**, not for building production applications. If you are building a application with the SDK, use the **[OpenHands Cloud Workspace](/sdk/guides/agent-server/cloud-workspace)** instead, which provides fully managed sandbox environments with SaaS credential support.
+The [Runtime API](https://runtime.all-hands.dev/) (`runtime.all-hands.dev`) is designed primarily for **[benchmark evaluation at scale](https://github.com/OpenHands/benchmarks)**, not for building production applications. If you are building a production application with the SDK, use the **[OpenHands Cloud Workspace](/sdk/guides/agent-server/cloud-workspace)** instead, which provides fully managed sandbox environments with SaaS credential support.
 </Warning>
 
 The API-sandboxed agent server demonstrates how to use `APIRemoteWorkspace` to connect to a [OpenHands runtime API service](https://runtime.all-hands.dev/). This eliminates the need to manage your own infrastructure, providing automatic scaling, monitoring, and secure sandboxed execution.

--- a/sdk/guides/agent-server/api-sandbox.mdx
+++ b/sdk/guides/agent-server/api-sandbox.mdx
@@ -6,7 +6,7 @@ description: Connect to hosted API-based agent server for fully managed infrastr
 > A ready-to-run example is available [here](#ready-to-run-example)!
 
 <Warning>
-The [Runtime API](https://runtime.all-hands.dev/) (`runtime.all-hands.dev`) is designed primarily for **benchmark evaluation at scale**, not for building production applications. If you are building a production application with the SDK, use the **[OpenHands Cloud Workspace](/sdk/guides/agent-server/cloud-workspace)** instead, which provides fully managed sandbox environments with SaaS credential support.
+The [Runtime API](https://runtime.all-hands.dev/) (`runtime.all-hands.dev`) is designed primarily for **[benchmark evaluation at scale](https://github.com/OpenHands/benchmarks)**, not for building production applications. If you are building a application with the SDK, use the **[OpenHands Cloud Workspace](/sdk/guides/agent-server/cloud-workspace)** instead, which provides fully managed sandbox environments with SaaS credential support.
 </Warning>
 
 The API-sandboxed agent server demonstrates how to use `APIRemoteWorkspace` to connect to a [OpenHands runtime API service](https://runtime.all-hands.dev/). This eliminates the need to manage your own infrastructure, providing automatic scaling, monitoring, and secure sandboxed execution.


### PR DESCRIPTION
## Summary

Adds a prominent warning to the [API-based Sandbox](https://docs.openhands.dev/sdk/guides/agent-server/api-sandbox) documentation page clarifying that the Runtime API (`runtime.all-hands.dev`) is designed for **community benchmark evaluation at scale**, not for building production applications.

The warning directs users to the [OpenHands Cloud Workspace](/sdk/guides/agent-server/cloud-workspace) for production use cases.

## Context

The `runtime.all-hands.dev` service was built to help the community run agent benchmark evaluations at scale. It was not intended to be used as a production workspace for applications built with the SDK. This warning helps set proper expectations and guides users to the right tool for their use case.

## Changes

- Added a `<Warning>` component near the top of `sdk/guides/agent-server/api-sandbox.mdx` with a clear message about the intended use of the Runtime API and a link to the recommended alternative for production.

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/13010e94-8529-4e2e-9af9-007356fa1cae)