### PR TITLE
docs: add Linux network binding warning for LM Studio with Docker

### DIFF
--- a/openhands/usage/llms/local-llms.mdx
+++ b/openhands/usage/llms/local-llms.mdx
@@ -64,7 +64,7 @@ Download and install the LM Studio desktop app from [lmstudio.ai](https://lmstud
 ![image](./screenshots/06_lm_studio_start_server.png)
 
 <Warning>
-**Linux users:** By default, LM Studio only listens on `127.0.0.1` (localhost). Since OpenHands runs inside a Docker container, it cannot reach `127.0.0.1` on the host — even with `--add-host host.docker.internal:host-gateway`.
+**Linux users:** By default, LM Studio only listens on `127.0.0.1` (localhost). If OpenHands runs inside a Docker container, it cannot reach `127.0.0.1` on the host — even with `--add-host host.docker.internal:host-gateway`.
 
 To fix this, enable **"Serve on Local Network"** in LM Studio's server settings. This switches the bind address to `0.0.0.0`, making the server reachable from Docker.
 

--- a/openhands/usage/llms/local-llms.mdx
+++ b/openhands/usage/llms/local-llms.mdx
@@ -63,6 +63,18 @@ Download and install the LM Studio desktop app from [lmstudio.ai](https://lmstud
 
 ![image](./screenshots/06_lm_studio_start_server.png)
 
+<Warning>
+**Linux users:** By default, LM Studio only listens on `127.0.0.1` (localhost). Since OpenHands runs inside a Docker container, it cannot reach `127.0.0.1` on the host — even with `--add-host host.docker.internal:host-gateway`.
+
+To fix this, enable **"Serve on Local Network"** in LM Studio's server settings. This switches the bind address to `0.0.0.0`, making the server reachable from Docker.
+
+You can verify connectivity from inside the container:
+```bash
+docker exec -it openhands-app curl -s http://host.docker.internal:1234/v1/models
+```
+If this returns the model list, the connection is working. If it hangs or errors, LM Studio is still bound to localhost only.
+</Warning>
+
 ### 5. Start OpenHands
 
 1. Check [the installation guide](/openhands/usage/run-openhands/local-setup) and ensure all prerequisites are met before running OpenHands, then run:


### PR DESCRIPTION
## What

Adds a warning box to the LM Studio quickstart section explaining that on Linux, LM Studio defaults to binding on `127.0.0.1` and the Docker container cannot reach it — even with `--add-host host.docker.internal:host-gateway`.

## Why

This is the #1 support question for Linux users running local LLMs with Docker. The error message (`litellm.InternalServerError: OpenAIException - Connection error`) gives no clue about the root cause.

The Ollama, SGLang, and vLLM sections already show `--host 0.0.0.0` in their example commands, but the LM Studio quickstart was missing any mention of network binding.

## What changes

- Added a `<Warning>` box after 'Step 4: Start the LLM server' explaining:
  - Why the connection fails on Linux
  - How to fix it (enable 'Serve on Local Network' in LM Studio)
  - How to verify connectivity with `docker exec ... curl`

## Context

Came up in #questions on Slack — a user on Fedora spent 30+ messages debugging what turned out to be this exact issue.