### PR TITLE
docs: update SDK example entrypoint paths

### DIFF
--- a/sdk/guides/agent-server/custom-tools.mdx
+++ b/sdk/guides/agent-server/custom-tools.mdx
@@ -239,7 +239,7 @@ ENV PYTHONPATH="/app:${PYTHONPATH}"
 This example is available on GitHub: [examples/02_remote_agent_server/06_custom_tool/](https://github.com/OpenHands/software-agent-sdk/tree/main/examples/02_remote_agent_server/06_custom_tool)
 </Note>
 
-```python icon="python" expandable examples/02_remote_agent_server/06_custom_tool/custom_tool_example.py
+```python icon="python" expandable examples/02_remote_agent_server/06_custom_tool/main.py
 """Example: Using custom tools with remote agent server.
 
 This example demonstrates how to use custom tools with a remote agent server

--- a/sdk/guides/hooks.mdx
+++ b/sdk/guides/hooks.mdx
@@ -58,7 +58,7 @@ policy must exit with `2`.
 This example is available on GitHub: [examples/01_standalone_sdk/33_hooks](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/01_standalone_sdk/33_hooks/)
 </Note>
 
-```python icon="python" expandable examples/01_standalone_sdk/33_hooks/33_hooks.py
+```python icon="python" expandable examples/01_standalone_sdk/33_hooks/main.py
 """OpenHands Agent SDK — Hooks Example
 
 Demonstrates the OpenHands hooks system.
@@ -212,7 +212,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
     cost = conversation.conversation_stats.get_combined_metrics().accumulated_cost
     print(f"\nEXAMPLE_COST: {cost}")
 ```
-<RunExampleCode path_to_script="examples/01_standalone_sdk/33_hooks/33_hooks.py"/>
+<RunExampleCode path_to_script="examples/01_standalone_sdk/33_hooks/main.py"/>
 
 
 ### Hook Scripts


### PR DESCRIPTION
## Summary

- Update SDK hooks guide to reference `examples/01_standalone_sdk/33_hooks/main.py`
- Update remote custom tools guide to reference `examples/02_remote_agent_server/06_custom_tool/main.py`
- Align docs with OpenHands/software-agent-sdk#3259 directory example entrypoint renames

## Validation

- `git diff --check`
- Confirmed old example filenames are no longer referenced in the edited docs

_This pull request was created by an AI agent (OpenHands) on behalf of the user._