### PR TITLE
docs: add external PostgreSQL configuration guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -439,6 +439,7 @@
           "enterprise/enterprise-vs-oss",
           "enterprise/quick-start",
           "enterprise/analytics",
+          "enterprise/external-postgres",
           {
             "group": "K8s Install",
             "pages": [

--- a/enterprise/external-postgres.mdx
+++ b/enterprise/external-postgres.mdx
@@ -39,7 +39,8 @@ automatically create all required databases during installation.
 CREATE USER openhands_user WITH PASSWORD 'your-secure-password' CREATEDB;
 ```
 
-The user also needs permission to grant `USAGE` and `CREATE` on the `public` schema.
+When the user creates its own databases, it will automatically have all necessary privileges
+on them including the ability to manage the `public` schema.
 
 ### Option 2: Manual Database Creation
 
@@ -102,9 +103,7 @@ in the Admin Console or Helm values:
 - **Port**: PostgreSQL port (default: 5432)
 - **Username**: The database user created above
 - **Password**: The user's password
-- **SSL Mode**: Configure based on your security requirements
 
 <Note>
-  For production deployments, we recommend enabling SSL/TLS for database connections
-  and using a connection pooler like PgBouncer for improved performance.
+  For production deployments, we recommend enabling SSL/TLS for database connections.
 </Note>

--- a/enterprise/external-postgres.mdx
+++ b/enterprise/external-postgres.mdx
@@ -1,0 +1,110 @@
+---
+title: External PostgreSQL
+description: Configure OpenHands Enterprise to use your own PostgreSQL database
+icon: database
+---
+
+OpenHands Enterprise can connect to an external PostgreSQL instance instead of using
+the bundled database. This is useful when you have existing database infrastructure,
+need specific backup/recovery procedures, or require high availability configurations.
+
+## PostgreSQL Version
+
+OpenHands Enterprise requires **PostgreSQL 16.4.0 or above**. PostgreSQL 17 is also supported.
+
+## Required Databases
+
+OpenHands Enterprise uses the following databases:
+
+| Database | Purpose |
+|----------|---------|
+| `openhands` | Core application data |
+| `bitnami_keycloak` | Identity and access management |
+| `litellm` | LLM proxy configuration and usage tracking |
+| `runtime_api_db` | Runtime/sandbox management |
+| `automations` | Scheduled tasks and automation workflows |
+
+## Database User Requirements
+
+The PostgreSQL user provided to OpenHands Enterprise needs specific privileges depending
+on your preferred setup approach.
+
+### Option 1: Automatic Database Creation (Recommended)
+
+If you provide a database user with the `CREATEDB` privilege, OpenHands Enterprise will
+automatically create all required databases during installation.
+
+```sql
+-- Create user with CREATEDB privilege
+CREATE USER openhands_user WITH PASSWORD 'your-secure-password' CREATEDB;
+```
+
+The user also needs permission to grant `USAGE` and `CREATE` on the `public` schema.
+
+### Option 2: Manual Database Creation
+
+If your security policies prevent granting `CREATEDB`, you must manually create all
+databases before installation:
+
+```sql
+-- Create the databases
+CREATE DATABASE openhands;
+CREATE DATABASE bitnami_keycloak;
+CREATE DATABASE litellm;
+CREATE DATABASE runtime_api_db;
+CREATE DATABASE automations;
+
+-- Create user without CREATEDB
+CREATE USER openhands_user WITH PASSWORD 'your-secure-password';
+
+-- Grant privileges on each database
+GRANT ALL PRIVILEGES ON DATABASE openhands TO openhands_user;
+GRANT ALL PRIVILEGES ON DATABASE bitnami_keycloak TO openhands_user;
+GRANT ALL PRIVILEGES ON DATABASE litellm TO openhands_user;
+GRANT ALL PRIVILEGES ON DATABASE runtime_api_db TO openhands_user;
+GRANT ALL PRIVILEGES ON DATABASE automations TO openhands_user;
+
+-- Connect to each database and grant schema privileges
+\c openhands
+GRANT USAGE, CREATE ON SCHEMA public TO openhands_user;
+
+\c bitnami_keycloak
+GRANT USAGE, CREATE ON SCHEMA public TO openhands_user;
+
+\c litellm
+GRANT USAGE, CREATE ON SCHEMA public TO openhands_user;
+
+\c runtime_api_db
+GRANT USAGE, CREATE ON SCHEMA public TO openhands_user;
+
+\c automations
+GRANT USAGE, CREATE ON SCHEMA public TO openhands_user;
+```
+
+## Network Requirements
+
+Ensure your PostgreSQL instance is accessible from:
+
+- The OpenHands application pods/services
+- The Keycloak service
+- The LiteLLM proxy service
+- The Runtime API service
+
+If using network policies or firewalls, allow connections on the PostgreSQL port (default: 5432)
+from the OpenHands deployment.
+
+## Configuration
+
+When configuring OpenHands Enterprise, provide your external PostgreSQL connection details
+in the Admin Console or Helm values:
+
+- **Host**: Your PostgreSQL server hostname or IP
+- **Port**: PostgreSQL port (default: 5432)
+- **Username**: The database user created above
+- **Password**: The user's password
+- **SSL Mode**: Configure based on your security requirements
+
+<Note>
+  For production deployments, we recommend enabling SSL/TLS for database connections
+  and using a connection pooler like PgBouncer for improved performance.
+</Note>

--- a/enterprise/k8s-install/index.mdx
+++ b/enterprise/k8s-install/index.mdx
@@ -50,6 +50,10 @@ OpenHands Enterprise consists of several components deployed as Kubernetes workl
 
 ## Guides
 
+<Card title="External PostgreSQL" icon="database" href="/enterprise/external-postgres">
+  Configure OpenHands to use your own PostgreSQL database instead of the bundled instance.
+</Card>
+
 <Card title="Resource Limits" icon="gauge-high" href="/enterprise/k8s-install/resource-limits">
   Configure memory, CPU, and storage for optimal performance.
 </Card>

--- a/enterprise/quick-start.mdx
+++ b/enterprise/quick-start.mdx
@@ -148,6 +148,7 @@ All items below must be completed before running the installer:
 - Inbound ports are open: `80`, `443`, and `30000`
 - Outbound domains are reachable from the VM
 - GitHub App prerequisites are prepared
+- (Optional) [External PostgreSQL](/enterprise/external-postgres) instance provisioned if using your own database
 
 <Warning>
   Do not run the installer until preflight checks pass.
@@ -329,6 +330,13 @@ You should now see the application configuration page.
 ### LLM Configuration
 
 Enter your Anthropic API key from the [Anthropic Console](https://console.anthropic.com/).
+
+### Database Configuration
+
+By default, OpenHands Enterprise uses a bundled PostgreSQL database. If you need to use your
+own PostgreSQL instance (for example, to integrate with existing database infrastructure or
+meet specific backup/HA requirements), see [External PostgreSQL](/enterprise/external-postgres)
+for setup instructions.
 
 ### GitHub Authentication
 


### PR DESCRIPTION
## Summary

Add documentation for customers deploying OpenHands Enterprise with their own external PostgreSQL instance instead of the bundled database.

## Changes

- **New page: `enterprise/external-postgres.mdx`** — Comprehensive guide covering:
  - PostgreSQL version requirements (16.4.0+, PostgreSQL 17 also supported)
  - Required databases: `openhands`, `bitnami_keycloak`, `litellm`, `runtime_api_db`, `automations`
  - Two setup options:
    - **Automatic creation**: User with `CREATEDB` privilege
    - **Manual creation**: SQL scripts for creating all databases and granting permissions
  - Network requirements
  - Configuration guidance

- **Updated `enterprise/k8s-install/index.mdx`** — Added card linking to the new external PostgreSQL guide

- **Updated `docs.json`** — Added navigation entry for the new page

## Context

This information was gathered from internal discussions about customer requirements for external PostgreSQL setup (specifically for customers who need to use their existing database infrastructure rather than the bundled PostgreSQL).

---
*This PR was created by an AI agent (OpenHands) on behalf of John-Mason Shackelford.*

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b081c81a-5220-4db5-ac9e-3517249fe15c)