### PR TITLE
docs(sdk-hooks): add explicit Exit Codes section to SDK hooks guide

### DIFF
--- a/sdk/guides/hooks.mdx
+++ b/sdk/guides/hooks.mdx
@@ -25,6 +25,27 @@ Hooks let you observe and customize key lifecycle moments in the SDK without for
 | SessionStart | When conversation starts | No |
 | SessionEnd | When conversation ends | No |
 
+## Exit Codes
+
+Hook scripts signal their result through their exit code. The SDK matches the
+[Claude Code hook contract](https://docs.claude.com/en/docs/claude-code/hooks):
+
+- **`0` — success.** The operation proceeds. `stdout` is parsed as JSON for
+  structured output (`decision`, `reason`, `additionalContext`, `continue`).
+- **`2` — block.** The operation is denied. For `PreToolUse` and
+  `UserPromptSubmit` this rejects the action; for `Stop` it prevents the
+  agent from finishing and the conversation continues. `stderr` / `reason`
+  is surfaced as feedback.
+- **Any other non-zero exit code — non-blocking error.** `success` is set to
+  `False` and the error is logged via `HookExecutionEvent`, but the
+  operation still proceeds.
+
+<Warning>
+Only exit code `2` blocks. Exit code `1` (the conventional Unix failure
+code) is treated as a non-blocking error. A hook intended to enforce a
+policy must exit with `2`.
+</Warning>
+
 ## Key Concepts
 
 - Registration points: subscribe to events or attach pre/post hooks around LLM calls and tool execution


### PR DESCRIPTION
## Context

A user asked whether the SDK's stop-hook behavior (only exit code `2` blocks) is (1) consistent with Claude Code, and (2) clearly documented everywhere people learn about hooks.

### (1) Consistency: ✅ already consistent — no SDK behavior change needed

The SDK's `HookExecutor` does:

```python
success = (returncode == 0)
blocked = (returncode == 2)
```

This matches Claude Code's [documented hook contract](https://docs.claude.com/en/docs/claude-code/hooks) exactly:

> Exit 0 = success; Exit 2 = blocking error; any other exit code = non-blocking error.
>
> Warning: For most hook events, only exit code 2 blocks the action. Claude Code treats exit code 1 as a non-blocking error and proceeds with the action, even though 1 is the conventional Unix failure code.

### (2) Documentation gap

This repo's two hooks pages diverge:

| Page | Before |
|---|---|
| `openhands/usage/customization/hooks.mdx` | ✅ Has explicit "Exit codes" section enumerating 0 / 2 / other |
| `sdk/guides/hooks.mdx` | ⚠️ Only "Yes (exit 2)" in the can-block column of a table |

So a developer reading the SDK guide could easily assume the conventional Unix "non-zero = failure = block" semantics — exactly the gotcha Claude Code calls out with a Warning.

## Change

Add an explicit "Exit Codes" section to `sdk/guides/hooks.mdx`, mirroring the wording already used in `openhands/usage/customization/hooks.mdx` and Claude Code's own reference, plus a `<Warning>` callout that only exit `2` blocks.

## Companion PR

The SDK side gets matching updates (HookResult docstring + the `33_hooks` example README) in:

- OpenHands/software-agent-sdk#3097

No code/behavior change; documentation only.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/af4e7a4a-54e0-4215-a85b-96e14b91fa11)