### PR TITLE
docs: add Windows (PowerShell) instructions for Agent Canvas Docker setup

### DIFF
--- a/openhands/usage/agent-canvas/backend-setup/docker.mdx
+++ b/openhands/usage/agent-canvas/backend-setup/docker.mdx
@@ -7,20 +7,41 @@ The official Docker image packages the full Agent Canvas stack — backend and f
 
 ## Prerequisites
 
-- [Docker](https://docs.docker.com/get-docker/) installed and running
+- [Docker](https://docs.docker.com/get-docker/) installed and running (Docker Desktop on macOS/Windows, or Docker Engine on Linux)
 - Agent Canvas installed locally (if connecting from another instance) — see [Setup](/openhands/usage/agent-canvas/setup)
 
 ## Run the Official Image
 
-Mount a persistence directory for settings, secrets, and conversation history, and a projects directory for workspace access:
+Mount a persistence directory for settings, secrets, and conversation history, and a projects directory for workspace access.
 
-```bash
-docker run -it --rm \
-  -p 8000:8000 \
-  -v ~/.openhands:/home/openhands/.openhands \
-  -v ~/projects:/projects \
-  ghcr.io/openhands/agent-canvas:latest
-```
+<Tabs>
+  <Tab title="macOS / Linux">
+    ```bash
+    mkdir -p ~/projects ~/.openhands
+
+    docker run -it --rm \
+      -p 8000:8000 \
+      -v ~/.openhands:/home/openhands/.openhands \
+      -v ~/projects:/projects \
+      ghcr.io/openhands/agent-canvas:latest
+    ```
+  </Tab>
+  <Tab title="Windows (PowerShell)">
+    ```powershell
+    New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.openhands", "$env:USERPROFILE\projects" | Out-Null
+
+    docker run -it --rm `
+      -p 8000:8000 `
+      -v "$($env:USERPROFILE)\.openhands:/home/openhands/.openhands" `
+      -v "$($env:USERPROFILE)\projects:/projects" `
+      ghcr.io/openhands/agent-canvas:latest
+    ```
+
+    <Note>
+      Docker Desktop for Windows must be installed and running. PowerShell uses backticks (`` ` ``) for line continuation instead of backslashes.
+    </Note>
+  </Tab>
+</Tabs>
 
 Agent Canvas is now running at `http://localhost:8000`. The agent can access any project under the mounted `/projects` path.
 

--- a/openhands/usage/agent-canvas/setup.mdx
+++ b/openhands/usage/agent-canvas/setup.mdx
@@ -44,17 +44,37 @@ description: Install and run Agent Canvas via npm or Docker.
     | `OH_AGENT_SERVER_VERSION` | Pin a specific agent server version (e.g. `0.1.0`) |
   </Tab>
   <Tab title="Docker">
-    **Prerequisites:** [Docker](https://docs.docker.com/get-docker/).
+    **Prerequisites:** [Docker](https://docs.docker.com/get-docker/) (Docker Desktop on macOS/Windows, or Docker Engine on Linux).
 
-    A Docker image is available that sandboxes the entire Agent Canvas stack. Mount your project files and a persistence directory for settings, secrets, and conversation history:
+    A Docker image is available that sandboxes the entire Agent Canvas stack. Mount your project files and a persistence directory for settings, secrets, and conversation history.
 
+    Create a host directory for your projects (the agent can access any folder under this path) and run the container:
+
+    **macOS / Linux:**
     ```bash
+    mkdir -p ~/projects ~/.openhands
+
     docker run -it --rm \
       -p 8000:8000 \
       -v ~/.openhands:/home/openhands/.openhands \
       -v ~/projects:/projects \
       ghcr.io/openhands/agent-canvas:latest
     ```
+
+    **Windows (PowerShell):**
+    ```powershell
+    New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.openhands", "$env:USERPROFILE\projects" | Out-Null
+
+    docker run -it --rm `
+      -p 8000:8000 `
+      -v "$($env:USERPROFILE)\.openhands:/home/openhands/.openhands" `
+      -v "$($env:USERPROFILE)\projects:/projects" `
+      ghcr.io/openhands/agent-canvas:latest
+    ```
+
+    <Note>
+      On Windows, Docker Desktop must be installed and running. PowerShell uses backticks (`` ` ``) for line continuation instead of backslashes.
+    </Note>
 
     ### Environment Variables
 


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [ ] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

Adds Windows-specific Docker commands to the Agent Canvas documentation, sourced from the upstream [`README.windows.md`](https://github.com/OpenHands/agent-canvas/blob/main/README.windows.md) in the agent-canvas repo.

### Pages updated

**`openhands/usage/agent-canvas/setup.mdx`** (Install page — Docker tab)
- Updated Docker prerequisites to mention Docker Desktop on Windows
- Added a **"Windows (PowerShell)"** section alongside the existing macOS/Linux commands
- Includes PowerShell-syntax `docker run` with backtick line continuation, `$env:USERPROFILE` volume mount paths, and `New-Item` for directory creation
- Added a `<Note>` explaining the PowerShell syntax differences

**`openhands/usage/agent-canvas/backend-setup/docker.mdx`** (Docker Backend page)
- Updated prerequisites to mention Docker Desktop on macOS/Windows
- Converted the single code block into a `<Tabs>` component with **macOS / Linux** and **Windows (PowerShell)** tabs
- Windows tab includes the same PowerShell-syntax `docker run` command with a `<Note>` about Docker Desktop and backtick syntax

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/0d403df6-0132-4912-bddc-89313f785183)