### PR TITLE
Update agent settings guide for canonical class

### DIFF
--- a/sdk/guides/agent-settings.mdx
+++ b/sdk/guides/agent-settings.mdx
@@ -7,9 +7,9 @@ import RunExampleCode from "/sdk/shared-snippets/how-to-run-example.mdx";
 
 > A ready-to-run example is available [here](#ready-to-run-example)!
 
-`AgentSettings` gives you a structured, serializable way to define an agent's model, tools, and optional subsystems like the condenser. Use it when you want to store agent configuration in JSON, send it over an API, or rebuild agents from validated settings later.
+`OpenHandsAgentSettings` gives you a structured, serializable way to define an agent's model, tools, and optional subsystems like the condenser. Use it when you want to store agent configuration in JSON, send it over an API, or rebuild agents from validated settings later.
 
-## Why Use AgentSettings
+## Why Use Agent Settings
 
 - Keep agent configuration as data instead of wiring everything together imperatively.
 - Validate settings with Pydantic before creating an agent.
@@ -18,17 +18,17 @@ import RunExampleCode from "/sdk/shared-snippets/how-to-run-example.mdx";
 
 ## Build Settings
 
-Create an `AgentSettings` object with the same ingredients you would normally pass to an `Agent`.
+Create an `OpenHandsAgentSettings` object with the same ingredients you would normally pass to an `Agent`.
 
 ```python icon="python" focus={8, 11, 12, 13}
 from pydantic import SecretStr
 
-from openhands.sdk import AgentSettings, LLM, Tool
-from openhands.sdk.settings import CondenserSettings
+from openhands.sdk import LLM, Tool
+from openhands.sdk.settings import CondenserSettings, OpenHandsAgentSettings
 from openhands.tools.file_editor import FileEditorTool
 from openhands.tools.terminal import TerminalTool
 
-settings = AgentSettings(
+settings = OpenHandsAgentSettings(
     llm=LLM(
         model="anthropic/claude-sonnet-4-5-20250929",
         api_key=SecretStr("your-api-key"),
@@ -43,11 +43,11 @@ settings = AgentSettings(
 
 ## Serialize and Restore Settings
 
-Because `AgentSettings` is a Pydantic model, you can dump it to JSON-compatible data and restore it later.
+Because `OpenHandsAgentSettings` is a Pydantic model, you can dump it to JSON-compatible data and restore it later.
 
 ```python icon="python" focus={1, 2}
 payload = settings.model_dump(mode="json")
-restored = AgentSettings.model_validate(payload)
+restored = OpenHandsAgentSettings.model_validate(payload)
 ```
 
 This is useful when:
@@ -74,10 +74,10 @@ This example is available on GitHub: [examples/01_standalone_sdk/46_agent_settin
 </Note>
 
 ```python icon="python" expandable examples/01_standalone_sdk/46_agent_settings.py
-"""Create, serialize, and deserialize AgentSettings, then build a working agent.
+"""Create, serialize, and deserialize OpenHandsAgentSettings, then build an agent.
 
 Demonstrates:
-1. Configuring an agent entirely through AgentSettings (LLM, tools, condenser).
+1. Configuring an agent entirely through OpenHandsAgentSettings (LLM, tools, condenser).
 2. Serializing settings to JSON and restoring them.
 3. Building an Agent from settings via ``create_agent()``.
 4. Running a short conversation to prove the settings take effect.
@@ -89,7 +89,7 @@ import os
 
 from pydantic import SecretStr
 
-from openhands.sdk import LLM, AgentSettings, Conversation, Tool
+from openhands.sdk import LLM, Conversation, OpenHandsAgentSettings, Tool
 from openhands.sdk.settings import CondenserSettings
 from openhands.tools.file_editor import FileEditorTool
 from openhands.tools.terminal import TerminalTool
@@ -99,7 +99,7 @@ from openhands.tools.terminal import TerminalTool
 api_key = os.getenv("LLM_API_KEY")
 assert api_key is not None, "LLM_API_KEY environment variable is not set."
 
-settings = AgentSettings(
+settings = OpenHandsAgentSettings(
     llm=LLM(
         model=os.getenv("LLM_MODEL", "anthropic/claude-sonnet-4-5-20250929"),
         api_key=SecretStr(api_key),
@@ -118,7 +118,7 @@ print("Serialized settings (JSON):")
 print(json.dumps(payload, indent=2, default=str)[:800], "…")
 print()
 
-restored = AgentSettings.model_validate(payload)
+restored = OpenHandsAgentSettings.model_validate(payload)
 assert restored.condenser.enabled is True
 assert restored.condenser.max_size == 50
 assert len(restored.tools) == 2
@@ -149,7 +149,7 @@ print()
 
 # ── 4. Different settings → different behavior ───────────────────────────
 # Now create settings with ONLY the terminal tool and condenser disabled.
-terminal_only_settings = AgentSettings(
+terminal_only_settings = OpenHandsAgentSettings(
     llm=settings.llm,
     tools=[Tool(name=TerminalTool.name)],
     condenser=CondenserSettings(enabled=False),


### PR DESCRIPTION
## Summary
- update the SDK Agent Settings guide to use `OpenHandsAgentSettings` instead of the deprecated `AgentSettings` alias
- refresh the embedded example imports and constructors to match OpenHands/software-agent-sdk#3208

This prepares the docs for the SDK PR that removes the deprecated `AgentSettings` public alias.

## Testing
- Not run; documentation-only change.

This PR was created by an AI agent (OpenHands) on behalf of the user.