### PR TITLE
docs(acp): deprecate acp_env; route env/credentials through conversation secrets

### DIFF
--- a/sdk/guides/agent-acp.mdx
+++ b/sdk/guides/agent-acp.mdx
@@ -78,9 +78,9 @@ Each `AgentContext` field is tagged as ACP-compatible or not. At initialization,
 | `load_user_skills` | ✅ | Load skills from `~/.openhands/skills/` |
 | `load_public_skills` | ✅ | Load skills from the public extensions repo |
 | `marketplace_path` | ✅ | Filter public skills via marketplace JSON |
-| `secrets` | ❌ | ACP subprocesses do not use OpenHands secret injection |
+| `secrets` | ✅ | Injected into the ACP subprocess environment (and masked if the server echoes them back) |
 
-Passing `secrets` (or any future field marked `acp_compatible: False`) raises `NotImplementedError`.
+Any `AgentContext` field marked `acp_compatible: False` raises `NotImplementedError` at initialization.
 
 ### What ACPAgent Does Not Support
 
@@ -124,7 +124,6 @@ If you attach to an existing conversation by `conversation_id`, use `ACPAgent` f
 agent = ACPAgent(
     acp_command=["npx", "-y", "@agentclientprotocol/claude-agent-acp"],
     acp_args=["--profile", "my-profile"],      # extra CLI args
-    acp_env={"ANTHROPIC_API_KEY": "sk-..."},   # extra env vars
 )
 ```
 
@@ -132,7 +131,23 @@ agent = ACPAgent(
 |-----------|-------------|
 | `acp_command` | Command to start the ACP server (required) |
 | `acp_args` | Additional arguments appended to the command |
-| `acp_env` | Additional environment variables for the server process |
+| `acp_env` | **Deprecated** (removed in 1.29.0). Route env/credentials through the conversation's `secrets` or `agent_context.secrets` instead — see below. |
+
+### Environment Variables and Credentials
+
+Pass the environment variables and credentials the ACP server needs through the conversation's `secrets` (or `agent_context.secrets`). They flow into the conversation's secret registry, are injected into the ACP subprocess environment, and are masked if the server echoes them back into its output:
+
+```python icon="python"
+conversation = Conversation(
+    agent=agent,
+    workspace="./my-project",
+    secrets={"ANTHROPIC_API_KEY": "sk-..."},
+)
+```
+
+<Note>
+`acp_env` still works but is deprecated and will be removed in 1.29.0; prefer the secret-registry channels above for environment variables and credentials.
+</Note>
 
 ### Authentication
 


### PR DESCRIPTION
## What
`ACPAgent.acp_env` was deprecated in software-agent-sdk 1.24.0 (removal in 1.29.0; see OpenHands/software-agent-sdk#3464). The ACP guide still recommended it for credentials (`acp_env={"ANTHROPIC_API_KEY": "sk-..."}`), and separately claimed `AgentContext.secrets` is ACP-incompatible / raises `NotImplementedError` — which is now the **recommended replacement** channel, so the page contradicted itself.

## Changes (`sdk/guides/agent-acp.mdx`)
- Drop `acp_env` from the configuration example; mark it **Deprecated (removed in 1.29.0)** in the parameter table, pointing to the conversation's `secrets` / `agent_context.secrets`.
- Add an **Environment Variables and Credentials** section showing `Conversation(agent=..., workspace=..., secrets={...})` — the canonical channel that flows into the secret registry and is injected into the ACP subprocess env.
- Fix the AgentContext compatibility table: `secrets` is now `acp_compatible: True` (injected into the subprocess env, and masked if echoed back — OpenHands/software-agent-sdk#3463), not a `NotImplementedError`.

`llms.txt` / `llms-full.txt` are regenerated by the scheduled `Sync llms context files` workflow, so they're intentionally not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)