### PR TITLE
Add Enterprise Support Policy page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -440,6 +440,7 @@
           "enterprise/quick-start",
           "enterprise/analytics",
           "enterprise/external-postgres",
+          "enterprise/support-policy",
           {
             "group": "K8s Install",
             "pages": [

--- a/enterprise/support-policy.mdx
+++ b/enterprise/support-policy.mdx
@@ -1,0 +1,91 @@
+---
+title: Support Policy
+description: Severity levels, response commitments, and support processes for OpenHands Enterprise customers
+icon: headset
+---
+
+Clear response commitments, defined severity levels, and a dedicated team
+standing behind every deployment.
+
+## Severity Levels
+
+Every support request is classified by impact so we can respond with the right
+urgency.
+
+<CardGroup cols={2}>
+  <Card title="Severity 1" icon="circle-exclamation" color="#dc2626">
+    **Production Down**
+
+    Product is down or seriously impaired and there is no workaround currently
+    available.
+  </Card>
+  <Card title="Severity 2" icon="triangle-exclamation" color="#ea580c">
+    **Reduced Capacity**
+
+    Customer's system is functioning but in a reduced capacity, and there is no
+    workaround currently available or the workaround is cumbersome to use.
+  </Card>
+  <Card title="Severity 3" icon="circle-info" color="#ca8a04">
+    **Minor Impact**
+
+    Does not prevent normal operation of the Customer's system, or where the
+    situation may be temporarily circumvented using an available workaround.
+  </Card>
+  <Card title="Severity 4" icon="message-question" color="#16a34a">
+    **General Request**
+
+    Non-critical errors or issues, including general questions and requests for
+    enhancements to the product.
+  </Card>
+</CardGroup>
+
+## First Response SLA
+
+Our commitment to acknowledging your issue. All times represent a qualified
+human response, not an automated reply.
+
+### Standard Support
+
+Included with every Enterprise deployment. Coverage is Monday–Friday during
+business hours.
+
+| Severity | First Response Time |
+|----------|---------------------|
+| **Sev 1** — Production Down | 16 business hours |
+| **Sev 2** — Reduced Capacity | 1 business day |
+| **Sev 3** — Minor Impact | 2 business days |
+| **Sev 4** — General Request | 3 business days |
+
+### Premium Support
+
+For mission-critical enterprise deployments. Sev 1 coverage is 24/7 including
+weekends. Sev 2–4 coverage is Monday–Friday.
+
+| Severity | First Response Time |
+|----------|---------------------|
+| **Sev 1** — Production Down | 30 minutes |
+| **Sev 2** — Reduced Capacity | 4 hours |
+| **Sev 3** — Minor Impact | 8 hours |
+| **Sev 4** — General Request | 1 business day |
+
+<Note>
+  The SLA times listed above represent first response commitments. While we
+  strive to resolve issues as quickly as possible, these times should not be
+  interpreted as expected time-to-resolution.
+</Note>
+
+## How to Report an Issue
+
+Submit support requests through the
+[OpenHands Support Portal](https://support.openhands.dev). The support portal
+allows you to create, track, and manage all of your support requests in one
+place.
+
+<CardGroup cols={2}>
+  <Card title="Support Portal" icon="life-ring" href="https://support.openhands.dev">
+    Submit and track support requests.
+  </Card>
+  <Card title="Contact Sales" icon="envelope" href="https://openhands.dev/contact">
+    Learn more about Premium Support or discuss your support needs.
+  </Card>
+</CardGroup>

--- a/enterprise/support-policy.mdx
+++ b/enterprise/support-policy.mdx
@@ -16,26 +16,27 @@ urgency.
   <Card title="Severity 1" icon="circle-exclamation" color="#dc2626">
     **Production Down**
 
-    Product is down or seriously impaired and there is no workaround currently
-    available.
+    A vital feature or the entire platform is non-functional. No workaround
+    exists. Affects multiple teams or the entire organization.
   </Card>
   <Card title="Severity 2" icon="triangle-exclamation" color="#ea580c">
-    **Reduced Capacity**
+    **Major Block**
 
-    Customer's system is functioning but in a reduced capacity, and there is no
-    workaround currently available or the workaround is cumbersome to use.
+    A core feature is broken or severely degraded. A workaround may exist but
+    is impractical for sustained use. Work across one or more teams is
+    significantly disrupted.
   </Card>
   <Card title="Severity 3" icon="circle-info" color="#ca8a04">
-    **Minor Impact**
+    **Partial Failure**
 
-    Does not prevent normal operation of the Customer's system, or where the
-    situation may be temporarily circumvented using an available workaround.
+    System behavior is degraded, disrupting work, but users are able to
+    complete tasks. A reasonable workaround is available.
   </Card>
   <Card title="Severity 4" icon="message-question" color="#16a34a">
     **General Request**
 
-    Non-critical errors or issues, including general questions and requests for
-    enhancements to the product.
+    Non-critical errors, cosmetic issues, general questions, or requests for
+    product enhancements. Day-to-day work is not disrupted.
   </Card>
 </CardGroup>
 
@@ -46,26 +47,26 @@ human response, not an automated reply.
 
 ### Standard Support
 
-Included with every Enterprise deployment. Coverage is Monday–Friday during
-business hours.
+Included with every Enterprise deployment. Coverage is Monday–Friday,
+9 AM – 5 PM EST.
 
 | Severity | First Response Time |
 |----------|---------------------|
 | **Sev 1** — Production Down | 16 business hours |
-| **Sev 2** — Reduced Capacity | 1 business day |
-| **Sev 3** — Minor Impact | 2 business days |
+| **Sev 2** — Major Block | 1 business day |
+| **Sev 3** — Partial Failure | 2 business days |
 | **Sev 4** — General Request | 3 business days |
 
 ### Premium Support
 
-For mission-critical enterprise deployments. Sev 1 coverage is 24/7 including
-weekends. Sev 2–4 coverage is Monday–Friday.
+For mission-critical enterprise deployments. Sev 1 coverage is 24/7, including
+weekends and holidays. Sev 2–4 coverage is Monday–Friday, 9 AM – 5 PM EST.
 
 | Severity | First Response Time |
 |----------|---------------------|
 | **Sev 1** — Production Down | 30 minutes |
-| **Sev 2** — Reduced Capacity | 4 hours |
-| **Sev 3** — Minor Impact | 8 hours |
+| **Sev 2** — Major Block | 4 hours |
+| **Sev 3** — Partial Failure | 8 hours |
 | **Sev 4** — General Request | 1 business day |
 
 <Note>


### PR DESCRIPTION
## Summary

Adds a customer-facing **Support Policy** page to the Enterprise docs section at `docs.openhands.dev/enterprise/support-policy`.

## What's included

- **Severity Levels (Sev 1–4)** — Definitions aligned internally, covering Production Down through General Request
- **First Response SLA** — Standard (M–F business hours) and Premium (24/7 for Sev 1, M–F for Sev 2–4) response time commitments
- **How to Report an Issue** — Directs customers to the Support Portal, with a note clarifying SLA times are first-response commitments, not resolution times
- **Navigation update** — Adds the page to the Enterprise sidebar in `docs.json`

## Changes

| File | Change |
|------|--------|
| `enterprise/support-policy.mdx` | New page (severity levels, SLA tables, reporting instructions) |
| `docs.json` | Added `enterprise/support-policy` to Enterprise nav |

---
_This PR was created by an AI agent (OpenHands) on behalf of Chris Nelson._

@chrisnelson-design can click here to [continue refining the PR](https://app.all-hands.dev/conversations/364fa7f7-adb5-4859-af8a-d82a0afd0af0)