### PR TITLE
Move Automations from Cloud tab to Documentation > Product Guides > Automation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -63,6 +63,15 @@
                 ]
               },
               {
+                "group": "Automation",
+                "pages": [
+                  "openhands/usage/automations/overview",
+                  "openhands/usage/automations/creating-automations",
+                  "openhands/usage/automations/event-automations",
+                  "openhands/usage/automations/managing-automations"
+                ]
+              },
+              {
                 "group": "Settings",
                 "pages": [
                   "openhands/usage/settings/application-settings",
@@ -419,16 +428,6 @@
               "openhands/usage/cloud/organizations/managing-members",
               "openhands/usage/cloud/organizations/roles-permissions",
               "openhands/usage/cloud/organizations/settings"
-            ]
-          },
-          {
-            "group": "Automations (BETA)",
-            "icon": "clock",
-            "pages": [
-              "openhands/usage/automations/overview",
-              "openhands/usage/automations/creating-automations",
-              "openhands/usage/automations/event-automations",
-              "openhands/usage/automations/managing-automations"
             ]
           }
         ]

--- a/docs.json
+++ b/docs.json
@@ -63,7 +63,7 @@
                 ]
               },
               {
-                "group": "Automation",
+                "group": "Automations",
                 "pages": [
                   "openhands/usage/automations/overview",
                   "openhands/usage/automations/creating-automations",

--- a/enterprise/enterprise-vs-oss.mdx
+++ b/enterprise/enterprise-vs-oss.mdx
@@ -13,15 +13,17 @@ The table below highlights the key differences between the OpenHands Local GUI a
 | Feature | Local GUI | OpenHands Enterprise |
 |---------|-------------------|----------------------|
 | **Full breadth of agent functionality (sub-agents, MCP, skills, model agnosticism)** | ✅ | ✅ |
-| **Where does the agent run?** | Local dev machines | Scalable, runtime sandboxes |
+| **Where does the agent run?** | Locally or on a custom backend | Scalable, Kubernetes runtimes |
 | **Scalability** *Run multiple concurrent agent conversations* | Limited by machine | Unlimited, on-demand |
-| **'@OpenHands' in Slack and Jira** *Important for real-time resolution of bugs and feedback* | ❌ | ✅ |
-| **'@OpenHands' in GitHub, GitLab, Bitbucket** *Important for real-time resolution of PR comments and failing tests* | ❌ | ✅ |
+| **Automations** *Create scheduled and event-based workflows* | ✅  | ✅ |
+| **'@OpenHands' in Slack and Jira** *Important for real-time resolution of bugs and feedback* | ✅ Requires custom [Automation](/openhands/usage/automations/overview) | ✅ Native integration |
+| **'@OpenHands' in GitHub, GitLab, Bitbucket** *Important for real-time resolution of PR comments and failing tests* | ✅ Requires custom [Automation](/openhands/usage/automations/overview) | ✅ |
 | **Multiple agent conversations in one place** *Give users visibility into all agent conversations* | ✅ | ✅ |
 | **Share conversations** *Unlock collaboration use cases* | ❌ | ✅ |
-| **Remote monitoring of agent conversations** *Enable Human-in-the-Loop operations for running agents* | ❌ Requires access to machine where agent is running | ✅ Monitor remotely from OpenHands Enterprise UI |
-| **Multi-user management and RBAC** *Roll out to several users and teams* | ❌ | ✅ |
-| **Automations** *Create scheduled and event-based workflows* | ❌ | ✅ |
+| **Multi-user Organizations and RBAC** *Roll out to several users and teams* | ❌ | ✅ |
+| **User and Organization Budgets** *Monitor and control costs* | ❌ | ✅ |
+| **Agent Observability Integrations** *Centralized logging of conversations* | ❌ | ✅ Integrates Laminar |
+| **Private Plugin Marketplace** *Publish reusable plugins for teams to use* | ❌ | ✅ |
 | **SAML** | ❌ | ✅ |
 | **REST APIs** | ❌ | ✅ |
 
@@ -40,11 +42,11 @@ The OpenHands Local GUI is ideal for:
 
 OpenHands Enterprise is the right choice when you need:
 
-- **Team collaboration** — Share conversations and manage multiple users from a single platform
+- **Multi-use RBAC** — Manage multiple users from a single platform
 - **Platform integrations** — Invoke OpenHands directly from Slack, Jira, GitHub, GitLab, or Bitbucket
 - **Scalability** — Run unlimited parallel agent conversations without local resource constraints
 - **Enterprise security** — SAML authentication, RBAC, and centralized audit logs
-- **Remote monitoring** — Track agent progress in real-time from anywhere
+- **Usage Monitoring** — Track and enforce budgets; monitor usage across all users
 
 ## Getting Started
 

--- a/enterprise/enterprise-vs-oss.mdx
+++ b/enterprise/enterprise-vs-oss.mdx
@@ -14,16 +14,15 @@ The table below highlights the key differences between the OpenHands Local GUI a
 |---------|-------------------|----------------------|
 | **Full breadth of agent functionality (sub-agents, MCP, skills, model agnosticism)** | ✅ | ✅ |
 | **Where does the agent run?** | Locally or on a custom backend | Scalable, Kubernetes runtimes |
-| **Scalability** *Run multiple concurrent agent conversations* | Limited by machine | Unlimited, on-demand |
-| **Automations** *Create scheduled and event-based workflows* | ✅  | ✅ |
-| **'@OpenHands' in Slack and Jira** *Important for real-time resolution of bugs and feedback* | ✅ Requires custom [Automation](/openhands/usage/automations/overview) | ✅ Native integration |
-| **'@OpenHands' in GitHub, GitLab, Bitbucket** *Important for real-time resolution of PR comments and failing tests* | ✅ Requires custom [Automation](/openhands/usage/automations/overview) | ✅ |
-| **Multiple agent conversations in one place** *Give users visibility into all agent conversations* | ✅ | ✅ |
-| **Share conversations** *Unlock collaboration use cases* | ❌ | ✅ |
-| **Multi-user Organizations and RBAC** *Roll out to several users and teams* | ❌ | ✅ |
-| **User and Organization Budgets** *Monitor and control costs* | ❌ | ✅ |
-| **Agent Observability Integrations** *Centralized logging of conversations* | ❌ | ✅ Integrates Laminar |
-| **Private Plugin Marketplace** *Publish reusable plugins for teams to use* | ❌ | ✅ |
+| **Scalability** <br> *Run multiple concurrent agent conversations* | Limited by machine | Unlimited, on-demand |
+| **Automations** <br> *Create scheduled and event-based workflows* | ✅  | ✅ |
+| **'@OpenHands' in Slack and Jira** <br> *Important for real-time resolution of bugs and feedback* | ✅ Requires custom [Automation](/openhands/usage/automations/overview) | ✅ Native integration |
+| **'@OpenHands' in GitHub, GitLab, Bitbucket** <br> *Important for real-time resolution of PR comments and failing tests* | ✅ Requires custom [Automation](/openhands/usage/automations/overview) | ✅ |
+| **Share conversations** <br> *Unlock collaboration use cases* | ❌ | ✅ |
+| **Multi-user Organizations and RBAC** <br> *Roll out to several users and teams* | ❌ | ✅ |
+| **User and Organization Budgets** <br> *Monitor and control costs* | ❌ | ✅ |
+| **Agent Observability Integrations** <br> *Centralized logging of conversations* | ❌ | ✅ Integrates Laminar |
+| **Private Plugin Marketplace** <br> *Publish reusable plugins for teams to use* | ❌ | ✅ |
 | **SAML** | ❌ | ✅ |
 | **REST APIs** | ❌ | ✅ |
 

--- a/enterprise/enterprise-vs-oss.mdx
+++ b/enterprise/enterprise-vs-oss.mdx
@@ -14,7 +14,6 @@ The table below highlights the key differences between the OpenHands Local GUI a
 |---------|-------------------|----------------------|
 | **Full breadth of agent functionality (sub-agents, MCP, skills, model agnosticism)** | ✅ | ✅ |
 | **Where does the agent run?** | Locally or on a custom backend | Scalable, Kubernetes runtimes |
-| **Scalability** <br /> *Run multiple concurrent agent conversations* | Limited by machine | Unlimited, on-demand |
 | **Automations** <br /> *Create scheduled and event-based workflows* | ✅  | ✅ |
 | **'@OpenHands' in Slack and Jira** <br /> *Important for real-time resolution of bugs and feedback* | Requires custom [Automation](/openhands/usage/automations/overview) | Native integration |
 | **'@OpenHands' in GitHub, GitLab, Bitbucket** <br /> *Important for real-time resolution of PR comments and failing tests* | Requires custom [Automation](/openhands/usage/automations/overview) | Native integration |

--- a/enterprise/enterprise-vs-oss.mdx
+++ b/enterprise/enterprise-vs-oss.mdx
@@ -16,12 +16,12 @@ The table below highlights the key differences between the OpenHands Local GUI a
 | **Where does the agent run?** | Locally or on a custom backend | Scalable, Kubernetes runtimes |
 | **Scalability** <br> *Run multiple concurrent agent conversations* | Limited by machine | Unlimited, on-demand |
 | **Automations** <br> *Create scheduled and event-based workflows* | ✅  | ✅ |
-| **'@OpenHands' in Slack and Jira** <br> *Important for real-time resolution of bugs and feedback* | ✅ Requires custom [Automation](/openhands/usage/automations/overview) | ✅ Native integration |
-| **'@OpenHands' in GitHub, GitLab, Bitbucket** <br> *Important for real-time resolution of PR comments and failing tests* | ✅ Requires custom [Automation](/openhands/usage/automations/overview) | ✅ |
+| **'@OpenHands' in Slack and Jira** <br> *Important for real-time resolution of bugs and feedback* | Requires custom [Automation](/openhands/usage/automations/overview) | Native integration |
+| **'@OpenHands' in GitHub, GitLab, Bitbucket** <br> *Important for real-time resolution of PR comments and failing tests* | Requires custom [Automation](/openhands/usage/automations/overview) | Native integration |
 | **Share conversations** <br> *Unlock collaboration use cases* | ❌ | ✅ |
 | **Multi-user Organizations and RBAC** <br> *Roll out to several users and teams* | ❌ | ✅ |
 | **User and Organization Budgets** <br> *Monitor and control costs* | ❌ | ✅ |
-| **Agent Observability Integrations** <br> *Centralized logging of conversations* | ❌ | ✅ Integrates Laminar |
+| **Agent Observability Integrations** <br> *Centralized logging of conversations* | ❌ | ✅ Uses Laminar|
 | **Private Plugin Marketplace** <br> *Publish reusable plugins for teams to use* | ❌ | ✅ |
 | **SAML** | ❌ | ✅ |
 | **REST APIs** | ❌ | ✅ |

--- a/enterprise/enterprise-vs-oss.mdx
+++ b/enterprise/enterprise-vs-oss.mdx
@@ -14,15 +14,15 @@ The table below highlights the key differences between the OpenHands Local GUI a
 |---------|-------------------|----------------------|
 | **Full breadth of agent functionality (sub-agents, MCP, skills, model agnosticism)** | ✅ | ✅ |
 | **Where does the agent run?** | Locally or on a custom backend | Scalable, Kubernetes runtimes |
-| **Scalability** <br> *Run multiple concurrent agent conversations* | Limited by machine | Unlimited, on-demand |
-| **Automations** <br> *Create scheduled and event-based workflows* | ✅  | ✅ |
-| **'@OpenHands' in Slack and Jira** <br> *Important for real-time resolution of bugs and feedback* | Requires custom [Automation](/openhands/usage/automations/overview) | Native integration |
-| **'@OpenHands' in GitHub, GitLab, Bitbucket** <br> *Important for real-time resolution of PR comments and failing tests* | Requires custom [Automation](/openhands/usage/automations/overview) | Native integration |
-| **Share conversations** <br> *Unlock collaboration use cases* | ❌ | ✅ |
-| **Multi-user Organizations and RBAC** <br> *Roll out to several users and teams* | ❌ | ✅ |
-| **User and Organization Budgets** <br> *Monitor and control costs* | ❌ | ✅ |
-| **Agent Observability Integrations** <br> *Centralized logging of conversations* | ❌ | ✅ Uses Laminar|
-| **Private Plugin Marketplace** <br> *Publish reusable plugins for teams to use* | ❌ | ✅ |
+| **Scalability** <br /> *Run multiple concurrent agent conversations* | Limited by machine | Unlimited, on-demand |
+| **Automations** <br /> *Create scheduled and event-based workflows* | ✅  | ✅ |
+| **'@OpenHands' in Slack and Jira** <br /> *Important for real-time resolution of bugs and feedback* | Requires custom [Automation](/openhands/usage/automations/overview) | Native integration |
+| **'@OpenHands' in GitHub, GitLab, Bitbucket** <br /> *Important for real-time resolution of PR comments and failing tests* | Requires custom [Automation](/openhands/usage/automations/overview) | Native integration |
+| **Share conversations** <br /> *Unlock collaboration use cases* | ❌ | ✅ |
+| **Multi-user Organizations and RBAC** <br /> *Roll out to several users and teams* | ❌ | ✅ |
+| **User and Organization Budgets** <br /> *Monitor and control costs* | ❌ | ✅ |
+| **Agent Observability Integrations** <br /> *Centralized logging of conversations* | ❌ | ✅ Uses Laminar|
+| **Private Plugin Marketplace** <br /> *Publish reusable plugins for teams to use* | ❌ | ✅ |
 | **SAML** | ❌ | ✅ |
 | **REST APIs** | ❌ | ✅ |
 

--- a/enterprise/enterprise-vs-oss.mdx
+++ b/enterprise/enterprise-vs-oss.mdx
@@ -4,13 +4,13 @@ description: Compare OpenHands Enterprise and Open Source offerings to choose th
 icon: scale-balanced
 ---
 
-This page describes the key differences between **OpenHands Local GUI** (open source) for individual developers and small teams running the Local GUI on their own machines, and **OpenHands Enterprise** for organizations that need advanced collaboration, integrations, and management capabilities.
+This page describes the key differences between **OpenHands Agent Canvas** (open source) for individual developers and small teams running the Agent Canvas on their own machines, and **OpenHands Enterprise** for organizations that need advanced collaboration, integrations, and management capabilities.
 
 ## Feature Comparison
 
-The table below highlights the key differences between the OpenHands Local GUI and OpenHands Enterprise offerings:
+The table below highlights the key differences between the OpenHands Agent Canvas and OpenHands Enterprise offerings:
 
-| Feature | Local GUI | OpenHands Enterprise |
+| Feature | Agent Canvas | OpenHands Enterprise |
 |---------|-------------------|----------------------|
 | **Full breadth of agent functionality (sub-agents, MCP, skills, model agnosticism)** | ✅ | ✅ |
 | **Where does the agent run?** | Locally or on a custom backend | Scalable, Kubernetes runtimes |
@@ -27,14 +27,14 @@ The table below highlights the key differences between the OpenHands Local GUI a
 
 ## When to Choose Each Option
 
-### OpenHands Local GUI
+### OpenHands Agent Canvas
 
-The OpenHands Local GUI is ideal for:
+The OpenHands Agent Canvas is ideal for:
 
 - Individual developers exploring AI-assisted coding
 - Small teams with basic requirements
 - Self-hosted environments where you manage your own infrastructure
-- Running OpenHands locally on your own machine
+- Running OpenHands locally on your own machine using the Agent Canvas
 
 ### OpenHands Enterprise
 
@@ -50,7 +50,7 @@ OpenHands Enterprise is the right choice when you need:
 
 <CardGroup cols={2}>
   <Card
-    title="Try Local GUI"
+    title="Try Agent Canvas"
     icon="desktop"
     href="/openhands/usage/run-openhands/local-setup#start-the-app"
   >

--- a/openhands/usage/automations/creating-automations.mdx
+++ b/openhands/usage/automations/creating-automations.mdx
@@ -3,10 +3,6 @@ title: Creating Automations
 description: Learn how to create scheduled automations using the Automation Skill.
 ---
 
-<Info>
-**Beta Feature**: Automations is currently in beta and available for **OpenHands Cloud** and **OpenHands Enterprise** users only.
-</Info>
-
 The easiest way to create an automation is to ask OpenHands directly. The Automation Skill handles all the details—you just describe what you want.
 
 ## Prompt vs Plugin Automations
@@ -81,7 +77,7 @@ The prompt is what the AI agent executes each time the automation runs. Write it
 
 Tell the automation what to do with its output:
 
-- "Post to the #alerts Slack channel" (requires [Slack MCP](/openhands/usage/cloud/slack-installation))
+- "Post to the #alerts Slack channel" (requires [Slack MCP](/openhands/usage/settings/mcp-settings))
 - "Save to `reports/weekly-summary.md`"
 - "Create a GitHub issue with the findings" (automatic if you logged in with GitHub)
 - "Send a message via the configured notification service"
@@ -111,7 +107,7 @@ Each automation runs in a full OpenHands sandbox with:
 - **Your secrets**: Access API keys stored in Settings > Secrets
 - **MCP integrations**: Use your configured MCP servers
 - **Network access**: Make HTTP requests, connect to APIs
-- **Git provider access**: Tokens from your Cloud login (GitHub, GitLab, or Bitbucket) are automatically included
+- **Git provider access**: Tokens from your login (GitHub, GitLab, or Bitbucket) are automatically included
 
 ## Schedules
 

--- a/openhands/usage/automations/event-automations.mdx
+++ b/openhands/usage/automations/event-automations.mdx
@@ -3,10 +3,6 @@ title: Event-Based Automations
 description: Trigger automations from GitHub events or custom webhooks instead of cron schedules.
 ---
 
-<Info>
-**Beta Feature**: Event-based automations are in beta for **OpenHands Cloud** and **OpenHands Enterprise** users.
-</Info>
-
 Event-based automations run when something happens—a PR is opened, an issue is commented on, or a webhook fires—instead of on a schedule. This is ideal for responsive workflows like auto-reviewing PRs, triaging issues, or reacting to external service events.
 
 ## Built-In vs. Custom Integrations

--- a/openhands/usage/automations/event-automations.mdx
+++ b/openhands/usage/automations/event-automations.mdx
@@ -93,7 +93,9 @@ For services beyond GitHub—like Linear, Stripe, or Slack—register a custom w
 
 ### Walkthrough: Linear Integration
 
-This example walks through setting up a Linear webhook to auto-triage new issues.
+<Note>
+This example walks through setting up a Linear webhook to auto-triage new issues using Automations in **[OpenHands Cloud](https://app.all-hands.dev)**.
+</Note>
 
 #### Step 1: Get Your Webhook Secret from Linear
 

--- a/openhands/usage/automations/managing-automations.mdx
+++ b/openhands/usage/automations/managing-automations.mdx
@@ -3,10 +3,6 @@ title: Managing Automations
 description: List, update, enable, disable, and delete your automations.
 ---
 
-<Info>
-**Beta Feature**: Automations is currently in beta and available for **OpenHands Cloud** and **OpenHands Enterprise** users only.
-</Info>
-
 You can manage your automations by asking OpenHands directly—just like you created them.
 
 ## Viewing Your Automations

--- a/openhands/usage/automations/overview.mdx
+++ b/openhands/usage/automations/overview.mdx
@@ -81,7 +81,7 @@ our open GitHub issues, then posts to #engineering on Slack.
 
 Once you create an automation, you can view them by clicking on the "Automations" icon on the left-hand navigation.
 
-You can also ask OpenHands to list [existing automations, enable/disable them, or trigger manual runs—all through conversation](managing-automations.mdx).
+You can also ask OpenHands to list [existing automations, enable/disable them, or trigger manual runs](managing-automations).
 
 
 

--- a/openhands/usage/automations/overview.mdx
+++ b/openhands/usage/automations/overview.mdx
@@ -81,7 +81,7 @@ our open GitHub issues, then posts to #engineering on Slack.
 
 Once you create an automation, you can view them by clicking on the "Automations" icon on the left-hand navigation.
 
-You can also ask OpenHands to list [existing automations, enable/disable them, or trigger manual runs](managing-automations).
+You can also ask OpenHands to list [existing automations, enable/disable them, or trigger manual runs](/openhands/usage/automations/managing-automations).
 
 
 

--- a/openhands/usage/automations/overview.mdx
+++ b/openhands/usage/automations/overview.mdx
@@ -1,15 +1,11 @@
 ---
 title: Automations Overview
-description: Create scheduled tasks that run automatically in OpenHands Cloud and Enterprise.
+description: Create scheduled tasks that run automatically in OpenHands.
 ---
-
-<Info>
-**Beta Feature**: Automations is currently in beta and available for **OpenHands Cloud** and **OpenHands Enterprise** users only.
-</Info>
 
 Automations let you schedule AI-powered tasks that run automatically—daily reports, health checks, data syncs, and more. Each automation runs a full OpenHands conversation on your chosen schedule, with access to your LLM settings, stored secrets, and integrations.
 
-Your git provider credentials are automatically available—if you logged into OpenHands Cloud with GitHub, GitLab, or Bitbucket, that access is included by default.
+Your git provider credentials are automatically available—if you logged into OpenHands with GitHub, GitLab, or Bitbucket, that access is included by default.
 
 ## What Can Automations Do?
 
@@ -20,7 +16,7 @@ Your git provider credentials are automatically available—if you logged into O
 - **Send notifications**: Post updates to Slack, create GitHub issues, or send alerts
 
 <Note>
-Automations can only interact with services you've configured access to. For example, posting to Slack requires the [Slack MCP integration](/openhands/usage/cloud/slack-installation). Git providers you logged in with (GitHub, GitLab, Bitbucket) are automatically available.
+Automations can only interact with services you've configured access to. For example, posting to Slack requires the [Slack MCP integration](/openhands/usage/settings/mcp-settings). Git providers you logged in with (GitHub, GitLab, Bitbucket) are automatically available.
 </Note>
 
 ## Two Types of Automations
@@ -67,7 +63,7 @@ When your automation runs:
 
 Automations are user-scoped—each automation and its runs belong to you. Conversations created by your automations automatically appear in your conversations list, just like any other conversation you start.
 
-Your automation has access to everything a normal OpenHands conversation does: terminal, file editing, your configured LLM, stored secrets, and MCP integrations. Git provider tokens from your Cloud login (GitHub, GitLab, or Bitbucket) are automatically included.
+Your automation has access to everything a normal OpenHands conversation does: terminal, file editing, your configured LLM, stored secrets, and MCP integrations. Git provider tokens from your login (GitHub, GitLab, or Bitbucket) are automatically included.
 
 ## Getting Started
 
@@ -98,8 +94,7 @@ You can also list existing automations, enable/disable them, or trigger manual r
 
 ## Prerequisites
 
-- **OpenHands Cloud or Enterprise account** (not available in open-source)
-- **Configured LLM** in your [settings](https://app.all-hands.dev/settings)
+- **Configured LLM** in your settings
 - **Stored secrets** (optional) for any additional API keys your automations need (e.g., Slack tokens)
 
 ---

--- a/openhands/usage/automations/overview.mdx
+++ b/openhands/usage/automations/overview.mdx
@@ -67,21 +67,10 @@ Your automation has access to everything a normal OpenHands conversation does: t
 
 ## Getting Started
 
-Before creating automations, complete this one-time setup:
+**Prerequisites**
 
-### 1. Create an OpenHands API Key
-
-Go to [Settings > API Keys](https://app.all-hands.dev/settings/api-keys) and create a new API key.
-
-### 2. Save the API Key as a Secret
-
-Copy the API key value and go to [Settings > Secrets](https://app.all-hands.dev/settings/secrets). Create a new secret with:
-- **Name**: `OPENHANDS_API_KEY`
-- **Value**: Your API key from step 1
-
-This allows the Automation Skill to create and manage automations on your behalf.
-
-### 3. Start a Conversation
+- **Configured LLM** in your settings
+- **Stored secrets** (optional) for any additional API keys your automations need (e.g., Slack tokens)
 
 Open a new conversation in OpenHands and ask it to create an automation:
 
@@ -90,12 +79,11 @@ Create an automation that runs every Monday at 9 AM and summarizes
 our open GitHub issues, then posts to #engineering on Slack.
 ```
 
-You can also list existing automations, enable/disable them, or trigger manual runs—all through conversation.
+Once you create an automation, you can view them by clicking on the "Automations" icon on the left-hand navigation.
 
-## Prerequisites
+You can also ask OpenHands to list [existing automations, enable/disable them, or trigger manual runs—all through conversation](managing-automations.mdx).
 
-- **Configured LLM** in your settings
-- **Stored secrets** (optional) for any additional API keys your automations need (e.g., Slack tokens)
+
 
 ---
 


### PR DESCRIPTION
## Summary

Moves the "Automations" section from the Cloud tab to the Documentation tab, under "Product Guides > Automation", in preparation for open-sourcing Automations.

## Changes

- **Removed** the "Automations (BETA)" group from the Cloud tab
- **Added** a new "Automation" group under "Product Guides" in the Documentation tab

The same documentation pages are referenced:
- `openhands/usage/automations/overview`
- `openhands/usage/automations/creating-automations`
- `openhands/usage/automations/event-automations`
- `openhands/usage/automations/managing-automations`

## Notes

- Removed the "(BETA)" label from the group name since Automations is being open-sourced
- Removed the clock icon that was previously on the Cloud tab group

---

*This PR was created by an AI agent (OpenHands) on behalf of the user.*

@jpelletier1 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/bf75aa40-09fa-402b-ad6c-e7d30303599a)