### PR TITLE
docs: clean up VM backend setup instructions

### DIFF
--- a/openhands/usage/agent-canvas/backend-setup/vm.mdx
+++ b/openhands/usage/agent-canvas/backend-setup/vm.mdx
@@ -23,10 +23,12 @@ Lock down inbound traffic **before** starting the backend:
 
 ## 2. Install Prerequisites
 
-On Ubuntu:
+You need **Node.js 22.x** and **uv**. See the [Agent Canvas quickstart](https://github.com/OpenHands/agent-canvas#quickstart) for all install options.
+
+On Ubuntu the shortest path is:
 
 ```bash
-apt-get update && apt-get install -y curl git
+sudo apt-get update && sudo apt-get install -y curl
 
 # Node.js 22.x (via nvm, asdf, or NodeSource)
 # uv (for the agent server runtime):
@@ -97,7 +99,7 @@ Update your network firewall to additionally allow:
 ### Install nginx and Certbot
 
 ```bash
-apt-get install -y nginx certbot python3-certbot-nginx
+sudo apt-get install -y nginx certbot python3-certbot-nginx
 ```
 
 ### Configure nginx


### PR DESCRIPTION
## Summary

Small cleanup to the VM / Self-Hosted Backend setup guide based on real-world experience setting up a devbox.

## Changes

- **Remove `git` from prerequisites** — it comes pre-installed on all standard VM images (Ubuntu, Debian, etc.)
- **Add `sudo` to `apt-get` commands** — users aren't root by default on most VMs
- **Link to Agent Canvas quickstart** for prerequisite install options (Node.js, uv) instead of only describing them inline

---
_This pull request was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b6f0869d-6044-42f2-9bbf-69286968429f)