### PR TITLE
docs: clarify skill injection behavior and add migration guide

### DIFF
--- a/.agents/skills/code-review.md
+++ b/.agents/skills/code-review.md
@@ -46,6 +46,7 @@ It's OK to approve a docs/ PR on the basis of a linked upstream PR, they will be
 - **Field/attribute names** on data classes and models are correct
 - **Supported values** (e.g., format strings like `"github:owner/repo"`) are actually handled in code
 - **Behavioral descriptions** match the implementation logic
+- **Prompt/context descriptions** distinguish between initial injection/construction, conversation-history inclusion, LLM context, and actual request transport. Flag ambiguous wording such as “sent with each request” unless the docs are intentionally describing transport-level behavior.
 - **Example code** would actually run without errors
 
 ### How to verify
@@ -90,7 +91,7 @@ Include a "Source Verification" section that lists the key claims verified and t
 
 | Documentation Claim | Verified? | Source Evidence |
 |---------------------|-----------|-----------------|
-| Legacy skills with `trigger=None` inject full content every turn | ✅ | [agent.py#L150](permalink) |
+| Legacy skills with `trigger=None` are included in the initial system prompt and remain in LLM context for subsequent turns | ✅ | [agent.py#L150](permalink) |
 | `load_skills_from_dir()` returns tuple of (skills, repo_skills) | ✅ | [context.py#L85](permalink) |
 | AgentSkills format uses progressive disclosure | ❌ Incorrect | [agent.py#L200](permalink) shows... |
 ```

--- a/.agents/skills/code-review.md
+++ b/.agents/skills/code-review.md
@@ -12,19 +12,23 @@ multiple source-of-truth codebases. Accuracy is critical.
 
 ## Source Code Verification (Required for SDK/CLI/App docs)
 
-When reviewing documentation that references APIs, function signatures, class names, or code examples
-from an upstream repository, you **MUST** clone the corresponding repository and verify the documentation
-against the actual source code. Do not trust that code examples or API descriptions are accurate without
-checking.
+When reviewing documentation that references APIs, function signatures, class names, code examples,
+or behavioral descriptions from an upstream repository, you **MUST** clone the corresponding repository
+and verify the documentation against the actual source code. Do not trust that code examples or API
+descriptions are accurate without checking.
+
+**Every review comment and every approval MUST include evidence from the source code.** For each
+documentation claim you verify (or flag as incorrect), provide a direct GitHub permalink to the
+relevant source file and line(s). A review that simply says "looks good" without citing source
+code is incomplete.
 
 ### Repositories to clone for verification
 
-| Documentation path | Source repository |
-|--------------------|-------------------|
-| `sdk/` | `OpenHands/software-agent-sdk` |
-| `openhands/` | `OpenHands/OpenHands` |
-| CLI-related docs | `OpenHands/OpenHands-CLI` |
-
+| Documentation path | Source repository | GitHub base URL |
+|--------------------|-------------------|-----------------|
+| `sdk/` | `OpenHands/software-agent-sdk` | `https://github.com/OpenHands/software-agent-sdk` |
+| `openhands/` | `OpenHands/OpenHands` | `https://github.com/OpenHands/OpenHands` |
+| CLI-related docs | `OpenHands/OpenHands-CLI` | `https://github.com/OpenHands/OpenHands-CLI` |
 
 ### Prefer upstream PR branches when linked
 
@@ -56,6 +60,46 @@ git clone --depth=1 https://github.com/OpenHands/software-agent-sdk.git /tmp/age
 
 # Search for the documented symbols
 grep -rn "function_name" /tmp/agent-sdk/
+```
+
+### Providing evidence in review comments (Required)
+
+For **every** documentation change that describes code behavior, APIs, or implementation details,
+your review MUST include a link to the corresponding source code as evidence. Use GitHub permalinks
+(with commit SHA or branch) so links remain stable.
+
+**Format for inline review comments:**
+
+When commenting on a specific line or section of the documentation, include evidence like:
+
+```
+✅ Verified: `is_agentskills_format` field exists on the Skill class.
+→ Source: https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-sdk/openhands/sdk/context.py#L42
+
+🔴 Incorrect: The docs say `trigger=None` causes injection into `<REPO_CONTEXT>`, but the code
+shows it injects into `<EXTRA_INFO>`.
+→ Source: https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-sdk/openhands/sdk/agent.py#L150-L165
+```
+
+**Format for the overall review body:**
+
+Include a "Source Verification" section that lists the key claims verified and their evidence:
+
+```
+## Source Verification
+
+| Documentation Claim | Verified? | Source Evidence |
+|---------------------|-----------|-----------------|
+| Legacy skills with `trigger=None` inject full content every turn | ✅ | [agent.py#L150](permalink) |
+| `load_skills_from_dir()` returns tuple of (skills, repo_skills) | ✅ | [context.py#L85](permalink) |
+| AgentSkills format uses progressive disclosure | ❌ Incorrect | [agent.py#L200](permalink) shows... |
+```
+
+If you cannot find source code to verify a documentation claim, explicitly flag it:
+
+```
+⚠️ Unverified: Could not find source code for the claimed behavior of "X".
+This should be verified before merging.
 ```
 
 ## Review Decisions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,7 @@ Workflow: `.github/workflows/sync-agent-sdk-openapi.yml`
 - Follow the style rules in `openhands/DOC_STYLE_GUIDE.md`.
 - Use Mintlify components (`<Note>`, `<Warning>`, `<Tabs>`, etc.) where appropriate.
 - When linking internally, prefer **absolute** doc paths (e.g. `/overview/quickstart`).
+- When documenting prompt/context behavior, avoid ambiguous transport phrasing like “sent with each request” unless discussing the actual API transport. Prefer precise wording such as “included in the initial system prompt” and “remains part of the conversation/LLM context for subsequent turns.”
 - Cloud integration docs live under `openhands/usage/cloud/`, and pages surfaced in **Documentation → Integrations → Cloud API** must also be added to the `Cloud API` group in `docs.json`.
 
 ### Mintlify tab ownership

--- a/sdk/guides/skill.mdx
+++ b/sdk/guides/skill.mdx
@@ -9,6 +9,56 @@ This guide shows how to implement skills in the SDK. For conceptual overview, se
 
 OpenHands supports an **extended version** of the [AgentSkills standard](https://agentskills.io/specification) with optional keyword triggers.
 
+## Skill Injection Behavior
+
+Understanding where skill content appears in the prompt is critical. The behavior differs based on skill format and trigger configuration:
+
+| Skill Format | Trigger | Where Content Appears | Model Mediated? |
+|--------------|---------|----------------------|-----------------|
+| **AgentSkills** (`SKILL.md`) | Any | `<available_skills>` (description only) | ✅ Yes — agent calls `invoke_skill()` |
+| **AgentSkills** (`SKILL.md`) | Has triggers | `<available_skills>` + auto-inject on match | ✅ Yes |
+| **Legacy** (inline/`*.md`) | `None` | **`<REPO_CONTEXT>` (full content, every turn)** | ❌ No |
+| **Legacy** (inline/`*.md`) | Has triggers | `<available_skills>` + auto-inject on match | ✅ Yes |
+
+<Warning>
+**Token Usage Warning**: Legacy skills with `trigger=None` inject their **full content** into `<REPO_CONTEXT>` on **every turn**. This can consume significant tokens. Consider using AgentSkills format (`SKILL.md`) for progressive disclosure instead.
+</Warning>
+
+### Prompt Structure
+
+Skills appear in different parts of the system prompt:
+
+```xml icon="file"
+<!-- System Prompt Structure -->
+
+<REPO_CONTEXT>
+  <!-- Legacy trigger=None skills: FULL content here, every turn -->
+  [BEGIN context from [agents]]
+  ... AGENTS.md content ...
+  [END Context]
+</REPO_CONTEXT>
+
+<SKILLS>
+  <available_skills>
+    <!-- AgentSkills + legacy with triggers: description only -->
+    <skill>
+      <name>github</name>
+      <description>Interact with GitHub...</description>
+    </skill>
+  </available_skills>
+</SKILLS>
+```
+
+When a trigger matches, content is injected into the **user message**:
+
+```xml icon="file"
+<EXTRA_INFO>
+The following information has been included based on a keyword match for "github".
+Skill location: /path/to/skill
+... skill content ...
+</EXTRA_INFO>
+```
+
 ## Context Loading Methods
 
 | Method | When Content Loads | Use Case |
@@ -49,6 +99,10 @@ agent_context = AgentContext(
     ]
 )
 ```
+
+<Warning>
+**Important**: Inline skills with `trigger=None` use **legacy format** behavior — full content is injected into `<REPO_CONTEXT>` on every turn. For large skills, consider using the AgentSkills `SKILL.md` format for progressive disclosure.
+</Warning>
 
 ## Trigger-Loaded Context
 
@@ -836,9 +890,15 @@ from openhands.sdk.context.skills import load_skills_from_dir
 repo_skills, knowledge_skills, agent_skills = load_skills_from_dir(skills_dir)
 ```
 
-- **repo_skills**: Skills from `repo.md` files (always active)
-- **knowledge_skills**: Skills from `knowledge/` subdirectories
-- **agent_skills**: Skills from `SKILL.md` files (AgentSkills standard)
+| Return Value | Source Files | Injection Behavior |
+|--------------|--------------|-------------------|
+| **repo_skills** | `repo.md`, `AGENTS.md`, `.cursorrules` | Full content in `<REPO_CONTEXT>` every turn |
+| **knowledge_skills** | `knowledge/` subdirectories, `*.md` with triggers | Listed in `<available_skills>`, auto-inject on trigger |
+| **agent_skills** | `SKILL.md` files (AgentSkills standard) | Listed in `<available_skills>`, agent calls `invoke_skill()` |
+
+<Tip>
+When passing to `AgentContext(skills=...)`, all three types are accepted. The injection behavior depends on the skill's `is_agentskills_format` flag and `trigger` field — see [Skill Injection Behavior](#skill-injection-behavior).
+</Tip>
 
 #### `discover_skill_resources()`
 
@@ -1164,6 +1224,57 @@ print(rendered)  # Commands replaced with output
 ```
 
 The `working_dir` parameter sets the current directory for command execution, enabling workspace-relative commands like `git status`.
+
+## Migrating from Legacy to AgentSkills Format
+
+If you have legacy inline skills consuming many tokens, convert them to AgentSkills format for progressive disclosure:
+
+### Before (Legacy Format)
+
+```python icon="python"
+# Legacy: Full content in <REPO_CONTEXT> every turn
+Skill(
+    name="api-guidelines",
+    content="""
+    # API Guidelines
+    ... 2000 lines of detailed documentation ...
+    """,
+    trigger=None,  # Always injected - uses many tokens!
+)
+```
+
+### After (AgentSkills Format)
+
+Create a directory `api-guidelines/SKILL.md`:
+
+```markdown icon="markdown"
+---
+name: api-guidelines
+description: Comprehensive API design guidelines for the project. Invoke when designing or reviewing API endpoints.
+---
+
+# API Guidelines
+
+... 2000 lines of detailed documentation ...
+```
+
+Then load it:
+
+```python icon="python"
+from openhands.sdk.skills import load_skills_from_dir
+
+# AgentSkills: Only description in prompt, agent reads full content on demand
+_, _, skills = load_skills_from_dir("/path/to/skills")
+agent_context = AgentContext(skills=list(skills.values()))
+```
+
+### Benefits
+
+| Aspect | Legacy `trigger=None` | AgentSkills `SKILL.md` |
+|--------|----------------------|------------------------|
+| Token usage | Full content every turn | Description only (~100 chars) |
+| Model control | None — always present | Agent decides when to read |
+| Scalability | Limited by context window | Many skills without token bloat |
 
 ## Next Steps
 

--- a/sdk/guides/skill.mdx
+++ b/sdk/guides/skill.mdx
@@ -17,11 +17,11 @@ Understanding where skill content appears in the prompt is critical. The behavio
 |--------------|---------|----------------------|-----------------|
 | **AgentSkills** (`SKILL.md`) | Any | `<available_skills>` (description only) | ✅ Yes — agent calls `invoke_skill()` |
 | **AgentSkills** (`SKILL.md`) | Has triggers | `<available_skills>` + auto-inject on match | ✅ Yes |
-| **Legacy** (inline/`*.md`) | `None` | **`<REPO_CONTEXT>` (full content, every turn)** | ❌ No |
+| **Legacy** (inline/`*.md`) | `None` | **`<REPO_CONTEXT>` (full content in the initial system prompt; sent with each LLM request)** | ❌ No |
 | **Legacy** (inline/`*.md`) | Has triggers | `<available_skills>` + auto-inject on match | ✅ Yes |
 
 <Warning>
-**Token Usage Warning**: Legacy skills with `trigger=None` inject their **full content** into `<REPO_CONTEXT>` on **every turn**. This can consume significant tokens. Consider using AgentSkills format (`SKILL.md`) for progressive disclosure instead.
+**Token Usage Warning**: Legacy skills with `trigger=None` add their **full content** to `<REPO_CONTEXT>` in the initial `SystemPromptEvent`. That system message remains in conversation history and is sent with each LLM request, so the content still affects token usage on each turn. Consider using AgentSkills format (`SKILL.md`) for progressive disclosure instead.
 </Warning>
 
 ### Prompt Structure
@@ -32,7 +32,8 @@ Skills appear in different parts of the system prompt:
 <!-- System Prompt Structure -->
 
 <REPO_CONTEXT>
-  <!-- Legacy trigger=None skills: FULL content here, every turn -->
+  <!-- Legacy trigger=None skills: FULL content in the initial system prompt;
+       included with each LLM request while retained in history -->
   [BEGIN context from [agents]]
   ... AGENTS.md content ...
   [END Context]
@@ -101,7 +102,7 @@ agent_context = AgentContext(
 ```
 
 <Warning>
-**Important**: Inline skills with `trigger=None` use **legacy format** behavior — full content is injected into `<REPO_CONTEXT>` on every turn. For large skills, consider using the AgentSkills `SKILL.md` format for progressive disclosure.
+**Important**: Inline skills with `trigger=None` use **legacy format** behavior — full content is added to `<REPO_CONTEXT>` in the initial system prompt and sent with each LLM request. For large skills, consider using the AgentSkills `SKILL.md` format for progressive disclosure.
 </Warning>
 
 ## Trigger-Loaded Context
@@ -892,7 +893,7 @@ repo_skills, knowledge_skills, agent_skills = load_skills_from_dir(skills_dir)
 
 | Return Value | Source Files | Injection Behavior |
 |--------------|--------------|-------------------|
-| **repo_skills** | `repo.md`, `AGENTS.md`, `.cursorrules` | Full content in `<REPO_CONTEXT>` every turn |
+| **repo_skills** | `repo.md`, `AGENTS.md`, `.cursorrules` | Full content in `<REPO_CONTEXT>` in the initial system prompt; sent with each LLM request |
 | **knowledge_skills** | `knowledge/` subdirectories, `*.md` with triggers | Listed in `<available_skills>`, auto-inject on trigger |
 | **agent_skills** | `SKILL.md` files (AgentSkills standard) | Listed in `<available_skills>`, agent calls `invoke_skill()` |
 
@@ -1232,14 +1233,14 @@ If you have legacy inline skills consuming many tokens, convert them to AgentSki
 ### Before (Legacy Format)
 
 ```python icon="python"
-# Legacy: Full content in <REPO_CONTEXT> every turn
+# Legacy: Full content in <REPO_CONTEXT> in the initial system prompt
 Skill(
     name="api-guidelines",
     content="""
     # API Guidelines
     ... 2000 lines of detailed documentation ...
     """,
-    trigger=None,  # Always injected - uses many tokens!
+    trigger=None,  # Always-on context - uses tokens on each LLM request!
 )
 ```
 
@@ -1272,7 +1273,7 @@ agent_context = AgentContext(skills=list(skills.values()))
 
 | Aspect | Legacy `trigger=None` | AgentSkills `SKILL.md` |
 |--------|----------------------|------------------------|
-| Token usage | Full content every turn | Description only (~100 chars) |
+| Token usage | Full content in system prompt, sent with each LLM request | Description only (~100 chars) |
 | Model control | None — always present | Agent decides when to read |
 | Scalability | Limited by context window | Many skills without token bloat |
 

--- a/sdk/guides/skill.mdx
+++ b/sdk/guides/skill.mdx
@@ -17,11 +17,11 @@ Understanding where skill content appears in the prompt is critical. The behavio
 |--------------|---------|----------------------|-----------------|
 | **AgentSkills** (`SKILL.md`) | Any | `<available_skills>` (description only) | ✅ Yes — agent calls `invoke_skill()` |
 | **AgentSkills** (`SKILL.md`) | Has triggers | `<available_skills>` + auto-inject on match | ✅ Yes |
-| **Legacy** (inline/`*.md`) | `None` | **`<REPO_CONTEXT>` (full content in the initial system prompt; sent with each LLM request)** | ❌ No |
+| **Legacy** (inline/`*.md`) | `None` | **`<REPO_CONTEXT>` (full content in the initial system prompt; included in LLM context for each turn)** | ❌ No |
 | **Legacy** (inline/`*.md`) | Has triggers | `<available_skills>` + auto-inject on match | ✅ Yes |
 
 <Warning>
-**Token Usage Warning**: Legacy skills with `trigger=None` add their **full content** to `<REPO_CONTEXT>` in the initial `SystemPromptEvent`. That system message remains in conversation history and is sent with each LLM request, so the content still affects token usage on each turn. Consider using AgentSkills format (`SKILL.md`) for progressive disclosure instead.
+**Token Usage Warning**: Legacy skills with `trigger=None` add their **full content** to `<REPO_CONTEXT>` in the initial `SystemPromptEvent`. That system message remains part of the conversation context for subsequent LLM calls, so the content still affects token usage on each turn. Consider using AgentSkills format (`SKILL.md`) for progressive disclosure instead.
 </Warning>
 
 ### Prompt Structure
@@ -33,7 +33,7 @@ Skills appear in different parts of the system prompt:
 
 <REPO_CONTEXT>
   <!-- Legacy trigger=None skills: FULL content in the initial system prompt;
-       included with each LLM request while retained in history -->
+       included in LLM context for each turn while retained in history -->
   [BEGIN context from [agents]]
   ... AGENTS.md content ...
   [END Context]
@@ -102,7 +102,7 @@ agent_context = AgentContext(
 ```
 
 <Warning>
-**Important**: Inline skills with `trigger=None` use **legacy format** behavior — full content is added to `<REPO_CONTEXT>` in the initial system prompt and sent with each LLM request. For large skills, consider using the AgentSkills `SKILL.md` format for progressive disclosure.
+**Important**: Inline skills with `trigger=None` use **legacy format** behavior — full content is added to `<REPO_CONTEXT>` in the initial system prompt and remains part of the conversation context for subsequent LLM calls. For large skills, consider using the AgentSkills `SKILL.md` format for progressive disclosure.
 </Warning>
 
 ## Trigger-Loaded Context
@@ -893,7 +893,7 @@ repo_skills, knowledge_skills, agent_skills = load_skills_from_dir(skills_dir)
 
 | Return Value | Source Files | Injection Behavior |
 |--------------|--------------|-------------------|
-| **repo_skills** | `repo.md`, `AGENTS.md`, `.cursorrules` | Full content in `<REPO_CONTEXT>` in the initial system prompt; sent with each LLM request |
+| **repo_skills** | `repo.md`, `AGENTS.md`, `.cursorrules` | Full content in `<REPO_CONTEXT>` in the initial system prompt; included in LLM context for each turn |
 | **knowledge_skills** | `knowledge/` subdirectories, `*.md` with triggers | Listed in `<available_skills>`, auto-inject on trigger |
 | **agent_skills** | `SKILL.md` files (AgentSkills standard) | Listed in `<available_skills>`, agent calls `invoke_skill()` |
 
@@ -1240,7 +1240,7 @@ Skill(
     # API Guidelines
     ... 2000 lines of detailed documentation ...
     """,
-    trigger=None,  # Always-on context - uses tokens on each LLM request!
+    trigger=None,  # Always-on context - affects token usage on each turn!
 )
 ```
 
@@ -1273,7 +1273,7 @@ agent_context = AgentContext(skills=list(skills.values()))
 
 | Aspect | Legacy `trigger=None` | AgentSkills `SKILL.md` |
 |--------|----------------------|------------------------|
-| Token usage | Full content in system prompt, sent with each LLM request | Description only (~100 chars) |
+| Token usage | Full content in system prompt; included in LLM context for each turn | Description only (~100 chars) |
 | Model control | None — always present | Agent decides when to read |
 | Scalability | Limited by context window | Many skills without token bloat |
 


### PR DESCRIPTION
## Summary

Address documentation gaps identified in OpenHands/software-agent-sdk#2981 regarding skill injection semantics.

## Problem

The current documentation shows 3 "loading methods" but the SDK actually implements **4 distinct injection behaviors** based on skill format (`is_agentskills_format`) and trigger configuration. Users have no way to know that:

- Legacy skills with `trigger=None` inject **full content** into `<REPO_CONTEXT>` on **every turn**
- AgentSkills format uses progressive disclosure (description only, agent reads on demand)
- The same `Skill()` constructor produces fundamentally different runtime behavior depending on format

## Changes

1. **New "Skill Injection Behavior" section** - Clear table at the top showing where content appears:

   | Skill Format | Trigger | Where Content Appears | Model Mediated? |
   |--------------|---------|----------------------|-----------------|
   | AgentSkills (`SKILL.md`) | Any | `<available_skills>` (description only) | ✅ Yes |
   | AgentSkills (`SKILL.md`) | Has triggers | `<available_skills>` + auto-inject | ✅ Yes |
   | Legacy (inline/`*.md`) | `None` | **`<REPO_CONTEXT>` (full content, every turn)** | ❌ No |
   | Legacy (inline/`*.md`) | Has triggers | `<available_skills>` + auto-inject | ✅ Yes |

2. **Warning callout** - Token usage warning for legacy `trigger=None` skills

3. **Prompt Structure section** - Shows XML structure of where skills appear in prompts

4. **Warning on inline skills** - Added warning to the "Inline Skill (Code-defined)" example

5. **Improved `load_skills_from_dir()` docs** - Table explaining injection behavior for each return value

6. **New "Migrating from Legacy to AgentSkills Format" section** - Before/after examples with benefits comparison

## Related Issues

- Fixes documentation gap reported in OpenHands/software-agent-sdk#2981

---

*This PR was created by an AI agent (OpenHands) on behalf of the user.*

@VascoSch92 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/fb2b65c2-bef5-44e9-9ff1-8e4a524a842b)