### PR TITLE
docs: add custom Agent Server image guide for Docker backend

### DIFF
--- a/openhands/usage/agent-canvas/backend-setup/docker.mdx
+++ b/openhands/usage/agent-canvas/backend-setup/docker.mdx
@@ -20,11 +20,7 @@ The OpenHands Agent Server publishes a base image at `ghcr.io/openhands/agent-se
 The example below adds the JDK and a few common utilities. Save it as `Dockerfile`:
 
 ```dockerfile icon="docker"
-# Pin to a specific agent server version for reproducible builds.
-# Replace <version> with a published tag, e.g. `0.10.0-python` or a commit
-# SHA tag like `1a2b3c4-python`. See:
-# https://github.com/OpenHands/software-agent-sdk/pkgs/container/agent-server
-FROM ghcr.io/openhands/agent-server:<version>
+FROM ghcr.io/openhands/agent-server:1-python
 
 USER root
 
@@ -45,6 +41,10 @@ USER openhands
 <Note>
   The base image already ships with Python, Node.js, `git`, `jq`, `tmux`, build tools, and a VS Code Web + VNC stack. Only add what you actually need on top.
 </Note>
+
+<Tip>
+  For fully reproducible builds, pin to a more specific tag like `1.24.0-python` instead of `1-python`.
+</Tip>
 
 Build the image with a tag you can reference later:
 
@@ -136,9 +136,10 @@ In **Manage Backends**, add one entry per container using the matching name, URL
 
 ## Updating the Image
 
-When you want to add more tooling or pick up a newer agent server release, bump the pinned tag in the `FROM` line of your `Dockerfile`, then:
+When you want to add more tooling or pick up a newer agent server release:
 
 ```bash
+docker pull ghcr.io/openhands/agent-server:1-python
 docker build -t agent-server-java:latest .
 docker stop agent-server-java && docker rm agent-server-java
 # then re-run the `docker run` from step 2

--- a/openhands/usage/agent-canvas/backend-setup/docker.mdx
+++ b/openhands/usage/agent-canvas/backend-setup/docker.mdx
@@ -20,7 +20,11 @@ The OpenHands Agent Server publishes a base image at `ghcr.io/openhands/agent-se
 The example below adds the JDK and a few common utilities. Save it as `Dockerfile`:
 
 ```dockerfile icon="docker"
-FROM ghcr.io/openhands/agent-server:latest-python
+# Pin to a specific agent server version for reproducible builds.
+# Replace <version> with a published tag, e.g. `0.10.0-python` or a commit
+# SHA tag like `1a2b3c4-python`. See:
+# https://github.com/OpenHands/software-agent-sdk/pkgs/container/agent-server
+FROM ghcr.io/openhands/agent-server:<version>
 
 USER root
 
@@ -132,10 +136,9 @@ In **Manage Backends**, add one entry per container using the matching name, URL
 
 ## Updating the Image
 
-When you want to add more tooling or pick up a newer agent server release:
+When you want to add more tooling or pick up a newer agent server release, bump the pinned tag in the `FROM` line of your `Dockerfile`, then:
 
 ```bash
-docker pull ghcr.io/openhands/agent-server:latest-python
 docker build -t agent-server-java:latest .
 docker stop agent-server-java && docker rm agent-server-java
 # then re-run the `docker run` from step 2

--- a/openhands/usage/agent-canvas/backend-setup/docker.mdx
+++ b/openhands/usage/agent-canvas/backend-setup/docker.mdx
@@ -1,6 +1,124 @@
 ---
 title: Setup a Docker Backend
-description: Run an OpenHands agent server in Docker and connect Agent Canvas to it.
+description: Build a custom OpenHands Agent Server image and connect Agent Canvas to it.
 ---
 
-Coming soon.
+This guide walks through building a **custom Agent Server image** that layers extra tooling (for example, the JDK) on top of the official base image, running it locally with Docker, and registering it as a backend in Agent Canvas.
+
+Use this approach when the default backend's toolchain is missing something your agent needs, such as a specific language runtime, build tool, or CLI.
+
+## Prerequisites
+
+- Docker installed and running
+- An LLM API key (Anthropic, OpenAI, etc.)
+- Agent Canvas installed and running locally — see [Setup](/openhands/usage/agent-canvas/setup)
+
+## 1. Build a Custom Image
+
+The OpenHands Agent Server publishes a base image at `ghcr.io/openhands/agent-server`. Extend it with a small `Dockerfile` that installs whatever your agent needs.
+
+The example below adds the JDK and a few common utilities. Save it as `Dockerfile`:
+
+```dockerfile icon="docker"
+FROM ghcr.io/openhands/agent-server:latest-python
+
+USER root
+
+# Install Java (JDK) and common build/diagnostic utilities.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      default-jdk \
+      maven \
+      unzip \
+      vim \
+      less \
+ && rm -rf /var/lib/apt/lists/*
+
+# Switch back to the unprivileged user that the base image runs as.
+USER openhands
+```
+
+<Note>
+  The base image already ships with Python, Node.js, `git`, `jq`, `tmux`, build tools, and a VS Code Web + VNC stack. Only add what you actually need on top.
+</Note>
+
+Build the image with a tag you can reference later:
+
+```bash
+docker build -t my-agent-server:latest .
+```
+
+<Tip>
+  For ARM hosts (Apple Silicon, Graviton), prefer the matching base tag (for example `latest-python` already supports multi-arch). If you need to force a platform, pass `--platform linux/amd64` to `docker build`.
+</Tip>
+
+## 2. Run the Custom Image
+
+Start the image, expose the agent server's HTTP port, and protect it with a session API key. The agent server reads `SESSION_API_KEY` from the environment and requires the same value on the `X-Session-API-Key` header for every request.
+
+```bash
+# Pick any sufficiently random value; you'll paste it into Agent Canvas later.
+export SESSION_API_KEY="$(openssl rand -hex 32)"
+
+docker run -d \
+  --name openhands-agent-server \
+  -p 8000:8000 \
+  -e SESSION_API_KEY="$SESSION_API_KEY" \
+  my-agent-server:latest
+```
+
+Verify the server is reachable:
+
+```bash
+curl -H "X-Session-API-Key: $SESSION_API_KEY" http://localhost:8000/health
+```
+
+<Warning>
+  The agent server can execute arbitrary shell commands inside the container. Treat `SESSION_API_KEY` like a production credential and **do not expose port 8000 to the public internet** without a TLS-terminating reverse proxy in front of it.
+</Warning>
+
+To follow logs or stop the container:
+
+```bash
+docker logs -f openhands-agent-server
+docker stop openhands-agent-server
+```
+
+## 3. Add the Backend in Agent Canvas
+
+With the container running, point Agent Canvas at it:
+
+1. Open Agent Canvas.
+2. Click the backend switcher in the top bar and choose **Manage Backends**.
+3. Click **Add Backend** and fill in:
+   - **Name** — anything memorable, e.g. `Local Docker (JDK)`
+   - **Host / Base URL** — `http://localhost:8000`
+   - **API Key** — the `SESSION_API_KEY` value from step 2
+   - **Type** — `Local`
+4. Save the backend and select it as the **active backend**.
+
+Agent Canvas will run a health check against the URL. Once it passes, the backend is ready to handle conversations using the tools you baked into the image.
+
+<Note>
+  See [Connect and Manage Backends](/openhands/usage/agent-canvas/backends) for what changes when you switch the active backend (settings, LLM availability, MCP servers, automations).
+</Note>
+
+## Updating the Image
+
+When you want to add more tooling or pick up a newer agent server release:
+
+```bash
+docker pull ghcr.io/openhands/agent-server:latest-python
+docker build -t my-agent-server:latest .
+docker stop openhands-agent-server && docker rm openhands-agent-server
+# then re-run the `docker run` from step 2
+```
+
+The existing backend entry in Agent Canvas keeps working as long as the host, port, and `SESSION_API_KEY` stay the same.
+
+## Related Guides
+
+- [Connect and Manage Backends](/openhands/usage/agent-canvas/backends)
+- [Setup a Local Backend](/openhands/usage/agent-canvas/backend-setup/local)
+- [Setup a VM Backend](/openhands/usage/agent-canvas/backend-setup/vm)
+- [Agent Server Overview](/sdk/guides/agent-server/overview)

--- a/openhands/usage/agent-canvas/backend-setup/docker.mdx
+++ b/openhands/usage/agent-canvas/backend-setup/docker.mdx
@@ -45,7 +45,7 @@ USER openhands
 Build the image with a tag you can reference later:
 
 ```bash
-docker build -t my-agent-server:latest .
+docker build -t agent-server-java:latest .
 ```
 
 <Tip>
@@ -56,32 +56,34 @@ docker build -t my-agent-server:latest .
 
 Start the image, expose the agent server's HTTP port, and protect it with a session API key. The agent server reads `SESSION_API_KEY` from the environment and requires the same value on the `X-Session-API-Key` header for every request.
 
+Use the same name for the container as you'll use for the Agent Canvas backend — it makes it easy to tell which container backs which backend later.
+
 ```bash
 # Pick any sufficiently random value; you'll paste it into Agent Canvas later.
 export SESSION_API_KEY="$(openssl rand -hex 32)"
 
 docker run -d \
-  --name openhands-agent-server \
-  -p 8000:8000 \
+  --name agent-server-java \
+  -p 8001:8000 \
   -e SESSION_API_KEY="$SESSION_API_KEY" \
-  my-agent-server:latest
+  agent-server-java:latest
 ```
 
 Verify the server is reachable:
 
 ```bash
-curl -H "X-Session-API-Key: $SESSION_API_KEY" http://localhost:8000/health
+curl -H "X-Session-API-Key: $SESSION_API_KEY" http://localhost:8001/health
 ```
 
 <Warning>
-  The agent server can execute arbitrary shell commands inside the container. Treat `SESSION_API_KEY` like a production credential and **do not expose port 8000 to the public internet** without a TLS-terminating reverse proxy in front of it.
+  The agent server can execute arbitrary shell commands inside the container. Treat `SESSION_API_KEY` like a production credential and **do not expose port 8001 to the public internet** without a TLS-terminating reverse proxy in front of it.
 </Warning>
 
 To follow logs or stop the container:
 
 ```bash
-docker logs -f openhands-agent-server
-docker stop openhands-agent-server
+docker logs -f agent-server-java
+docker stop agent-server-java
 ```
 
 ## 3. Add the Backend in Agent Canvas
@@ -91,8 +93,8 @@ With the container running, point Agent Canvas at it:
 1. Open Agent Canvas.
 2. Click the backend switcher in the top bar and choose **Manage Backends**.
 3. Click **Add Backend** and fill in:
-   - **Name** — anything memorable, e.g. `Local Docker (JDK)`
-   - **Host / Base URL** — `http://localhost:8000`
+   - **Name** — `agent-server-java` (matching the container name)
+   - **Host / Base URL** — `http://localhost:8001`
    - **API Key** — the `SESSION_API_KEY` value from step 2
    - **Type** — `Local`
 4. Save the backend and select it as the **active backend**.
@@ -103,14 +105,39 @@ Agent Canvas will run a health check against the URL. Once it passes, the backen
   See [Connect and Manage Backends](/openhands/usage/agent-canvas/backends) for what changes when you switch the active backend (settings, LLM availability, MCP servers, automations).
 </Note>
 
+## Running Multiple Custom Backends
+
+You can build as many custom images as you need and run each one as its own backend in Agent Canvas. A common pattern is one image per language or repo toolchain — for example a `agent-server-java` for JVM work, a `agent-server-rust` for Cargo projects, and a `agent-server-data` image with the Python data stack pre-installed.
+
+Give each container its own name, its own host port, and its own `SESSION_API_KEY`, then add a matching backend entry in Agent Canvas for each one:
+
+```bash
+# JVM toolchain on port 8001
+docker run -d --name agent-server-java \
+  -p 8001:8000 -e SESSION_API_KEY="$JAVA_KEY" \
+  agent-server-java:latest
+
+# Rust toolchain on port 8002
+docker run -d --name agent-server-rust \
+  -p 8002:8000 -e SESSION_API_KEY="$RUST_KEY" \
+  agent-server-rust:latest
+
+# Python data stack on port 8003
+docker run -d --name agent-server-data \
+  -p 8003:8000 -e SESSION_API_KEY="$DATA_KEY" \
+  agent-server-data:latest
+```
+
+In **Manage Backends**, add one entry per container using the matching name, URL, and API key. You can then switch between them from the backend selector depending on what kind of task you're working on.
+
 ## Updating the Image
 
 When you want to add more tooling or pick up a newer agent server release:
 
 ```bash
 docker pull ghcr.io/openhands/agent-server:latest-python
-docker build -t my-agent-server:latest .
-docker stop openhands-agent-server && docker rm openhands-agent-server
+docker build -t agent-server-java:latest .
+docker stop agent-server-java && docker rm agent-server-java
 # then re-run the `docker run` from step 2
 ```
 


### PR DESCRIPTION
## Summary

Replaces the "Coming soon." placeholder at `openhands/usage/agent-canvas/backend-setup/docker.mdx` with a full walkthrough for building a **custom Agent Server image** and using it as an Agent Canvas backend.

The guide covers:

1. **Build a custom image** — `FROM ghcr.io/openhands/agent-server:latest-python`, adding the JDK, Maven, and common utilities on top.
2. **Run the image** — `docker run` with a generated `SESSION_API_KEY`, plus a `curl` health check and safety guidance for exposing the port.
3. **Add the backend to Agent Canvas** — `Manage Backends → Add Backend`, paste the URL + API key, mark it as `Local`, and switch to it as the active backend.
4. **Updating the image** — pull a newer base, rebuild, restart, keep the same backend entry.

Includes cross-links to the related guides:
- [Connect and Manage Backends](/openhands/usage/agent-canvas/backends)
- [Local](/openhands/usage/agent-canvas/backend-setup/local) and [VM](/openhands/usage/agent-canvas/backend-setup/vm) backend pages
- [Agent Server Overview](/sdk/guides/agent-server/overview)

## Target

This PR targets the `docs/onboarding-agent-canvas` branch so it stacks onto #533.

---

_This PR was created by an AI agent (OpenHands) on behalf of @rbren._