### PR TITLE
Add Tech Notes section under Enterprise with LLM key protection article

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -434,6 +434,13 @@
               "enterprise/k8s-install/index",
               "enterprise/k8s-install/resource-limits"
             ]
+          },
+          {
+            "group": "Tech Notes",
+            "pages": [
+              "enterprise/tech-notes/index",
+              "enterprise/tech-notes/llm-key-protection"
+            ]
           }
         ]
       }

--- a/enterprise/tech-notes/images/llm-key-architecture.d2
+++ b/enterprise/tech-notes/images/llm-key-architecture.d2
@@ -1,0 +1,110 @@
+direction: down
+
+title: LLM API Key Protection Architecture {
+  near: top-center
+  shape: text
+  style: {
+    font-size: 24
+    bold: true
+  }
+}
+
+agent-server: Agent Server (Python Process) {
+  style: {
+    fill: "#f8fafc"
+    stroke: "#94a3b8"
+    border-radius: 12
+  }
+
+  agent-loop: Agent Loop {
+    style: {
+      fill: "#eef2ff"
+      stroke: "#6366f1"
+      border-radius: 8
+    }
+  }
+
+  llm: LLM\n(api_key 🔑) {
+    style: {
+      fill: "#fef3c7"
+      stroke: "#f59e0b"
+      border-radius: 8
+      font-color: "#92400e"
+    }
+  }
+
+  provider-api: LiteLLM / Provider API {
+    style: {
+      fill: "#ecfdf5"
+      stroke: "#10b981"
+      border-radius: 8
+    }
+  }
+
+  agent-loop -> llm: {
+    style: {
+      stroke: "#6366f1"
+      stroke-width: 2
+    }
+  }
+
+  llm -> provider-api: {
+    style: {
+      stroke: "#6366f1"
+      stroke-width: 2
+    }
+  }
+
+  sandbox: Sandbox Environment (Isolated Container) {
+    style: {
+      fill: "#fef2f2"
+      stroke: "#ef4444"
+      stroke-dash: 5
+      border-radius: 10
+    }
+
+    bash: Bash Commands {
+      style: {
+        fill: "#ffffff"
+        stroke: "#d1d5db"
+        border-radius: 6
+      }
+    }
+
+    files: File Editor {
+      style: {
+        fill: "#ffffff"
+        stroke: "#d1d5db"
+        border-radius: 6
+      }
+    }
+
+    tools: Other Tools {
+      style: {
+        fill: "#ffffff"
+        stroke: "#d1d5db"
+        border-radius: 6
+      }
+    }
+
+    no-access: |md
+      ❌ No LLM_API_KEY
+      ❌ No SESSION_API_KEY
+      ❌ No Provider Credentials
+    | {
+      style: {
+        fill: "#fee2e2"
+        stroke: "#fecaca"
+        border-radius: 6
+        font-color: "#991b1b"
+      }
+    }
+  }
+
+  agent-loop -> sandbox: Tool calls\n(no secrets) {
+    style: {
+      stroke: "#9ca3af"
+      stroke-width: 2
+    }
+  }
+}

--- a/enterprise/tech-notes/images/llm-key-architecture.svg
+++ b/enterprise/tech-notes/images/llm-key-architecture.svg
@@ -1,0 +1,851 @@
+<?xml version="1.0" encoding="utf-8"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" data-d2-version="v0.7.1" preserveAspectRatio="xMinYMin meet" viewBox="0 0 1618 905"><svg class="d2-3229218106 d2-svg" width="1618" height="905" viewBox="-101 -173 1618 905"><rect x="-101.000000" y="-173.000000" width="1618.000000" height="905.000000" rx="0.000000" fill="#FFFFFF" class=" fill-N7" stroke-width="0" /><style type="text/css"><![CDATA[
+.d2-3229218106 .text {
+	font-family: "d2-3229218106-font-regular";
+}
+@font-face {
+	font-family: d2-3229218106-font-regular;
+	src: url("data:application/font-woff;base64,d09GRgABAAAAABAEAAoAAAAAGEQAAguFAAAAAAAAAAAAAAAAAAAAAAAAAABPUy8yAAAA9AAAAGAAAABgXd/Vo2NtYXAAAAFUAAAAtwAAAPAEpAX+Z2x5ZgAAAgwAAAk3AAAMjPEtmahoZWFkAAALRAAAADYAAAA2G4Ue32hoZWEAAAt8AAAAJAAAACQKhAXuaG10eAAAC6AAAACjAAAAsFGECXBsb2NhAAAMRAAAAFoAAABaSSxGaG1heHAAAAygAAAAIAAAACAARAD2bmFtZQAADMAAAAMjAAAIFAbDVU1wb3N0AAAP5AAAAB0AAAAg/9EAMgADAgkBkAAFAAACigJYAAAASwKKAlgAAAFeADIBIwAAAgsFAwMEAwICBGAAAvcAAAADAAAAAAAAAABBREJPAEAAIP//Au7/BgAAA9gBESAAAZ8AAAAAAeYClAAAACAAA3icfM05SmsBAIXhLy/3OcZ5nq9zUmUNIgrBRtDGSixExEYsRPfk1FmIopXrEFyFzRHuAjzNaT74UVNXQ0PhG6VSUX1L27ZdHfsOHTl26tyla7dJJZratuzo2HNQiRNnLly5SfKV5Ccfec9bXvOS53zmKY95yH3uqubfq9nU1PJPXeG/Lt169OrTr2HAoCHDNowYNWbchElTps2YNWfegkVLSstWrFqzzi8AAAD//wEAAP//qEIsigB4nGxWb0wb9/l/vt87uIJt4GKfz4CNfXfgwzbGf872YWzsAMYYAhhsIMEJ5JeEhCS0+SVMSkWVJduatnmzzlpbteq6rdr6plKntqrULuq7tunY+merNLVrVaJqL1i0/lsZndY/nKc7GweqvvqeTs/3+fN5Ps/n+0ANzAHgMH4YCKiDRtgHDIBEc3QHJ4oCJUuyLLCELCKamkMfKkWERkJkJEIGBj4eWL1yBR26jB/evrP36tLSjYW771Z+unFLCaK3bwEGAgDbcBHqgAYwUpLodIpCbS1hlIyCKFBv2G/Y9zmayEbHBzcXbs4lPk+i/19clO+KRu9SCri4fX5tDQCAgAIAbsdFoKEFBDU3KWg2M6ZaitGOWoGQgpFwyCkI9M5H4dXBk9GAL3YgeX708rHp0fHxkyszC/OzK7joSPcGso2kbiK1f9aNVnuDUf/2VnKgLwoACEKlLdyKnwAbQA3vdIZDkYgUNLOU0ynwtbWMyWyWghGZra1FudyPD4xdzcePWL0tA+7EvBQ8nPCN2rvF4/qpx5bPPpYLOCJWvv9iLrc60MmHvEHNfwEA3cRF0GkYMxwjMQLDMQV0j/L+V1+hAC6m3x7+bLhq+1cNv9u2tGb59de4mL6ZVj7YsYPf4aKKt0RLdCGvglf+j5O4CPryfwlJlFEgKKaQJxC98Nan869dwEXlJTTytXIWzdz3l52Yb+Ii1JTvcEwhj+y4uP2SmlLF5w9xUcVHoiWj2cxKkYhslGiBDkVkgSIEQhTMZoYuLF7Ws3pSz+gvnZy4gyBDl+RLIZKgcFH5DT/E80M8Wtg+j850LXseUZ5B0494lruUR6sxvLgIxnIMVnI6w7REVz3PfjpMElR29rNhklT9LV4LLodQfvs8+uUDgdMh5WnAWh9P4ieg8Tud1AgjBiMaTXitoWgsd2V4+EoufzmTuZyPHfSfPXTorP+QfvrxM2cenZp69MyZx6dHBldz9zz44D251UEVB6zlqNP6aNrFSEGgb1Pw5dFzifvvvPP4bP7g7AIuts9klhaVb1GmPz0sa3W6S1voc/wEeLUMRVnjVjjkdIpiN97LPDVPlm3DavaoaeiiJygclfoztoB9wd7nCi/EYouCt22kWx7kgi3zzr72yKI+3NXb4Y35+U5rg8vgHvAHs15ve8TGhbrsrhZdZ5O3PxCaCQICKwD6FheBUisRwhwj0H9/HX30Oh5Np7df1PpeKgGgdVyERgApTEhspfGyRDCv3ZibabI3kTTfOH3whoJ+fr093dGRbr+unFM0rEKlLfQ82oQWaAdgebUVckgrixK1IhlaUIVBDEbksDZkr/RN/ewXtKfTPWpz8Cd65yZTFMFPmYWEsHosqB/pn5yh7T2CwxQ1u+46rLzba3UP8PYHGuM+VwdgyJW20Dd4DYzgKCMrUAItMVQ5Vrn/5farCoJc/IiDoAZymMt2Hj0eO5qOZ2ND9v2CI6nnbEG89sohm3j/hfzFxNBSYfIE7yhZ2fIsdJe20LNoU8Xv+7ViRyr27T8d719O+Iea3YzP1jUk5gf5XnM7N6mPr0zmVuI8GzFafDM9+SWbSbZxKma+0hZ6f6eGMmaaczEs7YAlh6uB/nv4XOyY7E44yHyKIqxjzfvj9mibmHSm9fetZn+QaGvJv7zdE7W6hgYVK+vL9xw8AVjL/09oEyxg31OBKq1cVegIToMKsf1nE8lFef4kwsrvaw6mhVirzZ59A5HJqDSl71vJTq4kLp02NNeNH2HoiKkNOUfHs5p+e0sO9AnahAD0wXiVAWHnrkOrTWKEiqDzYhm/Sr+I4O1xNVbGi3eWbf4zd97J7WvmjRYxOB0wtRueXqRZ/2RQ5A37OgILMzPxc2PuvrjHE++LpKcl33QD19RiOfBRKmmPmkldp9XebSBNKU94wk3VJJvC9tCYi9a1mtg2uc875kPPJ8PheDwcTirX+px8C0ka3YzYrfU/B4Dew2sVBdjhl6qEGrfoXI4QxoPjw7kuf0esA6+9ssj5js0rbyJXKuHsUJ6EUgmGAOAF/CJ2ghsAasFzCaq+N/BaVbuNqnaLFJObIv58+LfXCw8exmtKG4JXlfV/nv1R5U5pC/6G19QZVTGmJbpKwae7XbmGOpKidHeY9dEwPrX9sJFGKEGS5Vj4C7QJnBZLnWu1G3uqoapnLkURjjFPT7LROdF1YCTX1R1J5bp8kRTaSAu+QJcrtFPiAeXJyrGDFdqsYFWJsRurFEUIE1WwNGd7sKrw9V9oExqh9Xs1vcoR1BhbSiaXYvFTyeSpeHJ8PJmYmKjMWnwlN7kSTy3lp0+fns4vgaYXEvoGbVZm7XZ2GhOdIssYd+uFmimX9Swcjx3t4Qd5fLcmF8l2LvEWfqHH2vnAhdzFRFvLzFOo9jt6oWKwgDbVbaiKQUUtygA0Z1w2tklvarQPNqONQ92R+gxJBhPKWvm+tbSF7kWbKlPYve+F9lx857UoPxbvhBYElyPl8fs5qZUfcM9lvRPWzuaIo9vT5m8VUl5XVi9a5WbOa2/m2XoDF3bFsg42ZLS4rayN0Rk4uVsc6NTiW0pbaAifA7bCLyEsy5K2lFR59vFEX2asfujeezm3oU3fZPLpCxlkSNRcuzaobHoDdWSC0mm+DpS20NtoQ+XDHq7SFXn7aDyT9/idMV7FhR/TH5tHIeW9VEL0oDmlZazTD0idDfQHtAEGAInYtYsQLz87c0TH6kgdW39k6hm0oXzSnhGETDsyKS2AoAEAPYc2oBlAksVdbxnFCpUdlaIafv3QXL/OYiB1Zl1s9qFfzQ0bWhpIg0U/oNxaNrpNJrdx+YsvL5i7GMbDXtBq0pd8Wj6tu/sjy3tSa8CFJpu+6Q5TnSvSqHt15oSuWUfqTPUHJ1+ifUPv1JL9uCbmbUf/UP5tz/BcxoEM25v+MW/Z/0/QrdJ1dc9jwxyjRx9elmVt7idRHf5QxYEtiyqrSSP7biKdTki90WjvcyfXr169uWg5ur6ysn4UEDhLk7BeuSNq25CaL2OqndPspUQ6/VzF2rJ48+rVdUBQX/o/NIVf1+IjCdUjXVz58kni1LePV/kNT6GNnT00l0MbKt6lP+JRkPGL6s5La9pfHi6L3W6x2O141NZsaWuzNNvgfwAAAP//AQAA//9H9rVvAAABAAAAAguFbxGdOV8PPPUAAwPoAAAAANhdoKEAAAAA3WYvNv46/tsIbwPIAAAAAwACAAAAAAAAAAEAAAPY/u8AAAiY/jr+OghvAAEAAAAAAAAAAAAAAAAAAAAseJwcyqFKxXAYxuHf+y4IMrTJwpCBIKi4lWERk5g0fc1P8HZMdrv3YZ7ZYDEb9YTDWPsfWHrK41cemcAdlR9IXzP6kNQfqT3St6R+SX+TfiH9xugr0kecu6HVTylaGH1GaKL3BYM29Fq4dEcwc6d/gkJUN4RPCB+vL/RE6J1WQeOOe31R64OD1S21BkIDp3pmn5mA8rkDAAD//wEAAP//7e8jLQAAAAAsACwAUACGALYAzADgAOwBBgEWAUgBagGaAbwCAAISAjACaAKcAsoC/AMwA5wDvgPKA+QEAAQyBFQEgAS0BNQFFAU6BVwFeAWkBdQF4AX6BhQGJAYwBkYAAAABAAAALACMAAwAZgAHAAEAAAAAAAAAAAAAAAAABAADeJyclN1OG1cUhT8H221UNRcVisgNOpdtlYzdCKIErkwJilWEU4/TH6mqNHjGP2I8M/IMUKo+QK/7Fn2LXPU5+hBVr6uzvA02qhSBELDOnL33WWevtQ+wyb9sUKs/BP5q/mC4xnZzz/ADHjWfGt7guPG34fpKTIO48ZvhJl82+oY/4n39D8Mfs1P/2fBDtupHhj/heX3T8Kcbjn8MP2KH9wtcg5f8brjGFoXhB2zyk+ENHmM1a3Ue0zbc4DO2DTfZBgZMqUiZkjHGMWLKmHPmJJSEJMyZMiIhxtGlQ0qlrxmRkGP8v18jQirmRKo4ocKREpISUTKxir8qK+etThxpNbe9DhUTIk6VcUZEhiNnTE5GwpnqVFQU7NGiRclQfAsqSgJKpqQE5MwZ06LHEccMmDClxHGkSp5ZSM6Iiksine8swndmSEJGaazOyYjF04lfouwuxzh6FIpdrXy8VuEpju+U7bnliv2KQL9uhdn6uUs2ERfqZ6qupNq5lIIT7fpzO3wrXLGHu1d/1pl8uEex/leqfMq59I+lVCYmGc5t0SGUg0L3BMeB1l1CdeR7ugx4Q493DLTu0KdPhxMGdHmt3B59HF/T44RDZXSFF3tHcswJP+L4hq5ifO3E+rNQLOEXCnN3KY5z3WNGoZ575oHumuiGd1fYz1C+5o5SOUPNkY900i/TnEWMzRWFGM7Uy6U3SutfbI6Y6S5e25t9Pw0XNnvLKb4i1wx7ty44eeUWjD6kanDLM5f6CYiIyTlVxJCcGS0qrsT7LRHnpDgO1b03mpKKznWOP+dKLkmYiUGXTHXmFPobmW9C4z5c872ztyRWvmd6dn2r+5zi1Ksbjd6pe8u90LqcrCjQMlXzFTcNxTUz7yeaqVX+oXJLvW45z+iTSPVUN7j9DjwnoM0Ou+wz0TlD7VzYG9HWO9HmFfvqwRmJokZydWIVdgl4wS67vOLFWs0OhxzQY/8OHBdZPQ54fWtnXadlFWd1/hSbtvg6nl2vXt5br8/v4MsvNFE3L2Nf2vhuX1i1G/+fEDHzXNzW6p3cE4L/AAAA//8BAAD//wdbTDAAeJxiYGYAg//nGIwYsAAAAAAA//8BAAD//y8BAgMAAAA=");
+}
+@font-face {
+	font-family: d2-3229218106-font-semibold;
+	src: url("data:application/font-woff;base64,d09GRgABAAAAABAMAAoAAAAAGGgAAguFAAAAAAAAAAAAAAAAAAAAAAAAAABPUy8yAAAA9AAAAGAAAABgXqrWeWNtYXAAAAFUAAAAtwAAAPAEpAX+Z2x5ZgAAAgwAAAkKAAAMVJ7jlcBoZWFkAAALGAAAADYAAAA2FnoA72hoZWEAAAtQAAAAJAAAACQKgQXsaG10eAAAC3QAAACrAAAAsFPzCIhsb2NhAAAMIAAAAFoAAABaSBJFWG1heHAAAAx8AAAAIAAAACAARAD2bmFtZQAADJwAAANOAAAIcCYSZQ5wb3N0AAAP7AAAAB0AAAAg/9EAMgADAhoCWAAFAAACigJYAAAASwKKAlgAAAFeADIBJgAAAgsGAwMEAwICBGAAAvcAAAADAAAAAAAAAABBREJPAAAAIP//Au7/BgAAA9gBESAAAZ8AAAAAAesClAAAACAAA3icfM05SmsBAIXhLy/3OcZ5nq9zUmUNIgrBRtDGSixExEYsRPfk1FmIopXrEFyFzRHuAjzNaT74UVNXQ0PhG6VSUX1L27ZdHfsOHTl26tyla7dJJZratuzo2HNQiRNnLly5SfKV5Ccfec9bXvOS53zmKY95yH3uqubfq9nU1PJPXeG/Lt169OrTr2HAoCHDNowYNWbchElTps2YNWfegkVLSstWrFqzzi8AAAD//wEAAP//qEIsigB4nIxWW3Ab5dl+v2/X2tiWDxtptci2VpJX2pWjRJJ3Ja0VR4p8tuSzZZvEcWJjQgAHnMQyZDiEn59QJgMzGugwAVIuuEuZTmdKLtJhWqbBpS3tMO2EkjIEyAUdpg3q0DK4mHbwbmcPSuxe9UZrS9++h+d9nud7oQqmAPAwfhEIqIYG2AkMgEz76aAsijylyIrCs4QiIpqaQt+qF97viJDRKBmJvd3+6IkTqLCMX9x8YOi+o0dvHDl4UD3/h6vqAnrtKgDWVAAcwyWoBhrAQcmiIIi8zUY4ZAcv8tRH7EW20VNP1nnK185de1T+REZz4+Px5aTyoHoSlzZX3ngDAICAghWHhibg9dpkyeVinDaKMR42npClZCIu8Dxd+aNwtff+dCycHOhaGVwu9Gay2enFwdHh/CIucQP7IhMNpH2ku2umDT0p7YqFVCGhxKMAgKBdW8cCvgAtAFWtgpCIJ5Oy5GIpQeBbbTbG6ZKlpMLabOjA5DNjE+cmMwvejDstJArRxcndvS2Z0L320ZceOP7KhOQfavKmlvIn/y/I5SLteuwCAPoLLkGtgS/jZ2SGZ/xMAT2rflEuIx8uLV5cfHsRKmdvGNjdPksX0HPqzS+/xKXFNxfVv1fOwW9wCQgDF7qwqgNnfo9ncAns5veyQ6YcPEExhVXi5v//tvzkG0dwSf0QtWnqKRR/6Be3cn6IS1BlvuNnCquoEZc2P9BLsmKexyXwGr87XC5WTiYVh0zzdDyZVHiK4AmR5zBDF86u1jI1ZK2z5tTTx6sogkwc73sgThJUFS6pV7xdPl+XF2U3V1DYm8tzL6vXkfAyl8951WuVPGlcAoeZh5UFIUHLtB7c5WLowun3ekiy9oT5wCX1+eekhxXUsrmCTj4XX1HUzwAbc1zBF6ABmrdN0iCMaLKkVZ8nmph+Kpd7anpG/5wZmZsbGZmbsxdeWVo6Pz5+fmnplcI9Z5eXz5xZXj4LgI3aOANX5xYm2nieoWXJpN7vcyvd3ScHjkw/P5SbwCXhwPDgkcg/0MjpTNTEUdDW0Sa+AGGjMlFxuUzaimIEbycc43S5WNZMgXZ2Pxbt5Wf3dOxN7Z71pcXU3dnUktDp7dsVSXlizQf35jvut0uRMX9bRGgLOMT63b2xeKF9j5Bv4toCbj9bG3RPDCQOJPQamgDwDlwCSu+CT/gZnv7wLfTlW3j34uLmB0ad2ncA6F+4BA0AcoKQWWvgikwwV955fKC+pZFs5OoHHvnV1+gHF4N9gtAXvKje8zXoOEW1dfRLtAFuXbFsqw6/YrREiUaDDM3rXiBKSSVh6OpKduLZl5AoBfr8u9ru3Tt3aH4H6R+iuPaWo6Mh+3h27M5GMdXiHGkSHrxX/TTZIsx63Mt1ctDPGfly2jquxmuwEzgdVZGneFpmKDPXlpHrnoGU/ixRc6hIePPBuWP75sfau6WOeEeTbM/G8drlyebWc6emTu+fnynkJ5XPXQ4drzZtHV1GG//FpttjqtiCq+f4/t5TXdH+5g5HiO0cyu31yEy0dcqeLk5MFtM+doh2zOZzs256mOMAQ1hbR2W8Bg5dVSZORmAxIVcQUhKVJP+cW+5cSOzqbCGL8zvI5kG7EnNL7mjPXvu5R8ZXMx732KXNTKJZmFc+Z3dOj4xNgYGNXvuf0AbcoefYrgXK76qUTsiGJFBz73K2675Uz2ykSn13x2inT2kW+ZlL1yUp3KN3Mb6a6by/L+DsGnTQgyyHYqmu/aZPhzQR/RttgAQZGDa6ERJxvXp9+InboMkMb6mmVRBNU7WmRGwRpsOy8lZR/2997+FEv8PtZ9xi8qDsDDb8ZNbeKE3FG1vp2jp+z50HD2UfzvNSeyAgSbHO/J5dPaFmofejllQ4vZu0hzhPtIF09IZTo21U1XR9uCk5JNioGifN3JHKxsYi6K14NCJL0WhcLcW8HiflCfiD+txzAOhveM1Se4VQuuMZZKZzRdI7LI0NFgNtvnYvXrs879lz7LD6HgqmJS+nvg6aBhkAeBe/gwXYBQAUhOEsWLExxmu3PFrRPVqkmNwp4vITP3zzzBMjeE0d+Oxd9dNrB87o57V1+Aav6XrUmULL9C3evZmWi43VJEU11Hjt+Szu3bzM0AjNkDYzD7EDbYDfyKNrWJ/Ctk6oW8/c/A7Sm4sku2h+JDKaXw0KkVQxKEZSqNzjj0TbBKnSXlp93XpUcEIbFk5Wjq046XIevQUUKnf7Ittwsnj6Hdr4Hzx7Z3qpu3spndE/M8lMJplMpy2FpYuTE8X0kdlcflbXmekNGVyNNiyN3a7OYiDLOLaYg9H/SGjunn3zii/LEXeb5tAsreEfx5uEcytTpzMe9+QFxNy2B6v/02hD33Ru9W+5g9l8U17kGWedq9GTZVH5zphcc5Qk93SoptfCHdo6egFtQMiY7e07QTDvhG1ew3KYcdrel44Gkv7uYEjwxpp8+0MLk/FJLtGU8AQD+0Kt2fCiXfTk3Vyrm2lmauy80tY1GWD7HayX9XD1dr4jsv8gIHBq62gWnwKXyakEn1AU2VhMnBa1vpke6B+uXzhzpq+upcbplO13j30xU/XMM4e+mKHIaarWrL9XW0d/RmV9/tu4SVs29rE++ZCvvaV4pJrwDduPHUZx9eO05AugcZUZFCKAdB0YMeoA5G3XzU9/9NBojb5PMDWjJy6ishbIC0I+oKmMkbseAP0RlcENIDvELS9SLG/tnBRV/+r3H1dq2Vqy2lkdPf3Cq4/vs7vryBpXbRxB+bAz7HSGnYe//fou126GCbN36XHtWtKop2nrTBRlW2k225KTq2coR7UYtVe//dB0LVNLVjuq8ycueQ/8zkbO4qpo0Is+/8o3wLcO+L/a1ApW7MfQX7Ur+t7GJvyMHX3yvb4+QDCijSI3vqFjwJrGyRoOyV7N9PdnBjuSyY5Lx248/fSNY76F68vL1xcAQVgbhQ3rHTFpbBKKIZqicX4w099/yTrtM9418i+gHvxrI79DJuw3R2++Rhz77oLFZfg5Kld2ylwRlVUGkPYz3AV9+B19f6WNm8oUkVcQvF5BwF0BzhMIeLgA/AcAAP//AQAA//8l36/uAAAAAQAAAAILhdrjxLdfDzz1AAMD6AAAAADYXaCrAAAAANheETP+OP7PCG4D3QAAAAMAAgAAAAAAAAABAAAD2P7vAAAImP44/jgIbgABAAAAAAAAAAAAAAAAAAAALHicHMqxScQAGEfx9/8rQSRoYyHpFBRDJBq0FosgfIjVp+AKDuAejiAu4AAuYOUOllY2d9fckRyX6sHj53ce+Qa34+An0rd0rkgNpCpy87Qg/Uf6jfQHne9IH3HqYyrNx5W3ufAVoR9qX9NoSe0dztwSKrjxLqF9Yuue8CXhk8mFXgl9cqgXDnxOr39K/bI3dUapngf1NHqmVEHA+LUGAAD//wEAAP//DKoguAAAAAAsACwAUACGALQAygDeAOoBBAEUAUgBagGWAbgB+gIMAioCYgKSAr4C8AMkA44DsAO8A9QD8AQiBEQEcASiBMIE/gUiBUQFYAWMBboFxgXgBfoGCAYUBioAAAABAAAALACOAAwAZAAHAAEAAAAAAAAAAAAAAAAABAADeJyclEFvG0UcxX9rpzYVIioIRamEqjmC1K6TKKna5oJDGtUisoM3BXHcxGt7FXvX2l0nhI/BR+DGF+DMqR+BA0c+AAcOnNG8mcR1QJBGlZq3npk37//+b/7AWrBKnWDlPvAGPA7Y4I3HNVb5y+M63WDF45W39txjEPQ9bvA4+NnjJr8Ev3v8Htu1Hz2+z3rtV4/fZ6v2h8cf1E3deLzKduNzjx/wqFF5/CEPGj84HMCzhucMAtYbv3lc4+PGnx7XWWs2PF5hrfmJx/f4qLnlcYNHzX1+wrDFBptsYHhy/fUMQ5sBOSckGCIuKalImFJi6JBxSk7BTP/HWhtg+JQxFRUzXtCixYX+hcTXbKFOTmnxGY8xXJBSMcbQJ6EkoeDcsx2Qk1Fh6BIztVrMOhE5cwpOScxDwre/pTUmk8ojCnL9YnWnnJAzYaB7RsyZEFOwRcgG2+ywS5t99uixu8R5xej4nvyDz53rscdLvpb+klTKzRL7mJxK1WecY9jUWij3n7PLlJgzEu0akvCd6rEMO4Q8ZYcdnvP0nbQte5PKlxhDpa4NtNu6cIYhZ3jnvqeq1vbRnntNpq66tYjK73S3Zwxo6bxRrWN5ZsQ8V78LUu0O76TmiFjdNewTYnjlWW+fzIpLZiQcM/aeLZIYyaeKC/m2cHVCKpczZdjWPVelrrYrZyI6HGLoiT9bYj5cYrBv42aaNpUWW9NC2fK9ix6fE5Mq4ydMtLJ4abHubfOVcMULzA13Sk7VhRmV+lCKK5TPI1r0OODwhpL/92igv66/J8yvE+Kqs8mw77tNpO5G5iGGPX13iOTIN3Q45hU9XnOs7zZ9+rTpckyHlzrbo4/hC3p02deJjrBbO1DKu3yL4Us62mO5E++P65h9fzOpL6Xd5TVlykyeW+Whny7JnTpsGHrWq7OlzpySMtROo/5lmlYxI5+KmRRO5eVVNhYvyyViqlpsbxfrI3JN1kKv07IaLv18sGl1mtwUqG7R1fBOmfnvaX1zfh3ppqFUFz4tbamzuY4pOXO5IVd9GQlnlERyrpSv9sz3Ysg1iwq9jJHUW7faTJRE64ubIdbLf/t1JH2F+uN4bbas05NrR4finrvk/A0AAP//AQAA///ZL1xfAAB4nGJgZgCD/+cYjBiwAAAAAAD//wEAAP//LwECAwAAAA==");
+}
+.d2-3229218106 .text-bold {
+	font-family: "d2-3229218106-font-bold";
+}
+@font-face {
+	font-family: d2-3229218106-font-bold;
+	src: url("data:application/font-woff;base64,d09GRgABAAAAAA/8AAoAAAAAGBgAAguFAAAAAAAAAAAAAAAAAAAAAAAAAABPUy8yAAAA9AAAAGAAAABgXxHXrmNtYXAAAAFUAAAAtwAAAPAEpAX+Z2x5ZgAAAgwAAAkhAAAMSELJZeNoZWFkAAALMAAAADYAAAA2G38e1GhoZWEAAAtoAAAAJAAAACQKfwXraG10eAAAC4wAAACqAAAAsFZFB7Rsb2NhAAAMOAAAAFoAAABaR4pEzm1heHAAAAyUAAAAIAAAACAARAD3bmFtZQAADLQAAAMoAAAIKgjwVkFwb3N0AAAP3AAAAB0AAAAg/9EAMgADAioCvAAFAAACigJYAAAASwKKAlgAAAFeADIBKQAAAgsHAwMEAwICBGAAAvcAAAADAAAAAAAAAABBREJPACAAIP//Au7/BgAAA9gBESAAAZ8AAAAAAfAClAAAACAAA3icfM05SmsBAIXhLy/3OcZ5nq9zUmUNIgrBRtDGSixExEYsRPfk1FmIopXrEFyFzRHuAjzNaT74UVNXQ0PhG6VSUX1L27ZdHfsOHTl26tyla7dJJZratuzo2HNQiRNnLly5SfKV5Ccfec9bXvOS53zmKY95yH3uqubfq9nU1PJPXeG/Lt169OrTr2HAoCHDNowYNWbchElTps2YNWfegkVLSstWrFqzzi8AAAD//wEAAP//qEIsigB4nIRWa1Ab1xU+92rRGrE8VqvVSkLvi3b1AAFaJPEQCIwE2Eg8bUwaMDaTxomxsWvjhqRM05k66TSRm3TkODhuncek08ck7WQ8nWnT0k4z46ae+J+T+k/ipGkndfOjoRnaSVKx6uxKYJM//YHuzHLvPed85/u+e6ACxgDwPD4POqiEWjACDyCzHtYnSxKh43I8TgRdXEIsPYaNyo9elgJUIEAF3auuR+bmUPYgPr957N7s/Px/5rq6lMu/fl05h06/DoCLXwDgfpyDSmABOFqWRFEier2OkzkiEfqjuidrq+urKcb6xfXXrv/A/6Yf7U0kWhfltuPKYzi3uXTpEgCADrIAOIFzwIINvGpucsRs5k16mtcWPdHJkVi0TSSElSPamn0/day3yR/pT50anEvHWiNtA5MPJ7oncc4xkAxN1lLVw339+wLoO0EiupXp6ZAPAEG4uIFb8CrUA1R4RTHaFovJEbNAiyLx6vW8ySxHYnFBj2Ynnpjcf24ieZ9nxBonjXtCU0P+pGVkgsk8c/zYxXHZe1BwRA7uvu9kg3XmECA1f/QJzkGVhivv4WWe8B4+i1aV/966hWpxbuXb37iwAlDee1vD7K69WXRJ+ezDD3Fu5dmVTdjaBx/gHOg0PNhsXgWs9B0fwzlgSt9lTtZxREfz2Tz1xktX//Hi8xmcU/6NqpSCsoy4+36xFfNDnIOK0hkPn80jjHOb6yvbsfCrOAcu7f+c2SzIsVick1miQhQnNE0kiTgxz2dffNBgNFAG1nDkhcfpSh0VnR2fbaOoXTTOKbfsPU5njx15N5c+cY+OuS59/vkl19io+5OtGBmcA64UQ5BFMRqVWaKTiNnM89lnf9ZLUTU5damoxjnlt0+3favzo80llP5ebKXz7wCAtf59E69C7Zc6qJFEKlHEq/YRTU0/Njz82HTpt39kpL9/ZISZuHh04ZnR0QtHj16ceHRpfn5xcX5+Sb1Xza1Fw9R0F/v0hPDbfPtg6MzAwFJ6fGi5N5HCOWlmNDPf/B6aeEAOljAkxQ1swKsQ1DKT4mZzibOSFMY7icabzIJQioBMvY9G9pEpf7hJDu33JMSuB1PtJ4PD7l5JbOoI7usa6FxkWsJfdYpeh8thbKhpHmiOTbc1Bmet9S6708l6LfvSsZl2QGAFwBzOAa1WQKIenrDXr6AvruC6lZXNdS3H4mcAmMc5qAWQozpZKDc6Luv4tauXO2ts1VSNvbrruau30csXfGlRTPsuKDO3NeyDxQ30NiqAFQiA4FWhj2vl0JJWHM8SVfvxSCwe1bT0u9TY2TwmAVdvQ7R5oXPu/mUD5RrcZfVxIwkXcyA5Ml3rkSz8YUfD4inlb7KdnBK4A4aQwyJo8fqKG9iM18CkslJFlNCElXn6Sw0nXtUkUNrT76CY03nKkfImppsTc9NibKoxYPIzHncUr72SsTl6vpbZ/3ByeSDzeNNbxhqtZw3FDbSGCmD7sh+UulRyAz2ypk/0DX09FR60p4k7mky2WMJcp2+K6T4zMbnU7RTmHJm+3ixfe8hdD1ruUnEDFfAacODewkq7WFIJv43SFhk+nTnRNdcWaLfq88sGyjaALZKRC5lIrJl58uHxMz12S+anm/2tNrJssr5lrOkf3JMGrOX+F1QASxmfu7VAe1T2qbnrZE0SyDV4anf/sa7B2WYKKzcNA63RWKt48LkrUqM3xvQsTYwvJZMLKc5XGZM999icqDMQbS55s7fYhGlUgGbogr1aNWK0TU1eJUB0K6wg86QsGq+kYadSwqTX6+5SJVc2ca+obfm082D7IFfvttgCnQejjZ5fjtKVbdNxh8voDYzNHE6t7HVIksMhSYFIr+STrR6mvvuGrb0x4aeq/a76SB1lTIUSo35mocpr6tjbYKg1c8aufnk8jK4FA1LA7w8ElXyDVajT6SxWu6Ok0z61QRqvVKWX+cSzhNWypNm+PG0fjozvyTvcdr8Fr71yjzW0MKtcR56Y3yoor0GxCHEAeA/fwKKqdqAhBE9s3+3Ea9veHJdpjkg03/cU9cMXfv6b508m8ZqyePW68u4fBh9R9xc3kBGvqXpUWcLK7Dbp/pTpyrOVFbTeyPiYe4cx2bwpGBE6XkGX4ugcqAAeLY6qYZVdOyqht9c+VXcDrdE+zrO3dWw473D7WtSfZrTe62oK+b2tW+W1KK+Vly2cUKGMUznG3TgtGyh3dhsotJ50Nu3AqcRRjTv/36/NyROp1IlkcjGVWkw2hcNN4aamsr66lyYnznQ/lO3ty6gyK3nDEDajAnDgBBDuZKfRT5QEnrtjDWqejj3SVx5IzMXcCVvFqBibCgVN/l/hn7TayHdP719O1ltHv48ato1Bqx09hQpg3IFvyb1LlddnRN5usFRb6+zdJrR+INJaUfEoRQUiygeAgC9uoOdRASStr3feArH0Fmxfpr4ETsyb9Ddaj4i7vUmXx+kI25xd/gf3dxxw7ba12To6RHd34AFGdM1Y6wWONXMGpqEjkJ6SLNMms2Sx1lSRjnD/bInbbHEDLeIlEDS0o1ESjcdlbcC4Y2YwM5rKsI889BBxMFaDwMWZo1PXjuvPnj39ZtCnpxb0TOmuRHEDfYbW1f7v4CZbtrA/j+/JO9120ZxfrtK59jILs6hNeT8asDnQkFKX9jUCUnWAimgdqgHkHc/NlR+f7zVwBqqSM/Sdewmtf+zLSlLW97FSp8VWm7CB1tU3Teakuw7SAinPmDRds/rU5UaD2UDtMu7yrj598XILIzBUpalSQvifY3yI50P8WPFfE3wjz4fME+q9TLEHbaJ1lY13+hKP70itBi+bPbU22rjL5zfQvz8/WGU0ULvYysS5V4T20Tf01ElU0eCwob++4x3wkUHyjlLVs788AzDFJXS7+KY6swlRD8+gd3OTk4BgqJhFfvy+ioNQMk5BeyKF68l0OjkTj0TiV47cOnv21hHx8M2FozfnAUFLMYvqymekmDZJxDXh5GbaI5H2mWQ6fUWcv3l04eZhUTsLCKqLh1AM/1GLz8m66muHrr2gu7/wXJnT8DZa35on+/JoXakDVHwVd8AkvqHOrqz2UpWE5AuHfb5wGHcECQmqf/A/AAAA//8BAAD//xreoXUAAAAAAQAAAAILhb70B31fDzz1AAED6AAAAADYXaCEAAAAAN1mLzb+N/7ECG0D8QABAAMAAgAAAAAAAAABAAAD2P7vAAAImP43/jcIbQABAAAAAAAAAAAAAAAAAAAALHicHMoxSsNwFMfx7/sJAfEfRYiCi4P+QdAY3BRMhreIywNBhzh07TV6g+69Q7t07QW69yodSpYUun+05octqBsHTQh90SgTSoS9EpoSKggNhBaEljT6I1TzqJo7leNBVzyrw21HVseTCrJuedAnbhXvyrjd42f/uFpcLyfnNsdtw43NuNYHrS5IEpc6J9meZD3f1vNmv5RW4TCujgAAAP//AQAA//9Cfhs9AAAAAAAsACwAUACEALAAxgDaAOYBAAEQAUIBZAGQAbIB8gIEAiICWgKMArgC6gMeA4YDqAO0A8wD6AQaBDwEaASYBLgE9AUaBTwFWAWEBbQFwAXaBfQGAgYOBiQAAAABAAAALACQAAwAYwAHAAEAAAAAAAAAAAAAAAAABAADeJyclM9uG1UUxn9ObNMKwQJFVbqJ7oJFkejYVEnVNiuH1IpFFAePC0JCSBPP+I8ynhl5Jg7hCVjzFrxFVzwEz4FYo/l87NgF0SaKknx37vnznXO+c4Ed/mabSvUh8Ec9MVxhr35ueIsH9RPD27TrW4arPKn9abhGWJsbrvN5rWf4I95WfzP8gP3qT4YfslttG/6YZ9Udw59sO/4y/Cn7vF3gCrzgV8MVdskMb7HDj4a3eYTFrFR5RNNwjc/YM1xnD+gzoSBmQsIIx5AJI66YEZHjEzFjwpCIEEeHFjGFviYEQo7Rf34N8CmYESjimAJHjE9MQM7YIv4ir5RzZRzqNLO7FgVjAi7kcUlAgiNlREpCxKXiFBRkvKJBg5yB+GYU5HjkTIjxSJkxokGXNqf0GTMhx9FWpJKZT8qQgmsC5XdmUXZmQERCbqyuSAjF04lfJO8Opzi6ZLJdj3y6EeFLHN/Ju+SWyvYrPP26NWabeZdsAubqZ6yuxLq51gTHui3ztvhWuOAV7l792WTy/h6F+l8o8gVXmn+oSSVikuDcLi18Kch3j3Ec6dzBV0e+p0OfE7q8oa9zix49WpzRp8Nr+Xbp4fiaLmccy6MjvLhrSzFn/IDjGzqyKWNH1p/FxCJ+JjN15+I4Ux1TMvW8ZO6p1kgV3n3C5Q6lG+rI5TPQHpWWTvNLtGcBI1NFJoZT9XKpjdz6F5oipqqlnO3tfbkNc9u95RbfkGqHS7UuOJWTWzB631S9dzRzrR+PgJCUC1kMSJnSoOBGvM8JuCLGcazunWhLClornzLPjVQSMRWDDonizMj0NzDd+MZ9sKF7Z29JKP+S6eWqqvtkcerV7YzeqHvLO9+6HK1NoGFTTdfUNBDXxLQfaafW+fvyzfW6pTzliJSY8F8vwDM8muxzwCFjZRjoZm6vQ1MvRJOXHKr6SyJZDaXnyCIc4PGcAw54yfN3+rhk4oyLW3FZz93imCO6HH5QFQv7Lke8Xn37/6y/i2lTtTierk4v7j3FJ3dQ6xfas9v3sqeJlZOYW7TbrTgjYFpycbvrNbnHeP8AAAD//wEAAP//9LdPUXicYmBmAIP/5xiMGLAAAAAAAP//AQAA//8vAQIDAAAA");
+}
+.d2-3229218106 .text-italic {
+	font-family: "d2-3229218106-font-italic";
+}
+@font-face {
+	font-family: d2-3229218106-font-italic;
+	src: url("data:application/font-woff;base64,d09GRgABAAAAABA4AAoAAAAAGPAAARhRAAAAAAAAAAAAAAAAAAAAAAAAAABPUy8yAAAA9AAAAGAAAABgW1SVeGNtYXAAAAFUAAAAtwAAAPAEpAX+Z2x5ZgAAAgwAAAldAAANGDIBFvxoZWFkAAALbAAAADYAAAA2G7Ur2mhoZWEAAAukAAAAJAAAACQLeAjQaG10eAAAC8gAAACrAAAAsE7fBGZsb2NhAAAMdAAAAFoAAABaS7JItG1heHAAAAzQAAAAIAAAACAARAD2bmFtZQAADPAAAAMmAAAIMgntVzNwb3N0AAAQGAAAACAAAAAg/8YAMgADAeEBkAAFAAACigJY//EASwKKAlgARAFeADIBIwAAAgsFAwMEAwkCBCAAAHcAAAADAAAAAAAAAABBREJPAAEAIP//Au7/BgAAA9gBESAAAZMAAAAAAeYClAAAACAAA3icfM05SmsBAIXhLy/3OcZ5nq9zUmUNIgrBRtDGSixExEYsRPfk1FmIopXrEFyFzRHuAjzNaT74UVNXQ0PhG6VSUX1L27ZdHfsOHTl26tyla7dJJZratuzo2HNQiRNnLly5SfKV5Ccfec9bXvOS53zmKY95yH3uqubfq9nU1PJPXeG/Lt169OrTr2HAoCHDNowYNWbchElTps2YNWfegkVLSstWrFqzzi8AAAD//wEAAP//qEIsigB4nHxWfUwb5/1/nueOOyDGYJ9fsAMY+85nMGcb7mwfxthgjDEYm7cEwi/BQPJraEJohZLStUuyrmWK2r1kbpVtWtW1VbtNm/rHqlSa1q1rtXaaaLtI29Ru3Vpp2tqSKlnXBrGqrcrd9JwNGP7YP+eTfM/35fP9fD7fB1QADgB0J7oCCFAFaoERmAGQGCdBSLLMWgnJ42FpWvYwDM09ANceeJRMHn2/5cnPBAeZvv+nw/+afwZd2VqCX83fd59y7MGTJ4/cvKl44Z9vAgAAUl8HAL6JCqAKGABgaMnD8x6WoiCUGNbD0u92vVJNVpOkXVJ+D287mh03fnAa3ru8HFzsjNyujKPC1vK1awAQgAUANaMCMAA7fpcYSbSYTRRF0xbtlyUkMRwK8uzuC7v6s7mltiQHpYH0hZGu2dmjqcyxM2dn78wN3YUKmbTQL1SSukTnUF6Ad6dln7h1I5UVY7huCCLqJvKhx4ADgAoXz4eCcSSJFivN86xLj8wmi0USw7KVoqBr+FS4/ejFbOd4fZgJ811zfZwrE21JNrNcXpe8ZyR35Utp2dva7Inddk93NB9qPig6fFoO3FMdKoADGt60k5ZolnbS7CpcrFHe9d7SfyRBXo8KiTf7Pukr+76q7Hui9LXvVs3H3aiQeK9P+UspNthEBUBoWBHs6sgqBnMn7xFUALrifxKUaIYlaJpdHUkQcGj6k++Mf+UhHyooL8D+L5QleOLSO9vn4COoACqK53ClI3dDUw0qbF3dru8FVAA27X/GKsk4MxMOyyxNsASeO02wq/mIhRx4Jb86nK2y68jR3wgxC0npKzOooDz+4IPwxNYyPCsstj2i/BDOPCKcFpTLpdgLqACY7djhsBZ9J+rId70kpa9ODa/mrrSRVG31ACooMw913CHBma1l+PS3pEVReQJzEnSrm2gWPQbqQLM23dJwLWaTHnnEOMLsKQ4ZOu5c8U+tDGROBv1TdyVDR+KuzAh+Dum+d2G4sJLqP39o+OGVVLL7xErk+Er0xErX/N1aDlyvT5utqYytLEswu/R8fuZs5v7Dp4OJuZOL2cGTqJCZGru9Q/kUpsdGI1KRhzp1EyroMeAFwOriPbLGu1CQ93gwKcPhHVJSlNlksVqLarieXG6JNE7K3eM+d9YbDc1Eo/MOyTbgd4caO7hsIBhd0HV1tbWJ/Z2caPHbh2RxQgy2+JtaHe0H+YDF15CWu44FAQR5AFAIFQCNu2BlJ80SP155sQa+XvPSCsolk1vPFes8BABqQgVQi78jJKvFoo1IliDxDenMmK+qtoqwCvUXDin/DkIAC7/mUrw7zb2gLKsaXh51E34KN4AJI2fdmYlVkiWClVmK8ohhWd5R33O9WSEzK3liBpKJH++pJNlpIz/KCWaxgUuGHB26Y5MD985ILc6YYh90B3r9gb/yLu9QXuzR9I2AQ92EH6M1YMbuh5FlaZaRaFrSIN3DBM1jbnhiBsLUcznnsSDusE9LH+KSoab2Vtc46zdJuhZnDK29ON/YdnQKp+71DuWleMzrvs67AARudRNehRugYU93u5Mruclbo7cJueMhodviY/jG9qlwpKs5bHHZc7qFfP+5yYDL1m419y8n+wbsBtHkBtvYIU9ZL7vY/W/wuoxEHZ8rlNAbce9Hz9M89+JW5374kNbLS3AD2IG7PB9mHu2kdpyRkMKYqbjD96ZO+4Zn2uVEk65C+W1Vc9LbGLE2NY5/X0WEsZUNzeoWj6eWJwT/mNgg6XvG3DaDZHZA94H6moYOxyRAAKoc3IAbwAH85UqQZYpi97KFoog93T7TMcVyDamWeEZv4w8HYmNtQzMdfNxAMD0LzLkIO+5qs3Q0sAmpKfAO3xiyurK9p3hhajJ51/+JmD/E3AJ0tnn/wLtaB6bbo9Ei3x0AwLfQWsnrdnlDa4YXCmLaEI7LufY6snVCiIcq49lukhxsGPSn0NrNGBtIdDo45TUomOprhr1+5SeqimOCz9FVxGO1Awq0De7m+hCt7fg1g/3aQ9OOy7l59Nn0yysj+WU7WlMaIXxdef/Ds+cBBIK6CT5Ha8CI0QoFsVdinpVGc0eCOp+7CKGBoGhYbdH1GGzozNbDdBVhhChKkjt50Q24gavBOYstWkuNUns6LW/6eA9N8of4ro6KwLQ7FibJeC5GkmnzoJDCGAxYBttScH2I65BbBCnRaWgyleOw+7aLM9wA9eU17IcZZ2yd8O9BWcuwH+QdvcC34QaoBY3l/C2KXuNsSZRvjM4KmVlxdE4YnvX6xqWwiB+6U8dS5yb9xWdv33J/Xzq53N83oN13PlEl+DHcKGqRLqtYj1jNZWhmj69Uf72HItyTfk2SIt/NIKPjR+W+cg091+vwlQTpOPUEhCVj4T9wO3f5cQFugLoyjKw0v43NAbIx67OZD9bZuawjBtfzQqyqv7InqlwDUP1C3YQX4Qbw7N8v+9cL3i7F5fJ0R97Wbu3lvbHWTn9EGBL8mQY/Izn5jnBzPNg+oQu28I4WP2v3OOzx1raEm2tqMdl9jibe6OoWfP1uXHO3ugmn0dKOH4Zlhu1BknalKfPD53uDJIykD2S5xMHzuosRosGltx8w1AV0Pb5aew00RiouXYorN4zGpqbqCpmuxbE71U34EVzH2tyOvct+pmSJz+wwc7AxLaSyeIm0HNb1yQYHA8PKG4wNUwZOK/YMW9rFUQDgP+A6qAEAq7C04hgJPpDOciRFkgaO+XZO2YLrynV2mOWGOGhT7NpZ9Q0A4J+KNbGMp2w/0la2dCemaeFvx0a8lXqarG2unTy09v+jQqWhmqxzMbMQvbdk8ZhNreal/9w6a/FbLIL1HI77shqA78J1YAeA1uanmeKe6vSIqm7W24xGd8JmPJTlKyoJ0uA2fjOr/NMWHfwjTUeqYiILrysfOXMsm3VBw9atQE4o1v2O+jX4rPpzfI+kZSfNHYCvVl8QRQ2PhDoGj6C38c63FukiWyntbmz9cr1TPpXxLS5VmfTP9j49sfLqr/K2S8rfH/cvzPMaHuoYuFE66wkb8Z7A5MP8gr7FM1XGWhGHeNZ+CTp/EFiY45nepyZWXvslPvsLdR4+hX6n1QQlOAivdiq5J4mFLx7d0QO4Bte3776O47kTcF0bBARpNAyuoqv4zs1o3Cia2T1ME2s1NbJo2GqxOesttub/AgAA//8BAAD///JpyEsAAAAAAQAAAAEYUeo5AD9fDzz1AAED6AAAAADYXaDMAAAAAN1mLzf+vf7dCB0DyQACAAMAAgAAAAAAAAABAAAD2P7vAAAIQP69/bwIHQPoAML/0QAAAAAAAAAAAAAALHicFMwxLgQBFMbx//dtiUSiWKpXPLPTSLTENgrZAxCdE2g1ruEeKo1yqCRCNY1kGlFrEZnMExf4+YpdnkBTPXtFesGhvkm9kYyk90m9kn4gfUn6mqUXpH5Z18SFXjj1Dq23Cd3ReE6rdxpvIa8RfBIaCH7YmwXhDcIzWs/rS+eEbmrUCUtvcqCOI91Wr64e9VGDkmM11eus7v8dYPUHAAD//wEAAP//DRoqbwAAAAAuAC4AUgCKALwA1ADqAPgBFAEkAVIBeAGqAc4CDgIiAkICegKyAuADGANSA5oDxAPQA+oEDAROBHgEpgTgBP4FOgVoBZQFsgXeBg4GHAY6BlgGaAZ2BowAAAABAAAALACMAAwAZgAHAAEAAAAAAAAAAAAAAAAABAADeJyclNtOG1cUhj8H2216uqhQRG7QvkylZEyjECXhypSgjIpw6nF6kKpKgz0+iPHMyDOYkifodd+ib5GrPkafoup1tX8vgx1FQSAE/Hv2OvxrrX9tYJP/2KBWvwv83ZwbrrHd/NnwHb5oHhneYL/5meE6Dxv/GG4waLw13ORBo2v4E97V/zT8KU/qvxm+y1b90PDnPK5vGv5yw/Gv4a94wrsFrsEz/jBcY4vC8B02+dXwBvewmLU699gx3OBrtg032QZ6TKhImZAxwjFkwogzZiSURCTMmDAkYYAjpE1Kpa8ZsZBj9MGvMREVM2JFHFPhSIlIiSkZW8S38sp5rYxDnWZ216ZiTMyJPE6JyXDkjMjJSDhVnIqKghe0aFHSF9+CipKAkgkpATkzRrTocMgRPcZMKHEcKpJnFpEzpOKcWPmdWfjO9EnIKI3VGRkD8XTil8g75AhHh0K2q5GP1iI8xPGjvD23XLbfEujXrTBbz7tkEzNXP1N1JdXNuSY41q3P2+YH4YoXuFv1Z53J9T0a6H+lyCecaf4DTSoTkwzntmgTSUGRu49jX+eQSB35iZAer+jwhp7Obbp0aXNMj5CX8u3QxfEdHY45kEcovLg7lGKO+QXH94Sy8bET689iYgm/U5i6S3GcqY4phXrumQeqNVGFN5+w36F8TR2lfPraI2/pNL9MexYzMlUUYjhVL5faKK1/A1PEVLX42V7d+22Y2+4tt/iCXDvs1brg5Ce3YHTdVIP3NHOun4CYATknsuiTM6VFxYV4vybmjBTHgbr3SltS0b708XkupJKEqRiEZIozo9Df2HQTGff+mu6dvSUD+Xump5dV3SaLU6+uZvRG3VveRdblZGUCLZtqvqKmvrhmpv1EO7XKP5Jvqdct5xGh4i52+0OvwA7P2WWPsbL0dTO/vPOvhLfYUwdOSWQ1lKZ9DY8J2CXgKbvs8pyn7/VyycYZH7fGZzV/mwP26bB3bTUL2w77vFyL9vHMf4ntjupxPLo8Pbv1NB/cQLXfaN+u3s2uJuenMbdoV9txTMzUc3FbqzW5+wT/AwAA//8BAAD//3KhUUAAAAADAAD/9QAA/84AMgAAAAAAAAAAAAAAAAAAAAAAAAAA");
+}]]></style><style type="text/css"><![CDATA[.shape {
+  shape-rendering: geometricPrecision;
+  stroke-linejoin: round;
+}
+.connection {
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.blend {
+  mix-blend-mode: multiply;
+  opacity: 0.5;
+}
+
+		.d2-3229218106 .fill-N1{fill:#0A0F25;}
+		.d2-3229218106 .fill-N2{fill:#676C7E;}
+		.d2-3229218106 .fill-N3{fill:#9499AB;}
+		.d2-3229218106 .fill-N4{fill:#CFD2DD;}
+		.d2-3229218106 .fill-N5{fill:#DEE1EB;}
+		.d2-3229218106 .fill-N6{fill:#EEF1F8;}
+		.d2-3229218106 .fill-N7{fill:#FFFFFF;}
+		.d2-3229218106 .fill-B1{fill:#0D32B2;}
+		.d2-3229218106 .fill-B2{fill:#0D32B2;}
+		.d2-3229218106 .fill-B3{fill:#E3E9FD;}
+		.d2-3229218106 .fill-B4{fill:#E3E9FD;}
+		.d2-3229218106 .fill-B5{fill:#EDF0FD;}
+		.d2-3229218106 .fill-B6{fill:#F7F8FE;}
+		.d2-3229218106 .fill-AA2{fill:#4A6FF3;}
+		.d2-3229218106 .fill-AA4{fill:#EDF0FD;}
+		.d2-3229218106 .fill-AA5{fill:#F7F8FE;}
+		.d2-3229218106 .fill-AB4{fill:#EDF0FD;}
+		.d2-3229218106 .fill-AB5{fill:#F7F8FE;}
+		.d2-3229218106 .stroke-N1{stroke:#0A0F25;}
+		.d2-3229218106 .stroke-N2{stroke:#676C7E;}
+		.d2-3229218106 .stroke-N3{stroke:#9499AB;}
+		.d2-3229218106 .stroke-N4{stroke:#CFD2DD;}
+		.d2-3229218106 .stroke-N5{stroke:#DEE1EB;}
+		.d2-3229218106 .stroke-N6{stroke:#EEF1F8;}
+		.d2-3229218106 .stroke-N7{stroke:#FFFFFF;}
+		.d2-3229218106 .stroke-B1{stroke:#0D32B2;}
+		.d2-3229218106 .stroke-B2{stroke:#0D32B2;}
+		.d2-3229218106 .stroke-B3{stroke:#E3E9FD;}
+		.d2-3229218106 .stroke-B4{stroke:#E3E9FD;}
+		.d2-3229218106 .stroke-B5{stroke:#EDF0FD;}
+		.d2-3229218106 .stroke-B6{stroke:#F7F8FE;}
+		.d2-3229218106 .stroke-AA2{stroke:#4A6FF3;}
+		.d2-3229218106 .stroke-AA4{stroke:#EDF0FD;}
+		.d2-3229218106 .stroke-AA5{stroke:#F7F8FE;}
+		.d2-3229218106 .stroke-AB4{stroke:#EDF0FD;}
+		.d2-3229218106 .stroke-AB5{stroke:#F7F8FE;}
+		.d2-3229218106 .background-color-N1{background-color:#0A0F25;}
+		.d2-3229218106 .background-color-N2{background-color:#676C7E;}
+		.d2-3229218106 .background-color-N3{background-color:#9499AB;}
+		.d2-3229218106 .background-color-N4{background-color:#CFD2DD;}
+		.d2-3229218106 .background-color-N5{background-color:#DEE1EB;}
+		.d2-3229218106 .background-color-N6{background-color:#EEF1F8;}
+		.d2-3229218106 .background-color-N7{background-color:#FFFFFF;}
+		.d2-3229218106 .background-color-B1{background-color:#0D32B2;}
+		.d2-3229218106 .background-color-B2{background-color:#0D32B2;}
+		.d2-3229218106 .background-color-B3{background-color:#E3E9FD;}
+		.d2-3229218106 .background-color-B4{background-color:#E3E9FD;}
+		.d2-3229218106 .background-color-B5{background-color:#EDF0FD;}
+		.d2-3229218106 .background-color-B6{background-color:#F7F8FE;}
+		.d2-3229218106 .background-color-AA2{background-color:#4A6FF3;}
+		.d2-3229218106 .background-color-AA4{background-color:#EDF0FD;}
+		.d2-3229218106 .background-color-AA5{background-color:#F7F8FE;}
+		.d2-3229218106 .background-color-AB4{background-color:#EDF0FD;}
+		.d2-3229218106 .background-color-AB5{background-color:#F7F8FE;}
+		.d2-3229218106 .color-N1{color:#0A0F25;}
+		.d2-3229218106 .color-N2{color:#676C7E;}
+		.d2-3229218106 .color-N3{color:#9499AB;}
+		.d2-3229218106 .color-N4{color:#CFD2DD;}
+		.d2-3229218106 .color-N5{color:#DEE1EB;}
+		.d2-3229218106 .color-N6{color:#EEF1F8;}
+		.d2-3229218106 .color-N7{color:#FFFFFF;}
+		.d2-3229218106 .color-B1{color:#0D32B2;}
+		.d2-3229218106 .color-B2{color:#0D32B2;}
+		.d2-3229218106 .color-B3{color:#E3E9FD;}
+		.d2-3229218106 .color-B4{color:#E3E9FD;}
+		.d2-3229218106 .color-B5{color:#EDF0FD;}
+		.d2-3229218106 .color-B6{color:#F7F8FE;}
+		.d2-3229218106 .color-AA2{color:#4A6FF3;}
+		.d2-3229218106 .color-AA4{color:#EDF0FD;}
+		.d2-3229218106 .color-AA5{color:#F7F8FE;}
+		.d2-3229218106 .color-AB4{color:#EDF0FD;}
+		.d2-3229218106 .color-AB5{color:#F7F8FE;}.appendix text.text{fill:#0A0F25}.md{--color-fg-default:#0A0F25;--color-fg-muted:#676C7E;--color-fg-subtle:#9499AB;--color-canvas-default:#FFFFFF;--color-canvas-subtle:#EEF1F8;--color-border-default:#0D32B2;--color-border-muted:#0D32B2;--color-neutral-muted:#EEF1F8;--color-accent-fg:#0D32B2;--color-accent-emphasis:#0D32B2;--color-attention-subtle:#676C7E;--color-danger-fg:red;}.sketch-overlay-B1{fill:url(#streaks-darker-d2-3229218106);mix-blend-mode:lighten}.sketch-overlay-B2{fill:url(#streaks-darker-d2-3229218106);mix-blend-mode:lighten}.sketch-overlay-B3{fill:url(#streaks-bright-d2-3229218106);mix-blend-mode:darken}.sketch-overlay-B4{fill:url(#streaks-bright-d2-3229218106);mix-blend-mode:darken}.sketch-overlay-B5{fill:url(#streaks-bright-d2-3229218106);mix-blend-mode:darken}.sketch-overlay-B6{fill:url(#streaks-bright-d2-3229218106);mix-blend-mode:darken}.sketch-overlay-AA2{fill:url(#streaks-dark-d2-3229218106);mix-blend-mode:overlay}.sketch-overlay-AA4{fill:url(#streaks-bright-d2-3229218106);mix-blend-mode:darken}.sketch-overlay-AA5{fill:url(#streaks-bright-d2-3229218106);mix-blend-mode:darken}.sketch-overlay-AB4{fill:url(#streaks-bright-d2-3229218106);mix-blend-mode:darken}.sketch-overlay-AB5{fill:url(#streaks-bright-d2-3229218106);mix-blend-mode:darken}.sketch-overlay-N1{fill:url(#streaks-darker-d2-3229218106);mix-blend-mode:lighten}.sketch-overlay-N2{fill:url(#streaks-dark-d2-3229218106);mix-blend-mode:overlay}.sketch-overlay-N3{fill:url(#streaks-normal-d2-3229218106);mix-blend-mode:color-burn}.sketch-overlay-N4{fill:url(#streaks-normal-d2-3229218106);mix-blend-mode:color-burn}.sketch-overlay-N5{fill:url(#streaks-bright-d2-3229218106);mix-blend-mode:darken}.sketch-overlay-N6{fill:url(#streaks-bright-d2-3229218106);mix-blend-mode:darken}.sketch-overlay-N7{fill:url(#streaks-bright-d2-3229218106);mix-blend-mode:darken}.light-code{display: block}.dark-code{display: none}]]></style><style type="text/css">.d2-3229218106 .md em,
+.d2-3229218106 .md dfn {
+  font-family: "d2-3229218106-font-italic";
+}
+
+.d2-3229218106 .md b,
+.d2-3229218106 .md strong {
+  font-family: "d2-3229218106-font-bold";
+}
+
+.d2-3229218106 .md code,
+.d2-3229218106 .md kbd,
+.d2-3229218106 .md pre,
+.d2-3229218106 .md samp {
+  font-family: "d2-3229218106-font-mono";
+  font-size: 1em;
+}
+
+.d2-3229218106 .md {
+  tab-size: 4;
+}
+
+/* variables are provided in d2renderers/d2svg/d2svg.go */
+
+.d2-3229218106 .md {
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  background-color: transparent; /* we don't want to define the background color */
+  font-family: "d2-3229218106-font-regular";
+  font-size: 16px;
+  line-height: 1.5;
+  word-wrap: break-word;
+}
+
+.d2-3229218106 .md details,
+.d2-3229218106 .md figcaption,
+.d2-3229218106 .md figure {
+  display: block;
+}
+
+.d2-3229218106 .md summary {
+  display: list-item;
+}
+
+.d2-3229218106 .md [hidden] {
+  display: none !important;
+}
+
+.d2-3229218106 .md a {
+  background-color: transparent;
+  color: var(--color-accent-fg);
+  text-decoration: none;
+}
+
+.d2-3229218106 .md a:active,
+.d2-3229218106 .md a:hover {
+  outline-width: 0;
+}
+
+.d2-3229218106 .md abbr[title] {
+  border-bottom: none;
+  text-decoration: underline dotted;
+}
+
+.d2-3229218106 .md dfn {
+  font-style: italic;
+}
+
+.d2-3229218106 .md h1 {
+  margin: 0.67em 0;
+  padding-bottom: 0.3em;
+  font-size: 2em;
+  border-bottom: 1px solid var(--color-border-muted);
+}
+
+.d2-3229218106 .md mark {
+  background-color: var(--color-attention-subtle);
+  color: var(--color-text-primary);
+}
+
+.d2-3229218106 .md small {
+  font-size: 90%;
+}
+
+.d2-3229218106 .md sub,
+.d2-3229218106 .md sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+.d2-3229218106 .md sub {
+  bottom: -0.25em;
+}
+
+.d2-3229218106 .md sup {
+  top: -0.5em;
+}
+
+.d2-3229218106 .md img {
+  border-style: none;
+  max-width: 100%;
+  box-sizing: content-box;
+  background-color: var(--color-canvas-default);
+}
+
+.d2-3229218106 .md figure {
+  margin: 1em 40px;
+}
+
+.d2-3229218106 .md hr {
+  box-sizing: content-box;
+  overflow: hidden;
+  background: transparent;
+  border-bottom: 1px solid var(--color-border-muted);
+  height: 0.25em;
+  padding: 0;
+  margin: 24px 0;
+  background-color: var(--color-border-default);
+  border: 0;
+}
+
+.d2-3229218106 .md input {
+  font: inherit;
+  margin: 0;
+  overflow: visible;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.d2-3229218106 .md [type="button"],
+.d2-3229218106 .md [type="reset"],
+.d2-3229218106 .md [type="submit"] {
+  -webkit-appearance: button;
+}
+
+.d2-3229218106 .md [type="button"]::-moz-focus-inner,
+.d2-3229218106 .md [type="reset"]::-moz-focus-inner,
+.d2-3229218106 .md [type="submit"]::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+.d2-3229218106 .md [type="button"]:-moz-focusring,
+.d2-3229218106 .md [type="reset"]:-moz-focusring,
+.d2-3229218106 .md [type="submit"]:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+.d2-3229218106 .md [type="checkbox"],
+.d2-3229218106 .md [type="radio"] {
+  box-sizing: border-box;
+  padding: 0;
+}
+
+.d2-3229218106 .md [type="number"]::-webkit-inner-spin-button,
+.d2-3229218106 .md [type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+.d2-3229218106 .md [type="search"] {
+  -webkit-appearance: textfield;
+  outline-offset: -2px;
+}
+
+.d2-3229218106 .md [type="search"]::-webkit-search-cancel-button,
+.d2-3229218106 .md [type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.d2-3229218106 .md ::-webkit-input-placeholder {
+  color: inherit;
+  opacity: 0.54;
+}
+
+.d2-3229218106 .md ::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  font: inherit;
+}
+
+.d2-3229218106 .md a:hover {
+  text-decoration: underline;
+}
+
+.d2-3229218106 .md hr::before {
+  display: table;
+  content: "";
+}
+
+.d2-3229218106 .md hr::after {
+  display: table;
+  clear: both;
+  content: "";
+}
+
+.d2-3229218106 .md table {
+  border-spacing: 0;
+  border-collapse: collapse;
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow: auto;
+}
+
+.d2-3229218106 .md td,
+.d2-3229218106 .md th {
+  padding: 0;
+}
+
+.d2-3229218106 .md details summary {
+  cursor: pointer;
+}
+
+.d2-3229218106 .md details:not([open]) > *:not(summary) {
+  display: none !important;
+}
+
+.d2-3229218106 .md kbd {
+  display: inline-block;
+  padding: 3px 5px;
+  color: var(--color-fg-default);
+  vertical-align: middle;
+  background-color: var(--color-canvas-subtle);
+  border: solid 1px var(--color-neutral-muted);
+  border-bottom-color: var(--color-neutral-muted);
+  border-radius: 6px;
+  box-shadow: inset 0 -1px 0 var(--color-neutral-muted);
+}
+
+.d2-3229218106 .md h1,
+.d2-3229218106 .md h2,
+.d2-3229218106 .md h3,
+.d2-3229218106 .md h4,
+.d2-3229218106 .md h5,
+.d2-3229218106 .md h6 {
+  margin-top: 24px;
+  margin-bottom: 16px;
+  font-weight: 400;
+  line-height: 1.25;
+  font-family: "d2-3229218106-font-semibold";
+}
+
+.d2-3229218106 .md h2 {
+  padding-bottom: 0.3em;
+  font-size: 1.5em;
+  border-bottom: 1px solid var(--color-border-muted);
+}
+
+.d2-3229218106 .md h3 {
+  font-size: 1.25em;
+}
+
+.d2-3229218106 .md h4 {
+  font-size: 1em;
+}
+
+.d2-3229218106 .md h5 {
+  font-size: 0.875em;
+}
+
+.d2-3229218106 .md h6 {
+  font-size: 0.85em;
+  color: var(--color-fg-muted);
+}
+
+.d2-3229218106 .md p {
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+
+.d2-3229218106 .md blockquote {
+  margin: 0;
+  padding: 0 1em;
+  color: var(--color-fg-muted);
+  border-left: 0.25em solid var(--color-border-default);
+}
+
+.d2-3229218106 .md ul,
+.d2-3229218106 .md ol {
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-left: 2em;
+}
+
+.d2-3229218106 .md ol ol,
+.d2-3229218106 .md ul ol {
+  list-style-type: lower-roman;
+}
+
+.d2-3229218106 .md ul ul ol,
+.d2-3229218106 .md ul ol ol,
+.d2-3229218106 .md ol ul ol,
+.d2-3229218106 .md ol ol ol {
+  list-style-type: lower-alpha;
+}
+
+.d2-3229218106 .md dd {
+  margin-left: 0;
+}
+
+.d2-3229218106 .md pre {
+  margin-top: 0;
+  margin-bottom: 0;
+  word-wrap: normal;
+}
+
+.d2-3229218106 .md ::placeholder {
+  color: var(--color-fg-subtle);
+  opacity: 1;
+}
+
+.d2-3229218106 .md input::-webkit-outer-spin-button,
+.d2-3229218106 .md input::-webkit-inner-spin-button {
+  margin: 0;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.d2-3229218106 .md::before {
+  display: table;
+  content: "";
+}
+
+.d2-3229218106 .md::after {
+  display: table;
+  clear: both;
+  content: "";
+}
+
+.d2-3229218106 .md > *:first-child {
+  margin-top: 0 !important;
+}
+
+.d2-3229218106 .md > *:last-child {
+  margin-bottom: 0 !important;
+}
+
+.d2-3229218106 .md a:not([href]) {
+  color: inherit;
+  text-decoration: none;
+}
+
+.d2-3229218106 .md .absent {
+  color: var(--color-danger-fg);
+}
+
+.d2-3229218106 .md .anchor {
+  float: left;
+  padding-right: 4px;
+  margin-left: -20px;
+  line-height: 1;
+}
+
+.d2-3229218106 .md .anchor:focus {
+  outline: none;
+}
+
+.d2-3229218106 .md p,
+.d2-3229218106 .md blockquote,
+.d2-3229218106 .md ul,
+.d2-3229218106 .md ol,
+.d2-3229218106 .md dl,
+.d2-3229218106 .md table,
+.d2-3229218106 .md pre,
+.d2-3229218106 .md details {
+  margin-top: 0;
+  margin-bottom: 16px;
+}
+
+.d2-3229218106 .md blockquote > :first-child {
+  margin-top: 0;
+}
+
+.d2-3229218106 .md blockquote > :last-child {
+  margin-bottom: 0;
+}
+
+.d2-3229218106 .md sup > a::before {
+  content: "[";
+}
+
+.d2-3229218106 .md sup > a::after {
+  content: "]";
+}
+
+.d2-3229218106 .md h1:hover .anchor,
+.d2-3229218106 .md h2:hover .anchor,
+.d2-3229218106 .md h3:hover .anchor,
+.d2-3229218106 .md h4:hover .anchor,
+.d2-3229218106 .md h5:hover .anchor,
+.d2-3229218106 .md h6:hover .anchor {
+  text-decoration: none;
+}
+
+.d2-3229218106 .md h1 tt,
+.d2-3229218106 .md h1 code,
+.d2-3229218106 .md h2 tt,
+.d2-3229218106 .md h2 code,
+.d2-3229218106 .md h3 tt,
+.d2-3229218106 .md h3 code,
+.d2-3229218106 .md h4 tt,
+.d2-3229218106 .md h4 code,
+.d2-3229218106 .md h5 tt,
+.d2-3229218106 .md h5 code,
+.d2-3229218106 .md h6 tt,
+.d2-3229218106 .md h6 code {
+  padding: 0 0.2em;
+  font-size: inherit;
+}
+
+.d2-3229218106 .md ul.no-list,
+.d2-3229218106 .md ol.no-list {
+  padding: 0;
+  list-style-type: none;
+}
+
+.d2-3229218106 .md ol[type="1"] {
+  list-style-type: decimal;
+}
+
+.d2-3229218106 .md ol[type="a"] {
+  list-style-type: lower-alpha;
+}
+
+.d2-3229218106 .md ol[type="i"] {
+  list-style-type: lower-roman;
+}
+
+.d2-3229218106 .md div > ol:not([type]) {
+  list-style-type: decimal;
+}
+
+.d2-3229218106 .md ul ul,
+.d2-3229218106 .md ul ol,
+.d2-3229218106 .md ol ol,
+.d2-3229218106 .md ol ul {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.d2-3229218106 .md li > p {
+  margin-top: 16px;
+}
+
+.d2-3229218106 .md li + li {
+  margin-top: 0.25em;
+}
+
+.d2-3229218106 .md dl {
+  padding: 0;
+}
+
+.d2-3229218106 .md dl dt {
+  padding: 0;
+  margin-top: 16px;
+  font-size: 1em;
+  font-style: italic;
+  font-family: "d2-3229218106-font-semibold";
+}
+
+.d2-3229218106 .md dl dd {
+  padding: 0 16px;
+  margin-bottom: 16px;
+}
+
+.d2-3229218106 .md table th {
+  font-family: "d2-3229218106-font-semibold";
+}
+
+.d2-3229218106 .md table th,
+.d2-3229218106 .md table td {
+  padding: 6px 13px;
+  border: 1px solid var(--color-border-default);
+}
+
+.d2-3229218106 .md table tr {
+  background-color: var(--color-canvas-default);
+  border-top: 1px solid var(--color-border-muted);
+}
+
+.d2-3229218106 .md table tr:nth-child(2n) {
+  background-color: var(--color-canvas-subtle);
+}
+
+.d2-3229218106 .md table img {
+  background-color: transparent;
+}
+
+.d2-3229218106 .md img[align="right"] {
+  padding-left: 20px;
+}
+
+.d2-3229218106 .md img[align="left"] {
+  padding-right: 20px;
+}
+
+.d2-3229218106 .md span.frame {
+  display: block;
+  overflow: hidden;
+}
+
+.d2-3229218106 .md span.frame > span {
+  display: block;
+  float: left;
+  width: auto;
+  padding: 7px;
+  margin: 13px 0 0;
+  overflow: hidden;
+  border: 1px solid var(--color-border-default);
+}
+
+.d2-3229218106 .md span.frame span img {
+  display: block;
+  float: left;
+}
+
+.d2-3229218106 .md span.frame span span {
+  display: block;
+  padding: 5px 0 0;
+  clear: both;
+  color: var(--color-fg-default);
+}
+
+.d2-3229218106 .md span.align-center {
+  display: block;
+  overflow: hidden;
+  clear: both;
+}
+
+.d2-3229218106 .md span.align-center > span {
+  display: block;
+  margin: 13px auto 0;
+  overflow: hidden;
+  text-align: center;
+}
+
+.d2-3229218106 .md span.align-center span img {
+  margin: 0 auto;
+  text-align: center;
+}
+
+.d2-3229218106 .md span.align-right {
+  display: block;
+  overflow: hidden;
+  clear: both;
+}
+
+.d2-3229218106 .md span.align-right > span {
+  display: block;
+  margin: 13px 0 0;
+  overflow: hidden;
+  text-align: right;
+}
+
+.d2-3229218106 .md span.align-right span img {
+  margin: 0;
+  text-align: right;
+}
+
+.d2-3229218106 .md span.float-left {
+  display: block;
+  float: left;
+  margin-right: 13px;
+  overflow: hidden;
+}
+
+.d2-3229218106 .md span.float-left span {
+  margin: 13px 0 0;
+}
+
+.d2-3229218106 .md span.float-right {
+  display: block;
+  float: right;
+  margin-left: 13px;
+  overflow: hidden;
+}
+
+.d2-3229218106 .md span.float-right > span {
+  display: block;
+  margin: 13px auto 0;
+  overflow: hidden;
+  text-align: right;
+}
+
+.d2-3229218106 .md code,
+.d2-3229218106 .md tt {
+  padding: 0.2em 0.4em;
+  margin: 0;
+  font-size: 85%;
+  background-color: var(--color-neutral-muted);
+  border-radius: 6px;
+}
+
+.d2-3229218106 .md code br,
+.d2-3229218106 .md tt br {
+  display: none;
+}
+
+.d2-3229218106 .md del code {
+  text-decoration: inherit;
+}
+
+.d2-3229218106 .md pre code {
+  font-size: 100%;
+}
+
+.d2-3229218106 .md pre > code {
+  padding: 0;
+  margin: 0;
+  word-break: normal;
+  white-space: pre;
+  background: transparent;
+  border: 0;
+}
+
+.d2-3229218106 .md .highlight {
+  margin-bottom: 16px;
+}
+
+.d2-3229218106 .md .highlight pre {
+  margin-bottom: 0;
+  word-break: normal;
+}
+
+.d2-3229218106 .md .highlight pre,
+.d2-3229218106 .md pre {
+  padding: 16px;
+  overflow: auto;
+  font-size: 85%;
+  line-height: 1.45;
+  background-color: var(--color-canvas-subtle);
+  border-radius: 6px;
+}
+
+.d2-3229218106 .md pre code,
+.d2-3229218106 .md pre tt {
+  display: inline;
+  max-width: auto;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  line-height: inherit;
+  word-wrap: normal;
+  background-color: transparent;
+  border: 0;
+}
+
+.d2-3229218106 .md .csv-data td,
+.d2-3229218106 .md .csv-data th {
+  padding: 5px;
+  overflow: hidden;
+  font-size: 12px;
+  line-height: 1;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.d2-3229218106 .md .csv-data .blob-num {
+  padding: 10px 8px 9px;
+  text-align: right;
+  background: var(--color-canvas-default);
+  border: 0;
+}
+
+.d2-3229218106 .md .csv-data tr {
+  border-top: 0;
+}
+
+.d2-3229218106 .md .csv-data th {
+  font-family: "d2-3229218106-font-semibold";
+  background: var(--color-canvas-subtle);
+  border-top: 0;
+}
+
+.d2-3229218106 .md .footnotes {
+  font-size: 12px;
+  color: var(--color-fg-muted);
+  border-top: 1px solid var(--color-border-default);
+}
+
+.d2-3229218106 .md .footnotes ol {
+  padding-left: 16px;
+}
+
+.d2-3229218106 .md .footnotes li {
+  position: relative;
+}
+
+.d2-3229218106 .md .footnotes li:target::before {
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  bottom: -8px;
+  left: -24px;
+  pointer-events: none;
+  content: "";
+  border: 2px solid var(--color-accent-emphasis);
+  border-radius: 6px;
+}
+
+.d2-3229218106 .md .footnotes li:target {
+  color: var(--color-fg-default);
+}
+
+.d2-3229218106 .md .task-list-item {
+  list-style-type: none;
+}
+
+.d2-3229218106 .md .task-list-item label {
+  font-weight: 400;
+}
+
+.d2-3229218106 .md .task-list-item.enabled label {
+  cursor: pointer;
+}
+
+.d2-3229218106 .md .task-list-item + .task-list-item {
+  margin-top: 3px;
+}
+
+.d2-3229218106 .md .task-list-item .handle {
+  display: none;
+}
+
+.d2-3229218106 .md .task-list-item-checkbox {
+  margin: 0 0.2em 0.25em -1.6em;
+  vertical-align: middle;
+}
+
+.d2-3229218106 .md .contains-task-list:dir(rtl) .task-list-item-checkbox {
+  margin: 0 -1.6em 0.25em 0.2em;
+}
+</style><g class="dGl0bGU="><g class="shape" ></g><text x="708.000000" y="-48.000000" fill="#0A0F25" class="text-bold fill-N1" style="text-anchor:middle;font-size:24px">LLM API Key Protection Architecture</text></g><g class="YWdlbnQtc2VydmVy"><g class="shape" ><rect x="0.000000" y="20.000000" width="1416.000000" height="611.000000" rx="12.000000" stroke="#94a3b8" fill="#f8fafc" style="stroke-width:2;" /></g><text x="708.000000" y="7.000000" fill="#0A0F25" class="text fill-N1" style="text-anchor:middle;font-size:28px">Agent Server (Python Process)</text></g><g class="YWdlbnQtc2VydmVyLmFnZW50LWxvb3A="><g class="shape" ><rect x="842.000000" y="50.000000" width="126.000000" height="66.000000" rx="8.000000" stroke="#6366f1" fill="#eef2ff" style="stroke-width:2;" /></g><text x="905.000000" y="88.500000" fill="#0A0F25" class="text-bold fill-N1" style="text-anchor:middle;font-size:16px">Agent Loop</text></g><g class="YWdlbnQtc2VydmVyLmxsbQ=="><g class="shape" ><rect x="1219.000000" y="303.000000" width="134.000000" height="82.000000" rx="8.000000" stroke="#f59e0b" fill="#fef3c7" style="stroke-width:2;" /></g><text x="1286.000000" y="341.500000" fill="#92400e" class="text-bold" style="text-anchor:middle;font-size:16px"><tspan x="1286.000000" dy="0.000000">LLM</tspan><tspan x="1286.000000" dy="18.500000">(api_key 🔑)</tspan></text></g><g class="YWdlbnQtc2VydmVyLnByb3ZpZGVyLWFwaQ=="><g class="shape" ><rect x="1187.000000" y="535.000000" width="199.000000" height="66.000000" rx="8.000000" stroke="#10b981" fill="#ecfdf5" style="stroke-width:2;" /></g><text x="1286.500000" y="573.500000" fill="#0A0F25" class="text-bold fill-N1" style="text-anchor:middle;font-size:16px">LiteLLM / Provider API</text></g><g class="YWdlbnQtc2VydmVyLnNhbmRib3g="><g class="shape" ><rect x="30.000000" y="281.000000" width="1139.000000" height="126.000000" rx="10.000000" stroke="#ef4444" fill="#fef2f2" style="stroke-width:2;stroke-dasharray:10.000000,9.865639;" /></g><text x="599.500000" y="269.000000" fill="#0A0F25" class="text fill-N1" style="text-anchor:middle;font-size:24px">Sandbox Environment (Isolated Container)</text></g><g class="YWdlbnQtc2VydmVyLnNhbmRib3guYmFzaA=="><g class="shape" ><rect x="60.000000" y="311.000000" width="161.000000" height="66.000000" rx="6.000000" stroke="#d1d5db" fill="#ffffff" style="stroke-width:2;" /></g><text x="140.500000" y="349.500000" fill="#0A0F25" class="text-bold fill-N1" style="text-anchor:middle;font-size:16px">Bash Commands</text></g><g class="YWdlbnQtc2VydmVyLnNhbmRib3guZmlsZXM="><g class="shape" ><rect x="281.000000" y="311.000000" width="118.000000" height="66.000000" rx="6.000000" stroke="#d1d5db" fill="#ffffff" style="stroke-width:2;" /></g><text x="340.000000" y="349.500000" fill="#0A0F25" class="text-bold fill-N1" style="text-anchor:middle;font-size:16px">File Editor</text></g><g class="YWdlbnQtc2VydmVyLnNhbmRib3gudG9vbHM="><g class="shape" ><rect x="459.000000" y="311.000000" width="128.000000" height="66.000000" rx="6.000000" stroke="#d1d5db" fill="#ffffff" style="stroke-width:2;" /></g><text x="523.000000" y="349.500000" fill="#0A0F25" class="text-bold fill-N1" style="text-anchor:middle;font-size:16px">Other Tools</text></g><g class="YWdlbnQtc2VydmVyLnNhbmRib3gubm8tYWNjZXNz"><g class="shape" ></g><g><foreignObject requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" x="647.000000" y="332.000000" width="492" height="24"><div xmlns="http://www.w3.org/1999/xhtml" class="md" style="background-color:#fee2e2;color:#991b1b"><p>❌ No LLM_API_KEY
+❌ No SESSION_API_KEY
+❌ No Provider Credentials</p>
+</div></foreignObject></g></g><g class="YWdlbnQtc2VydmVyLihhZ2VudC1sb29wIC0mZ3Q7IGxsbSlbMF0="><marker id="mk-d2-3229218106-2755093818" markerWidth="10.000000" markerHeight="12.000000" refX="7.000000" refY="6.000000" viewBox="0.000000 0.000000 10.000000 12.000000" orient="auto" markerUnits="userSpaceOnUse"> <polygon points="0.000000,0.000000 10.000000,6.000000 0.000000,12.000000" fill="#6366f1" class="connection" stroke-width="2" /> </marker><path d="M 970.432361 100.276736 C 1222.500000 167.552002 1286.000000 263.000000 1286.000000 299.000000" stroke="#6366f1" fill="none" class="connection" style="stroke-width:2;" marker-end="url(#mk-d2-3229218106-2755093818)" mask="url(#d2-3229218106)" /></g><g class="YWdlbnQtc2VydmVyLihsbG0gLSZndDsgcHJvdmlkZXItYXBpKVswXQ=="><path d="M 1286.000000 387.000000 C 1286.000000 425.000000 1286.000000 495.000000 1286.000000 531.000000" stroke="#6366f1" fill="none" class="connection" style="stroke-width:2;" marker-end="url(#mk-d2-3229218106-2755093818)" mask="url(#d2-3229218106)" /></g><g class="YWdlbnQtc2VydmVyLihhZ2VudC1sb29wIC0mZ3Q7IHNhbmRib3gpWzBd"><marker id="mk-d2-3229218106-3044516413" markerWidth="10.000000" markerHeight="12.000000" refX="7.000000" refY="6.000000" viewBox="0.000000 0.000000 10.000000 12.000000" orient="auto" markerUnits="userSpaceOnUse"> <polygon points="0.000000,0.000000 10.000000,6.000000 0.000000,12.000000" fill="#9ca3af" class="connection" stroke-width="2" /> </marker><path d="M 839.567236 100.275224 C 586.700012 167.552002 523.000000 196.699997 523.000000 241.500000" stroke="#9ca3af" fill="none" class="connection" style="stroke-width:2;" marker-end="url(#mk-d2-3229218106-3044516413)" mask="url(#d2-3229218106)" /><text x="657.000000" y="146.000000" fill="#676C7E" class="text-italic fill-N2" style="text-anchor:middle;font-size:16px"><tspan x="657.000000" dy="0.000000">Tool calls</tspan><tspan x="657.000000" dy="18.500000">(no secrets)</tspan></text></g><mask id="d2-3229218106" maskUnits="userSpaceOnUse" x="-101" y="-173" width="1618" height="905">
+<rect x="-101" y="-173" width="1618" height="905" fill="white"></rect>
+<rect x="618.000000" y="130.000000" width="78" height="37" fill="black"></rect>
+</mask></svg></svg>

--- a/enterprise/tech-notes/index.mdx
+++ b/enterprise/tech-notes/index.mdx
@@ -1,0 +1,38 @@
+---
+title: Tech Notes
+description: In-depth technical articles on OpenHands architecture, security, and implementation details
+icon: file-lines
+---
+
+Tech Notes provide detailed technical explanations of how OpenHands works under
+the hood. These articles go beyond basic documentation to explain architecture
+decisions, security models, and implementation details that help you understand
+and trust the platform.
+
+## Available Tech Notes
+
+<CardGroup cols={1}>
+  <Card
+    title="LLM API Key Protection"
+    icon="key"
+    href="/enterprise/tech-notes/llm-key-protection"
+  >
+    How OpenHands protects LLM API keys from agent access, including the
+    security architecture for LiteLLM virtual keys and BYOK configurations.
+  </Card>
+</CardGroup>
+
+## About Tech Notes
+
+Tech Notes are written for:
+
+- **Security teams** evaluating OpenHands for enterprise deployment
+- **Platform engineers** integrating OpenHands into existing infrastructure
+- **Developers** who want to understand how OpenHands works internally
+
+Each Tech Note includes:
+
+- Detailed technical explanations with code references
+- Security considerations and threat models
+- Architecture diagrams where applicable
+- Links to relevant source code for verification

--- a/enterprise/tech-notes/llm-key-protection.mdx
+++ b/enterprise/tech-notes/llm-key-protection.mdx
@@ -27,27 +27,9 @@ OpenHands uses a split architecture where:
 2. **The Sandbox** (isolated container or process) executes agent-requested
    commands without access to credentials
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                        Agent Server                              │
-│  ┌─────────────┐    ┌─────────────┐    ┌─────────────────────┐  │
-│  │   Agent     │───►│    LLM      │───►│  LiteLLM / Provider │  │
-│  │   Loop      │    │  (api_key)  │    │       API           │  │
-│  └─────────────┘    └─────────────┘    └─────────────────────┘  │
-│         │                                                        │
-│         │ Tool calls (no secrets)                                │
-│         ▼                                                        │
-│  ┌─────────────────────────────────────────────────────────┐    │
-│  │                    Sandbox Environment                    │    │
-│  │  ┌──────────┐  ┌──────────┐  ┌──────────┐               │    │
-│  │  │  Bash    │  │  Files   │  │  Other   │               │    │
-│  │  │ Commands │  │  Editor  │  │  Tools   │               │    │
-│  │  └──────────┘  └──────────┘  └──────────┘               │    │
-│  │                                                          │    │
-│  │  ❌ No LLM_API_KEY    ❌ No SESSION_API_KEY              │    │
-│  └─────────────────────────────────────────────────────────┘    │
-└─────────────────────────────────────────────────────────────────┘
-```
+<Frame>
+  <img src="/enterprise/tech-notes/images/llm-key-architecture.svg" alt="LLM API Key Protection Architecture" />
+</Frame>
 
 ## Protection Mechanisms
 

--- a/enterprise/tech-notes/llm-key-protection.mdx
+++ b/enterprise/tech-notes/llm-key-protection.mdx
@@ -18,6 +18,79 @@ The short answer is **no**. OpenHands implements multiple layers of protection
 to ensure that LLM API keys are never exposed to the agent's execution
 environment.
 
+## The LiteLLM Proxy Layer
+
+Before diving into SDK-level protections, it's important to understand the
+first layer of defense: the LiteLLM proxy.
+
+### How It Works
+
+OpenHands routes all LLM API calls through a LiteLLM proxy server. This proxy
+holds the actual provider API keys (OpenAI, Anthropic, etc.) and issues
+**virtual keys** to users:
+
+| Component | Who Configures It | What It Holds |
+|-----------|-------------------|---------------|
+| **LiteLLM Proxy** | OpenHands (SaaS) or Customer (Enterprise) | Master API keys for all LLM providers |
+| **Virtual Key** | Generated per Organization/Personal Workspace | Reference to master key, with budget/usage tracking |
+| **Agent** | N/A | Receives only the virtual key (if at all) |
+
+### Master Key Configuration
+
+- **OpenHands SaaS**: OpenHands configures master API keys in the LiteLLM proxy.
+  Users never see or handle provider API keys directly.
+- **OpenHands Enterprise**: Customers configure master API keys in their Helm
+  values file or VM Installer. These keys are stored in the LiteLLM proxy, not
+  in the application layer.
+
+### Virtual Keys Per Organization
+
+When a user or organization is created, OpenHands generates a **virtual key**
+in LiteLLM:
+
+```python
+# Simplified from enterprise/storage/lite_llm_manager.py
+
+key = await LiteLlmManager._generate_key(
+    client,
+    keycloak_user_id,
+    org_id,
+    key_alias,
+    max_budget,
+)
+
+# The virtual key is stored in user settings, NOT the master key
+oss_settings.update({
+    'agent_settings_diff': {
+        'llm': {
+            'model': get_default_litellm_model(),
+            'api_key': key,  # Virtual key, not provider key
+            'base_url': LITE_LLM_API_URL,  # Points to proxy
+        }
+    }
+})
+```
+
+This virtual key:
+- **Cannot be used directly** with provider APIs (OpenAI, Anthropic, etc.)
+- **Only works** with the LiteLLM proxy that issued it
+- **Has budget limits** enforced by the proxy
+- **Can be revoked** without affecting other users
+
+### What About BYOK (Bring Your Own Key)?
+
+When users provide their own API keys through the OpenHands settings UI, the
+behavior depends on the configuration:
+
+| BYOK Scenario | Goes Through LiteLLM? | Key Exposure |
+|---------------|----------------------|--------------|
+| Custom `base_url` pointing to own LiteLLM | Yes (user's proxy) | User's proxy holds master key |
+| Custom `base_url` pointing directly to provider | No | Key goes directly to provider |
+| Only custom `api_key` (no custom `base_url`) | Yes (OpenHands proxy) | Key is passed to OpenHands LiteLLM proxy |
+
+In all cases, the API key (whether virtual or BYOK) is stored in
+`Agent.llm.api_key` and protected by the SDK-level mechanisms described below.
+
 ## Architecture
 
 OpenHands uses a split architecture where:

--- a/enterprise/tech-notes/llm-key-protection.mdx
+++ b/enterprise/tech-notes/llm-key-protection.mdx
@@ -96,6 +96,27 @@ git operations), OpenHands uses a controlled injection mechanism:
 2. **Output masking**: Any secret values that appear in command output are
    automatically replaced with `<secret-hidden>`
 
+#### Understanding "Controlled": LLM vs Agent Access
+
+Registered secrets are **accessible to the agent** but **hidden from the LLM**:
+
+| Layer | Access to Secret Values |
+|-------|------------------------|
+| **LLM** (language model) | ❌ Never sees actual values—masked as `<secret-hidden>` in conversation history |
+| **Agent** (sandbox execution) | ✅ Full access—can read, write to files, transmit over network |
+
+**How it works**: When a command outputs a secret value, it's replaced with
+`<secret-hidden>` before being added to the conversation history. This prevents
+the secret from appearing in prompts sent to the LLM. However, the agent executing
+in the sandbox has full access to use the secret as needed.
+
+**Expected behavior**: The agent will use registered secrets for legitimate tasks—writing
+to `.git-credentials`, including tokens in API headers, configuring services, etc.
+This is by design. Output masking keeps secrets out of conversation logs and the UI,
+but does not restrict how the agent uses them during execution.
+
+#### Implementation Details
+
 ```python
 # From openhands-sdk/openhands/sdk/conversation/secret_registry.py
 
@@ -182,16 +203,21 @@ async def test_terminal_does_not_expose_session_api_key(bash_service, monkeypatc
 
 When users provide their own API keys through the OpenHands settings UI:
 
-| Secret Type | Exposed to Agent? | Notes |
-|-------------|-------------------|-------|
-| LLM API Key | ❌ No | Stored in `Agent.llm.api_key`, used only by SDK |
-| LiteLLM Virtual Key | ❌ No | Same protection as direct API keys |
-| GitHub/GitLab Tokens | ⚠️ Controlled | Injected on-demand, output masked |
-| Custom Secrets | ⚠️ Controlled | Injected on-demand, output masked |
+| Secret Type | Exposed to LLM? | Exposed to Agent? | Notes |
+|-------------|-----------------|-------------------|-------|
+| LLM API Key | ❌ No | ❌ No | Stored in `Agent.llm.api_key`, used only by SDK |
+| LiteLLM Virtual Key | ❌ No | ❌ No | Same protection as direct API keys |
+| GitHub/GitLab Tokens | ❌ No | ✅ Yes | Agent can use for git operations, write to files, etc. |
+| Custom Secrets | ❌ No | ✅ Yes | Agent can use as needed for tasks |
 
 The LLM API key specifically is **never** injected into the agent environment,
 regardless of whether it's a direct provider key, a LiteLLM virtual key, or
 an OpenHands-provided key.
+
+Registered secrets (GitHub/GitLab tokens, custom secrets) are fully accessible
+to the agent by design—this is required for the agent to perform tasks like
+pushing code or calling APIs. Output masking ensures these values don't appear
+in conversation history sent to the LLM.
 
 ## Potential Attack Vectors (and Mitigations)
 

--- a/enterprise/tech-notes/llm-key-protection.mdx
+++ b/enterprise/tech-notes/llm-key-protection.mdx
@@ -1,0 +1,280 @@
+---
+title: LLM API Key Protection
+description: How OpenHands protects LLM API keys from agent access and exfiltration
+icon: key
+---
+
+This technical note explains how OpenHands protects LLM API keys—including
+LiteLLM virtual keys and Bring Your Own Key (BYOK) configurations—from being
+accessed or exfiltrated by the AI agent running in the sandbox.
+
+## Overview
+
+When you use OpenHands, an AI agent executes code in a sandboxed environment.
+A natural security concern is: **can the agent access and steal the LLM API key
+used to power it?**
+
+The short answer is **no**. OpenHands implements multiple layers of protection
+to ensure that LLM API keys are never exposed to the agent's execution
+environment.
+
+## Architecture
+
+OpenHands uses a split architecture where:
+
+1. **The Agent Server** (Python process) holds sensitive credentials and makes
+   LLM API calls
+2. **The Sandbox** (isolated container or process) executes agent-requested
+   commands without access to credentials
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        Agent Server                              │
+│  ┌─────────────┐    ┌─────────────┐    ┌─────────────────────┐  │
+│  │   Agent     │───►│    LLM      │───►│  LiteLLM / Provider │  │
+│  │   Loop      │    │  (api_key)  │    │       API           │  │
+│  └─────────────┘    └─────────────┘    └─────────────────────┘  │
+│         │                                                        │
+│         │ Tool calls (no secrets)                                │
+│         ▼                                                        │
+│  ┌─────────────────────────────────────────────────────────┐    │
+│  │                    Sandbox Environment                    │    │
+│  │  ┌──────────┐  ┌──────────┐  ┌──────────┐               │    │
+│  │  │  Bash    │  │  Files   │  │  Other   │               │    │
+│  │  │ Commands │  │  Editor  │  │  Tools   │               │    │
+│  │  └──────────┘  └──────────┘  └──────────┘               │    │
+│  │                                                          │    │
+│  │  ❌ No LLM_API_KEY    ❌ No SESSION_API_KEY              │    │
+│  └─────────────────────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Protection Mechanisms
+
+### 1. LLM API Key Isolation
+
+The LLM's `api_key` is stored in the `Agent.llm.api_key` field as a Pydantic
+`SecretStr`. This key is:
+
+- Used **only within the SDK's Python process** when making API calls via
+  LiteLLM
+- **Never exported** as an environment variable to the shell
+- **Never accessible** via bash commands like `echo $LLM_API_KEY`
+
+The agent cannot request to "print environment variables" or write code that
+reads the LLM API key because **it simply doesn't exist** in the sandbox's
+environment.
+
+### 2. SESSION_API_KEY Stripping
+
+The `SESSION_API_KEY` is a credential that grants access to user secrets via
+the OpenHands API. If an agent could read this, it could potentially access
+other sensitive data.
+
+OpenHands explicitly strips this variable before any subprocess execution:
+
+```python
+# From openhands-sdk/openhands/sdk/utils/command.py
+
+_SENSITIVE_ENV_VARS = frozenset({"SESSION_API_KEY"})
+
+def sanitized_env(env: Mapping[str, str] | None = None) -> dict[str, str]:
+    """Return a copy of *env* with sanitized values.
+
+    Sensitive environment variables (e.g., ``SESSION_API_KEY``) are stripped
+    to prevent LLM-driven agents from accessing credentials via terminal
+    commands.
+    """
+    base_env: dict[str, str]
+    if env is None:
+        base_env = dict(os.environ)
+    else:
+        base_env = dict(env)
+
+    # Strip sensitive env vars to prevent agent access via bash commands
+    for key in _SENSITIVE_ENV_VARS:
+        base_env.pop(key, None)
+
+    return base_env
+```
+
+This `sanitized_env()` function is called in:
+- `bash_service.py` — before executing any bash command
+- `desktop_service.py` — before starting desktop processes  
+- `vscode_service.py` — before launching VS Code
+- `skills_service.py` — before running skill-related processes
+
+### 3. Registered Secrets: On-Demand Injection with Masking
+
+For secrets that **are** meant to be used by the agent (like `GITHUB_TOKEN` for
+git operations), OpenHands uses a controlled injection mechanism:
+
+1. **On-demand injection**: Secrets are only added to the environment when the
+   command text explicitly references them
+2. **Output masking**: Any secret values that appear in command output are
+   automatically replaced with `<secret-hidden>`
+
+```python
+# From openhands-sdk/openhands/sdk/conversation/secret_registry.py
+
+def get_secrets_as_env_vars(self, command: str) -> dict[str, str]:
+    """Get secrets that should be exported as environment variables."""
+    found_secrets = self.find_secrets_in_text(command)
+
+    if not found_secrets:
+        return {}
+
+    env_vars = {}
+    for key in found_secrets:
+        source = self.secret_sources[key]
+        value = source.get_value()
+        if value:
+            env_vars[key] = value
+            # Track for masking
+            self._exported_values[key] = value
+
+    return env_vars
+
+def mask_secrets_in_output(self, text: str) -> str:
+    """Mask secret values in the given text."""
+    masked_text = text
+    for value in self._exported_values.values():
+        masked_text = masked_text.replace(value, "<secret-hidden>")
+    return masked_text
+```
+
+### 4. LookupSecret for Dynamic Tokens
+
+For OAuth tokens and other credentials that may be refreshed, OpenHands uses
+`LookupSecret` which fetches tokens via authenticated HTTP requests at runtime:
+
+```python
+# From openhands-sdk/openhands/sdk/secret/secrets.py
+
+class LookupSecret(SecretSource):
+    """A secret looked up from some external url"""
+
+    url: str
+    headers: dict[str, str] = Field(default_factory=dict)
+
+    def get_value(self) -> str:
+        response = httpx.get(self.url, headers=self.headers, timeout=30.0)
+        response.raise_for_status()
+        return response.text
+```
+
+This means tokens are never stored statically in the sandbox—they're fetched
+fresh when needed, and the fetch URL/headers are also protected.
+
+## Security Testing
+
+The SDK includes explicit security tests to verify these protections work:
+
+```python
+# From tests/agent_server/test_terminal_service.py
+
+@pytest.mark.asyncio
+async def test_terminal_does_not_expose_session_api_key(bash_service, monkeypatch):
+    """Verify SESSION_API_KEY is not accessible to bash commands.
+
+    This is a security test: SESSION_API_KEY grants access to user secrets via
+    the SaaS API. If an LLM-driven agent could read this env var via terminal
+    commands, it could exfiltrate all user secrets.
+    """
+    secret_value = "super-secret-session-key-12345"
+    monkeypatch.setenv("SESSION_API_KEY", secret_value)
+
+    # Agent tries to read the env var
+    request = ExecuteBashRequest(
+        command='echo "SESSION_API_KEY=$SESSION_API_KEY"',
+        cwd="/tmp",
+    )
+    command, task = await bash_service.start_bash_command(request)
+    await task
+
+    # The secret value should NOT appear in the output
+    assert secret_value not in combined_stdout
+```
+
+## What About BYOK (Bring Your Own Key)?
+
+When users provide their own API keys through the OpenHands settings UI:
+
+| Secret Type | Exposed to Agent? | Notes |
+|-------------|-------------------|-------|
+| LLM API Key | ❌ No | Stored in `Agent.llm.api_key`, used only by SDK |
+| LiteLLM Virtual Key | ❌ No | Same protection as direct API keys |
+| GitHub/GitLab Tokens | ⚠️ Controlled | Injected on-demand, output masked |
+| Custom Secrets | ⚠️ Controlled | Injected on-demand, output masked |
+
+The LLM API key specifically is **never** injected into the agent environment,
+regardless of whether it's a direct provider key, a LiteLLM virtual key, or
+an OpenHands-provided key.
+
+## Potential Attack Vectors (and Mitigations)
+
+### Could an agent write a program to read env vars?
+
+The agent could write Python code like:
+```python
+import os
+print(os.environ.get('LLM_API_KEY', 'not found'))
+```
+
+**Mitigation**: The variable doesn't exist in the subprocess environment—it
+returns `'not found'`.
+
+### Could an agent read the agent-server's memory?
+
+In theory, a malicious program could try to read `/proc/<pid>/environ` of the
+parent process.
+
+**Mitigation**: The sandbox runs in an isolated container (Docker) with no
+access to the host's process space. The agent-server process is outside the
+container.
+
+### Could an agent intercept LLM API calls?
+
+The agent doesn't make LLM calls—the agent server does. The agent only
+receives the LLM's text responses, not the API request/response details.
+
+### Could secrets leak through error messages?
+
+FastAPI validation errors could potentially echo back request bodies containing
+secrets.
+
+**Mitigation**: OpenHands sanitizes all validation error responses:
+
+```python
+# From openhands-agent-server/openhands/agent_server/api.py
+
+def _sanitize_validation_errors(errors: Sequence[Any]) -> list[dict]:
+    """Sanitize validation error details to remove sensitive input values."""
+    sanitized: list[dict] = []
+    for error in errors:
+        error = dict(error)
+        if "input" in error:
+            error["input"] = sanitize_dict(error["input"])
+        sanitized.append(error)
+    return sanitized
+```
+
+## Summary
+
+OpenHands protects LLM API keys through defense-in-depth:
+
+1. **Architectural separation**: Keys live in the agent server, not the sandbox
+2. **Environment stripping**: Sensitive vars are removed before subprocess exec
+3. **On-demand injection**: Only explicitly-needed secrets are injected
+4. **Output masking**: Secret values are redacted from all output
+5. **Container isolation**: Sandbox cannot access host process memory
+
+This design ensures that even a malicious or manipulated agent cannot access
+or exfiltrate LLM API keys or LiteLLM virtual keys.
+
+## References
+
+- [OpenHands SDK Source Code](https://github.com/OpenHands/software-agent-sdk)
+- [Secret Registry Implementation](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-sdk/openhands/sdk/conversation/secret_registry.py)
+- [Sanitized Environment Implementation](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-sdk/openhands/sdk/utils/command.py)
+- [Security Tests](https://github.com/OpenHands/software-agent-sdk/blob/main/tests/agent_server/test_terminal_service.py)

--- a/enterprise/tech-notes/llm-key-protection.mdx
+++ b/enterprise/tech-notes/llm-key-protection.mdx
@@ -292,6 +292,15 @@ to the agent by design—this is required for the agent to perform tasks like
 pushing code or calling APIs. Output masking ensures these values don't appear
 in conversation history sent to the LLM.
 
+**Important**: A user can instruct the agent to write secret values to files.
+While output masking prevents the secret from appearing in the tool call results
+sent to the LLM, once written to disk the agent could subsequently read the file
+and include its contents in a message, pass the value to an external LLM, or
+transmit it via network requests. The security mechanism is designed to protect
+secrets from the LLM—not from the end user who stored them originally. Users
+retain full control over their own secrets and can direct the agent to use them
+however they choose.
+
 ## Potential Attack Vectors (and Mitigations)
 
 ### Could an agent write a program to read env vars?


### PR DESCRIPTION
## Summary

This PR adds a new "Tech Notes" subsection under the Enterprise tab, providing in-depth technical articles for security teams, platform engineers, and developers who want to understand how OpenHands works under the hood.

## Changes

### New Section: Tech Notes
- Added `enterprise/tech-notes/` directory
- Created index page explaining the purpose and audience for Tech Notes
- Added Tech Notes group to Enterprise tab in `docs.json` (appears last in sidebar)

### First Tech Note: LLM API Key Protection

A comprehensive technical article explaining how OpenHands protects LLM API keys from agent access and exfiltration. Covers:

- **Architecture Overview**: Split architecture diagram showing agent server vs sandbox isolation
- **Protection Mechanisms**:
  - LLM API key isolation (never exposed to sandbox environment)
  - `SESSION_API_KEY` stripping via `sanitized_env()`
  - On-demand secret injection with output masking
  - `LookupSecret` for dynamic token fetching
- **Security Testing**: References to existing security tests in the codebase
- **BYOK Implications**: Table showing what's protected vs. controlled access
- **Attack Vectors & Mitigations**: Addresses common security concerns
- **Code Examples**: Actual implementation snippets from the SDK

## Files Changed

| File | Description |
|------|-------------|
| `docs.json` | Added Tech Notes group to Enterprise tab |
| `enterprise/tech-notes/index.mdx` | Landing page for Tech Notes section |
| `enterprise/tech-notes/llm-key-protection.mdx` | First tech note on LLM key protection |

## Preview

The Tech Notes section will appear at the bottom of the Enterprise sidebar:
- Enterprise
  - ...existing pages...
  - K8s Install
  - **Tech Notes** ← new
    - Tech Notes (index)
    - LLM API Key Protection

---

*This PR was created by an AI agent (OpenHands) on behalf of the user.*

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3e4e2d34-dff8-4d04-bdad-dfa11f64ca9c)