### PR TITLE
docs(sdk): install openhands-sdk and openhands-tools as a matched set

### DIFF
--- a/sdk/getting-started.mdx
+++ b/sdk/getting-started.mdx
@@ -82,12 +82,17 @@ export LLM_API_KEY=your-api-key-here
 <AccordionGroup>
   <Accordion title="Option 1: Install via PyPI" icon="box">
     ```bash
-    pip install openhands-sdk # Core SDK (openhands.sdk)
-    pip install openhands-tools  # Built-in tools (openhands.tools)
-    # Optional: required for sandboxed workspaces in Docker or remote servers
-    pip install openhands-workspace # Workspace backends (openhands.workspace)
-    pip install openhands-agent-server # Remote agent server (openhands.agent_server)
+    # Core SDK + built-in tools — install together so their versions stay aligned
+    pip install -U openhands-sdk openhands-tools
+
+    # Optional: sandboxed workspaces in Docker or remote servers.
+    # List every package in one command so they all resolve to the same version.
+    pip install -U openhands-sdk openhands-tools openhands-workspace openhands-agent-server
     ```
+
+    <Warning>
+      `openhands-sdk` and `openhands-tools` are a matched set: they are built, tested, and released together at the same version number, and `openhands-tools` imports `openhands-sdk` internals directly. Always install and upgrade them in a **single** `pip` command so their versions match. Installing them separately can leave a newer `openhands-tools` against an older `openhands-sdk` (for example, when a previously installed copy is not upgraded), which fails at import with errors like `ModuleNotFoundError: No module named 'openhands.sdk.utils.path'`. To pin a specific release, use the same version for both, e.g. `pip install "openhands-sdk==1.22.1" "openhands-tools==1.22.1"`.
+    </Warning>
   </Accordion>
 
   <Accordion title="Option 2: Install from Source" icon="code">


### PR DESCRIPTION
## What

Updates the SDK Getting Started page (`sdk/getting-started.mdx`, *Step 2 → Option 1: Install via PyPI*) so the core packages are installed as a matched set, and adds a warning that they must stay on the same version.

## Why

The current instructions run four separate `pip install` commands with no version alignment:

```bash
pip install openhands-sdk
pip install openhands-tools
...
```

`openhands-tools` depends on `openhands-sdk` **without a version constraint** and imports its internals directly (it pulls in ~29 distinct `openhands.sdk.*` modules, including internal paths like `conversation.impl.local_conversation`, `event.base`, `llm.llm`, and `utils.path`). Because `pip install <pkg>` does not upgrade an already-installed copy, the separate-command pattern can leave a newer `openhands-tools` against an older `openhands-sdk`.

That mismatch fails at import — e.g. `openhands-tools` ≥ 1.20.0 imports `openhands.sdk.utils.path`, a module absent from older SDK releases (e.g. 1.17.0):

```
ModuleNotFoundError: No module named 'openhands.sdk.utils.path'
```

Reported in OpenHands/software-agent-sdk#3300.

Closes OpenHands/software-agent-sdk#3300.

## Change

- Install `openhands-sdk` and `openhands-tools` in a **single** `pip` command, with `-U` so a stale copy is upgraded.
- List all packages in one command for the optional workspace/server install too, so every version resolves together.
- Add a `<Warning>` explaining the two packages are a matched set that must share the same version, with the exact symptom of a mismatch and a pinned-install example.

This is a docs-only change. A complementary code fix (pinning the dependency in `openhands-tools`) can follow separately.