### PR TITLE
docs: fix agent-server Client SDK section with actual API

### DIFF
--- a/sdk/arch/agent-server.mdx
+++ b/sdk/arch/agent-server.mdx
@@ -388,12 +388,12 @@ flowchart LR
 
 | Workspace | Conversation Type | Communication |
 |-----------|------------------|---------------|
-| `LocalWorkspace` | `LocalConversation` | Direct execution |
-| `OpenHandsCloudWorkspace` | `RemoteConversation` | HTTPS + WebSocket to OpenHands Cloud |
-| `APIRemoteWorkspace` | `RemoteConversation` | HTTPS + WebSocket to Runtime API |
-| `DockerWorkspace` | `RemoteConversation` | HTTP + WebSocket to local container |
+| [`LocalWorkspace`](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-sdk/openhands/sdk/workspace/local.py) | [`LocalConversation`](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py) | Direct execution |
+| [`OpenHandsCloudWorkspace`](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-workspace/openhands/workspace/cloud/workspace.py) | [`RemoteConversation`](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py) | HTTPS + WebSocket to OpenHands Cloud |
+| [`APIRemoteWorkspace`](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-workspace/openhands/workspace/remote_api/workspace.py) | [`RemoteConversation`](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py) | HTTPS + WebSocket to Runtime API |
+| [`DockerWorkspace`](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-workspace/openhands/workspace/docker/workspace.py) | [`RemoteConversation`](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py) | HTTP + WebSocket to local container |
 
-### RemoteConversation Responsibilities
+### [`RemoteConversation`](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py) Responsibilities
 
 The `RemoteConversation` implementation handles all client-server concerns:
 

--- a/sdk/arch/agent-server.mdx
+++ b/sdk/arch/agent-server.mdx
@@ -368,39 +368,55 @@ curl https://agent-server.example.com/health
 - Resource exhaustion
 - Container failures
 
-## Client SDK
+## Connecting to Agent Server
 
-Python SDK for interacting with Agent Server:
+The SDK provides workspace classes that connect to remote agent servers. When you use a remote workspace, the `Conversation` factory automatically returns a `RemoteConversation` that communicates with the server via HTTP/WebSocket.
+
+### Using OpenHands Cloud
+
+The simplest way to use a remote agent server is via OpenHands Cloud:
 
 ```python
-from openhands.client import AgentServerClient
+from openhands.sdk import Conversation, RemoteConversation
+from openhands.workspace import OpenHandsCloudWorkspace
 
-client = AgentServerClient(
-    url="https://agent-server.example.com",
-    api_key="your-api-key"
-)
-
-# Create conversation
-conversation = client.create_conversation()
-
-# Send message
-response = client.send_message(
-    conversation_id=conversation.id,
-    message="Hello, agent!"
-)
-
-# Stream responses
-for event in client.stream_conversation(conversation.id):
-    if event.type == "message":
-        print(event.content)
+with OpenHandsCloudWorkspace(
+    cloud_api_url="https://app.all-hands.dev",
+    cloud_api_key="your-api-key",
+) as workspace:
+    # Conversation automatically becomes RemoteConversation
+    conversation = Conversation(agent=agent, workspace=workspace)
+    assert isinstance(conversation, RemoteConversation)
+    
+    conversation.send_message("Hello, agent!")
+    conversation.run()
 ```
 
-**Client handles**:
-- Authentication
-- Request/response serialization
-- Error handling
-- Streaming
-- Retries
+### Using API-based Sandbox
+
+For custom runtime environments, use `APIRemoteWorkspace`:
+
+```python
+from openhands.sdk import Conversation, RemoteConversation
+from openhands.workspace import APIRemoteWorkspace
+
+with APIRemoteWorkspace(
+    runtime_api_url="https://runtime.example.com",
+    runtime_api_key="your-api-key",
+    server_image="ghcr.io/openhands/agent-server:main-python",
+) as workspace:
+    conversation = Conversation(agent=agent, workspace=workspace)
+    assert isinstance(conversation, RemoteConversation)
+    
+    conversation.send_message("Hello, agent!")
+    conversation.run()
+```
+
+**Remote workspaces handle**:
+- Authentication and session management
+- WebSocket streaming for real-time events
+- Container lifecycle management
+- Automatic reconnection and retries
 
 ## Cost Considerations
 

--- a/sdk/arch/agent-server.mdx
+++ b/sdk/arch/agent-server.mdx
@@ -368,55 +368,47 @@ curl https://agent-server.example.com/health
 - Resource exhaustion
 - Container failures
 
-## Connecting to Agent Server
+## Client Integration Architecture
 
-The SDK provides workspace classes that connect to remote agent servers. When you use a remote workspace, the `Conversation` factory automatically returns a `RemoteConversation` that communicates with the server via HTTP/WebSocket.
+The SDK implements a **workspace-based dispatch pattern** for connecting to agent servers. The `Conversation` factory inspects the workspace type and returns the appropriate conversation implementation.
 
-### Using OpenHands Cloud
-
-The simplest way to use a remote agent server is via OpenHands Cloud:
-
-```python
-from openhands.sdk import Conversation, RemoteConversation
-from openhands.workspace import OpenHandsCloudWorkspace
-
-with OpenHandsCloudWorkspace(
-    cloud_api_url="https://app.all-hands.dev",
-    cloud_api_key="your-api-key",
-) as workspace:
-    # Conversation automatically becomes RemoteConversation
-    conversation = Conversation(agent=agent, workspace=workspace)
-    assert isinstance(conversation, RemoteConversation)
+```mermaid
+flowchart LR
+    Conv["Conversation()"] --> Check{"Workspace Type?"}
+    Check -->|LocalWorkspace| Local["LocalConversation"]
+    Check -->|RemoteWorkspace| Remote["RemoteConversation"]
+    Remote -->|HTTP/WebSocket| Server["Agent Server"]
     
-    conversation.send_message("Hello, agent!")
-    conversation.run()
+    style Conv fill:#f3e8ff,stroke:#7c3aed,stroke-width:2px
+    style Remote fill:#e8f3ff,stroke:#2b6cb0,stroke-width:2px
+    style Server fill:#fff4df,stroke:#b7791f,stroke-width:2px
 ```
 
-### Using API-based Sandbox
+### Workspace Types
 
-For custom runtime environments, use `APIRemoteWorkspace`:
+| Workspace | Conversation Type | Communication |
+|-----------|------------------|---------------|
+| `LocalWorkspace` | `LocalConversation` | Direct execution |
+| `OpenHandsCloudWorkspace` | `RemoteConversation` | HTTPS + WebSocket to OpenHands Cloud |
+| `APIRemoteWorkspace` | `RemoteConversation` | HTTPS + WebSocket to Runtime API |
+| `DockerWorkspace` | `RemoteConversation` | HTTP + WebSocket to local container |
 
-```python
-from openhands.sdk import Conversation, RemoteConversation
-from openhands.workspace import APIRemoteWorkspace
+### RemoteConversation Responsibilities
 
-with APIRemoteWorkspace(
-    runtime_api_url="https://runtime.example.com",
-    runtime_api_key="your-api-key",
-    server_image="ghcr.io/openhands/agent-server:main-python",
-) as workspace:
-    conversation = Conversation(agent=agent, workspace=workspace)
-    assert isinstance(conversation, RemoteConversation)
-    
-    conversation.send_message("Hello, agent!")
-    conversation.run()
-```
+The `RemoteConversation` implementation handles all client-server concerns:
 
-**Remote workspaces handle**:
-- Authentication and session management
-- WebSocket streaming for real-time events
-- Container lifecycle management
-- Automatic reconnection and retries
+- **Session management**: Authenticates and maintains connection to agent server
+- **Event streaming**: WebSocket connection for real-time agent events
+- **Request routing**: HTTP calls for conversation lifecycle operations
+- **Reconnection**: Automatic retry logic for transient failures
+
+### Usage Examples
+
+For complete working examples with all required setup:
+
+- **[OpenHands Cloud Workspace](/sdk/guides/agent-server/cloud-workspace)** - Managed cloud infrastructure
+- **[API-based Sandbox](/sdk/guides/agent-server/api-sandbox)** - Custom runtime environments
+- **[Docker Sandbox](/sdk/guides/agent-server/docker-sandbox)** - Local containerized execution
 
 ## Cost Considerations
 


### PR DESCRIPTION
## Summary

This PR fixes the outdated "Client SDK" documentation in the Agent Server architecture page.

## Problem

The documentation at https://docs.openhands.dev/sdk/arch/agent-server#client-sdk referenced a non-existent `AgentServerClient` class:

```python
from openhands.client import AgentServerClient  # THIS MODULE DOES NOT EXIST
```

As reported in #495, there is no such client SDK module in the `openhands-sdk` or `openhands-agent-server` packages.

## Solution

Replace the fictional client SDK documentation with the actual SDK usage patterns:

1. **`OpenHandsCloudWorkspace`** - For connecting to OpenHands Cloud
2. **`APIRemoteWorkspace`** - For custom runtime environments  
3. **`RemoteConversation`** - The actual class returned when using remote workspaces

The new documentation shows the correct pattern where `Conversation()` factory automatically returns a `RemoteConversation` when given a remote workspace.

## Testing

- Verified `openhands.client` module does not exist (`ModuleNotFoundError`)
- Verified `RemoteConversation`, `OpenHandsCloudWorkspace`, and `APIRemoteWorkspace` do exist and are importable
- New code examples match patterns used in existing guides (`api-sandbox.mdx`, `cloud-workspace.mdx`)

Fixes #495

---

*This PR was created by an AI agent (OpenHands) on behalf of the user.*

@VascoSch92 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b8a3540c-fb5c-41a6-8e5b-894f0ff39456)