### PR TITLE
Update Agent Canvas automations docs for new secrets flow

### DIFF
--- a/openhands/usage/agent-canvas/prebuilt/github-pr-review.mdx
+++ b/openhands/usage/agent-canvas/prebuilt/github-pr-review.mdx
@@ -63,18 +63,8 @@ The GitHub MCP server gives the agent tools for reading repositories, inspecting
 4. Open `MCP Servers`.
 5. Select `GitHub` from the MCP library.
 6. Paste the GitHub token you created earlier.
-7. Save the MCP server configuration.
-
-## Add the GitHub Token as a Secret
-
-Some automations also need the token available as a backend secret, especially when the agent runs GitHub commands or accesses private repositories.
-
-1. Open `Settings`.
-2. Open `Secrets`.
-3. Click `Add a new Secret`.
-4. Set the secret name to `GITHUB_TOKEN`.
-5. Paste the GitHub token as the secret value.
-6. Save the secret.
+7. Make sure the secret-creation toggle is on so Agent Canvas creates the token secret automatically when you save the MCP server configuration.
+8. Save the MCP server configuration.
 
 ## Start the PR Review Workflow
 

--- a/openhands/usage/agent-canvas/prebuilt/github-repo-monitor.mdx
+++ b/openhands/usage/agent-canvas/prebuilt/github-repo-monitor.mdx
@@ -65,18 +65,8 @@ The GitHub MCP server gives the agent tools for reading repository state and tak
 4. Open `MCP Servers`.
 5. Select `GitHub` from the MCP library.
 6. Paste the GitHub token you created earlier.
-7. Save the MCP server configuration.
-
-## Add the GitHub Token as a Secret
-
-Some automations also need the token available as a backend secret, especially when the agent runs GitHub commands or accesses private repositories.
-
-1. Open `Settings`.
-2. Open `Secrets`.
-3. Click `Add a new Secret`.
-4. Set the secret name to `GITHUB_TOKEN`.
-5. Paste the GitHub token as the secret value.
-6. Save the secret.
+7. Make sure the secret-creation toggle is on so Agent Canvas creates the token secret automatically when you save the MCP server configuration.
+8. Save the MCP server configuration.
 
 ## Start the Repository Monitor Workflow
 

--- a/openhands/usage/agent-canvas/prebuilt/slack-channel-monitor.mdx
+++ b/openhands/usage/agent-canvas/prebuilt/slack-channel-monitor.mdx
@@ -113,9 +113,15 @@ You do not need to know every detail before sending the prefilled prompt. The ag
 - Whether the agent should reply in Slack
 - Any GitHub repository or external service the agent should use
 
+
+<Info>
+  If you want the automation to watch for `@your-bot-name`, tell the agent to watch for Slack bot mentions as well as the trigger phrases you set. That way, it can respond when someone mentions the bot directly, not just when a specific keyword appears.
+</Info>
+
 You can edit the prefilled prompt before sending it if you want to provide any of those details up front.
 
-For example, you can ask the monitor to watch an alerts channel, summarize new incidents, and create a GitHub issue when a message includes a production error.
+For example, you can ask the tell the agent to configure the automation to watch an #alerts channel, summarize new incidents, and create a GitHub issue when a message includes a production error.
+
 
 ## Verify the Automation
 

--- a/openhands/usage/agent-canvas/prebuilt/slack-channel-monitor.mdx
+++ b/openhands/usage/agent-canvas/prebuilt/slack-channel-monitor.mdx
@@ -90,18 +90,8 @@ The Slack MCP server gives the agent tools for reading Slack channel activity an
 5. Select `Slack` from the MCP library.
 6. Paste the bot token.
 7. Enter your Slack workspace ID.
-8. Save the MCP server configuration.
-
-## Add the Slack Bot Token as a Secret
-
-Some automations also need the token available as a backend secret.
-
-1. Open `Settings`.
-2. Open `Secrets`.
-3. Click `Add a new Secret`.
-4. Set the secret name to `SLACK_BOT_TOKEN`.
-5. Paste the bot token as the secret value.
-6. Save the secret.
+8. Make sure the secret-creation toggle is on so Agent Canvas creates the bot token secret automatically when you save the MCP server configuration.
+9. Save the MCP server configuration.
 
 ## Start the Slack Channel Monitor Workflow
 


### PR DESCRIPTION
Agent canvas has been updated to support adding secrets at the same time you add an MCP server. The extra toggle is all that a user needs to do for Slack and Github.

This PR removes the sections on adding the secrets and replaces it with a step during MCP setup.

I've also added an info panel to slack channel monitor to explain watching for `@slack-bot-name` which is different than trigger words in text.

- [x] I have read and reviewed the documentation changes to the best of my ability.
- [x] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.


