### PR TITLE
docs: add Sandbox Grouping Strategy section to Application Settings

### DIFF
--- a/openhands/usage/settings/application-settings.mdx
+++ b/openhands/usage/settings/application-settings.mdx
@@ -8,13 +8,40 @@ description: Configure application-level settings for OpenHands.
 ## Overview
 
 The Application settings allows you to customize various application-level behaviors in OpenHands, including
-language preferences, notification settings, custom Git author configuration and more.
+language preferences, notification settings, sandbox grouping strategy, custom Git author configuration and more.
 
 ## Setting Maximum Budget Per Conversation
 
 To limit spending, go to `Settings > Application` and set a maximum budget per conversation (in USD)
 in the `Maximum Budget Per Conversation` field. OpenHands will stop the conversation once the budget is reached, but
 you can choose to continue the conversation with a prompt.
+
+## Sandbox Grouping Strategy
+
+The **Sandbox Grouping Strategy** setting controls how new conversations are assigned to sandboxes. A sandbox is an isolated environment where OpenHands executes code and commands. This setting lets you choose whether each conversation gets its own dedicated sandbox or whether conversations share sandboxes.
+
+To configure sandbox grouping:
+
+1. Navigate to `Settings > Application`
+2. Locate the **Sandbox Grouping Strategy** dropdown
+3. Select your preferred strategy
+4. Click `Save Changes`
+
+### Available Strategies
+
+| Strategy | Description |
+|----------|-------------|
+| **No Grouping** | Creates a new sandbox for each conversation. This is the default behavior and provides maximum isolation between conversations. |
+| **Group by Newest** | Adds new conversations to the most recently created sandbox. Useful when you want to continue working in the same environment across multiple conversations. |
+| **Least Recently Used** | Adds new conversations to the oldest (least recently used) sandbox. This helps distribute work across sandboxes and can reuse existing environments. |
+| **Fewest Conversations** | Adds new conversations to the sandbox with the fewest active conversations. This provides load balancing across your sandboxes. |
+| **Add to Any** | Uses the first available sandbox for new conversations. This is the most flexible option and optimizes for sandbox reuse. |
+
+<Note>
+  Choosing a grouping strategy other than "No Grouping" allows conversations to share environment state,
+  installed dependencies, and file system changes. This can speed up workflows but means changes from one
+  conversation may be visible to others in the same sandbox.
+</Note>
 
 ## Git Author Settings
 

--- a/openhands/usage/settings/application-settings.mdx
+++ b/openhands/usage/settings/application-settings.mdx
@@ -35,7 +35,7 @@ To configure sandbox grouping:
 | **Group by Newest** | Adds new conversations to the most recently created sandbox. Useful when you want to continue working in the same environment across multiple conversations. |
 | **Least Recently Used** | Adds new conversations to the oldest (least recently used) sandbox. This helps distribute work across sandboxes and can reuse existing environments. |
 | **Fewest Conversations** | Adds new conversations to the sandbox with the fewest active conversations. This provides load balancing across your sandboxes. |
-| **Add to Any** | Uses the first available sandbox for new conversations. This is the most flexible option and optimizes for sandbox reuse. |
+| **Add to Any** | Uses the first available sandbox for new conversations (any sandbox that exists in your environment). This is the most flexible option and optimizes for sandbox reuse. |
 
 <Note>
   Choosing a grouping strategy other than "No Grouping" allows conversations to share environment state,


### PR DESCRIPTION
## Summary

Document the Sandbox Grouping Strategy feature that was exposed to all users in [OpenHands/OpenHands#14291](https://github.com/OpenHands/OpenHands/pull/14291).

## Changes

- Added new **Sandbox Grouping Strategy** section to the Application Settings documentation
- Documented all 5 available strategies with clear descriptions:
  - **No Grouping** - Creates a new sandbox for each conversation (default)
  - **Group by Newest** - Adds to the most recently created sandbox
  - **Least Recently Used** - Adds to the oldest sandbox
  - **Fewest Conversations** - Adds to the least busy sandbox (load balancing)
  - **Add to Any** - Uses the first available sandbox
- Added note about shared state implications when using grouping strategies

## Related

- Feature PR: https://github.com/OpenHands/OpenHands/pull/14291

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._