### PR TITLE
docs: Add UTF8 encoding requirement for external PostgreSQL

### DIFF
--- a/enterprise/external-postgres.mdx
+++ b/enterprise/external-postgres.mdx
@@ -12,6 +12,27 @@ need specific backup/recovery procedures, or require high availability configura
 
 OpenHands Enterprise requires **PostgreSQL 16.4.0 or above**. PostgreSQL 17 is also supported.
 
+## Database Encoding Requirement
+
+<Warning>
+  All databases used by OpenHands Enterprise **must use UTF8 encoding**. Using other encodings
+  (such as LATIN1) will cause database migrations to fail during installation or upgrades.
+</Warning>
+
+When creating databases manually or configuring your PostgreSQL instance, ensure UTF8 encoding
+is set:
+
+```sql
+-- Check current database encoding
+SELECT datname, pg_encoding_to_char(encoding) AS encoding FROM pg_database;
+
+-- Create databases with explicit UTF8 encoding
+CREATE DATABASE openhands WITH ENCODING 'UTF8';
+```
+
+If your PostgreSQL server's default encoding is not UTF8, you may need to specify the encoding
+explicitly when creating each database, or configure the server's default encoding.
+
 ## Required Databases
 
 OpenHands Enterprise uses the following databases:
@@ -48,12 +69,12 @@ If your security policies prevent granting `CREATEDB`, you must manually create 
 databases before installation:
 
 ```sql
--- Create the databases
-CREATE DATABASE openhands;
-CREATE DATABASE bitnami_keycloak;
-CREATE DATABASE litellm;
-CREATE DATABASE runtime_api_db;
-CREATE DATABASE automations;
+-- Create the databases with UTF8 encoding
+CREATE DATABASE openhands WITH ENCODING 'UTF8';
+CREATE DATABASE bitnami_keycloak WITH ENCODING 'UTF8';
+CREATE DATABASE litellm WITH ENCODING 'UTF8';
+CREATE DATABASE runtime_api_db WITH ENCODING 'UTF8';
+CREATE DATABASE automations WITH ENCODING 'UTF8';
 
 -- Create user without CREATEDB
 CREATE USER openhands_user WITH PASSWORD 'your-secure-password';


### PR DESCRIPTION
## Summary

This PR documents the UTF8 encoding requirement for external PostgreSQL databases used with OpenHands Enterprise.

## Context

During a recent customer upgrade (C24, 0.7.3 → 0.7.16), the LiteLLM proxy container entered an error state due to failed database migrations. The root cause was identified as the external PostgreSQL database using **LATIN1 encoding** instead of **UTF8**.

Relevant Slack thread: https://allhandsai.slack.com/archives/C0A8MKT4RSA/p1779273466074369

## Changes

1. **Added a new "Database Encoding Requirement" section** after the PostgreSQL Version section with:
   - A warning callout emphasizing that UTF8 encoding is required
   - SQL commands to check existing database encoding
   - Example of creating databases with explicit UTF8 encoding
   - Guidance for servers with non-UTF8 default encoding

2. **Updated the manual database creation example** in Option 2 to include explicit `WITH ENCODING 'UTF8'` in all `CREATE DATABASE` statements.

## Testing

- [x] Verified MDX syntax is valid
- [x] Reviewed for consistency with existing documentation style

---
*This PR was created by an AI agent (OpenHands) on behalf of John-Mason Shackelford.*

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/77eeb5da-a838-4655-919c-0488a0be0558)