### PR TITLE
docs: document SDK switch LLM example

### DIFF
--- a/sdk/guides/agent-server/cloud-workspace.mdx
+++ b/sdk/guides/agent-server/cloud-workspace.mdx
@@ -383,6 +383,17 @@ cd agent-sdk
 uv run python examples/02_remote_agent_server/10_cloud_workspace_share_credentials.py
 ```
 
+
+## Settings and Secrets API Examples
+
+The remote agent-server examples also include end-to-end scripts for settings-backed secrets and authenticated LLM configuration:
+
+- [examples/02_remote_agent_server/12_settings_and_secrets_api.py](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/02_remote_agent_server/12_settings_and_secrets_api.py) demonstrates storing secrets through the Settings and Secrets API, referencing them with `LookupSecret`, and cleaning them up after use.
+- [examples/02_remote_agent_server/13_workspace_get_llm.py](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/02_remote_agent_server/13_workspace_get_llm.py) demonstrates configuring LLM settings on an authenticated agent-server and retrieving them through `RemoteWorkspace.get_llm()`.
+
+<RunExampleCode path_to_script="examples/02_remote_agent_server/12_settings_and_secrets_api.py"/>
+<RunExampleCode path_to_script="examples/02_remote_agent_server/13_workspace_get_llm.py"/>
+
 ## Next Steps
 
 - **[API-based Sandbox](/sdk/guides/agent-server/api-sandbox)** - Connect to Runtime API service

--- a/sdk/guides/llm-profile-store.mdx
+++ b/sdk/guides/llm-profile-store.mdx
@@ -232,6 +232,17 @@ store.delete("gpt")
 
 <RunExampleCode path_to_script="examples/01_standalone_sdk/44_model_switching_in_convo.py"/>
 
+
+## Agent-Driven LLM Switching
+
+Saved profiles can also be exposed to the agent through the `switch_llm` built-in tool. The tool call switches the conversation's active profile after the current model finishes the tool call, so future model calls use the selected profile.
+
+<Note>
+This example is available on GitHub: [examples/01_standalone_sdk/49_switch_llm_tool.py](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/01_standalone_sdk/49_switch_llm_tool.py)
+</Note>
+
+<RunExampleCode path_to_script="examples/01_standalone_sdk/49_switch_llm_tool.py"/>
+
 ## Next Steps
 
 - **[LLM Registry](/sdk/guides/llm-registry)** - Manage multiple LLMs in memory at runtime


### PR DESCRIPTION
## Summary
- Document the new `switch_llm` SDK example in the LLM Profile Store guide.
- Add docs references for the settings/secrets and `workspace.get_llm()` remote agent-server examples so the SDK documented-example check passes.

## Validation
- `DOCS_PATH=/workspace/project/openhands-docs python /workspace/project/software-agent-sdk/.github/scripts/check_documented_examples.py`

_This pull request was created by an AI agent (OpenHands) on behalf of the user._
