### PR TITLE
docs: document ALLOW_INSECURE_GIT_ACCESS for trusted local git providers

### DIFF
--- a/openhands/usage/environment-variables.mdx
+++ b/openhands/usage/environment-variables.mdx
@@ -166,6 +166,21 @@ These variables correspond to the `[security]` section in `config.toml`:
 
 ## Integration Variables
 
+### Git Provider Access
+| Environment Variable | Type | Default | Description |
+|---------------------|------|---------|-------------|
+| `ALLOW_INSECURE_GIT_ACCESS` | boolean | `false` | Allow OpenHands to connect to git providers over plain HTTP. Set this only for trusted local or internal Gitea/Forgejo instances where HTTPS is not available. |
+
+<Warning>
+  `ALLOW_INSECURE_GIT_ACCESS=true` permits insecure HTTP connections to git providers. Only enable it for trusted local or internal networks that you control. Do not use it for public or untrusted git providers.
+</Warning>
+
+When running OpenHands with Docker, set this on the OpenHands server container:
+
+```bash
+docker run -e ALLOW_INSECURE_GIT_ACCESS=true openhands/openhands
+```
+
 ### GitHub Integration
 | Environment Variable | Type | Default | Description |
 |---------------------|------|---------|-------------|

--- a/openhands/usage/environment-variables.mdx
+++ b/openhands/usage/environment-variables.mdx
@@ -169,7 +169,7 @@ These variables correspond to the `[security]` section in `config.toml`:
 ### Git Provider Access
 | Environment Variable | Type | Default | Description |
 |---------------------|------|---------|-------------|
-| `ALLOW_INSECURE_GIT_ACCESS` | boolean | `false` | Allow OpenHands to connect to git providers over plain HTTP. Set this only for trusted local or internal Gitea/Forgejo instances where HTTPS is not available. |
+| `ALLOW_INSECURE_GIT_ACCESS` | boolean | `false` | Allow OpenHands to connect to git providers over plain HTTP. Set this only for trusted local or internal git providers (such as Gitea/Forgejo) where HTTPS is not available. |
 
 <Warning>
   `ALLOW_INSECURE_GIT_ACCESS=true` permits insecure HTTP connections to git providers. Only enable it for trusted local or internal networks that you control. Do not use it for public or untrusted git providers.


### PR DESCRIPTION
## Summary

Adds documentation for `ALLOW_INSECURE_GIT_ACCESS` when using trusted local/internal Gitea or Forgejo instances over HTTP.

## Context

Related to OpenHands/OpenHands#14523.

@VascoSch92, you asked me to tag you in the PR.

## Scope

This PR is intentionally docs-only.

It:
- Adds `ALLOW_INSECURE_GIT_ACCESS` to the environment variables reference.
- Clarifies that it is intended only for trusted local/internal HTTP git providers.
- Mentions local Gitea/Forgejo-style usage.

It does not:
- Change runtime behavior.
- Claim to fully fix the environment propagation behavior described in #14523.
- Modify unrelated documentation.

## Validation

- Confirmed source behavior references `ALLOW_INSECURE_GIT_ACCESS`.
- Confirmed `git diff --check` passes.
- Ran the narrowed relevant pytest target: 30 passed, 6 deselected.
- Full pytest currently has an unrelated upstream failure caused by a raw GitHub URL returning 404.
- Mintlify CLI validation was attempted but unavailable/timed out via `npx`.