### PR TITLE
docs: add RunAPI OpenAI-compatible example

### DIFF
--- a/openhands/usage/llms/openai-llms.mdx
+++ b/openhands/usage/llms/openai-llms.mdx
@@ -16,6 +16,12 @@ If the model is not in the list, enable `Advanced` options, and enter it in `Cus
 
 Just as for OpenAI Chat completions, we use LiteLLM for OpenAI-compatible endpoints. You can find their full documentation on this topic [here](https://docs.litellm.ai/docs/providers/openai_compatible).
 
+For example, to use [RunAPI](https://runapi.ai) as an OpenAI-compatible endpoint, set:
+
+- `Custom Model` to `openai/<model-name>` using a model from [RunAPI models](https://runapi.ai/models.md)
+- `Base URL` to `https://api.runapi.ai/v1`
+- `API Key` to your RunAPI API key
+
 ## Using an OpenAI Proxy
 
 If you're using an OpenAI proxy, in the OpenHands UI through the Settings under the `LLM` tab:

--- a/openhands/usage/llms/openai-llms.mdx
+++ b/openhands/usage/llms/openai-llms.mdx
@@ -19,7 +19,7 @@ Just as for OpenAI Chat completions, we use LiteLLM for OpenAI-compatible endpoi
 For example, to use [RunAPI](https://runapi.ai) as an OpenAI-compatible endpoint, set:
 
 - `Custom Model` to `openai/<model-name>` using a model from [RunAPI models](https://runapi.ai/models.md)
-- `Base URL` to `https://api.runapi.ai/v1`
+- `Base URL` to `https://runapi.ai/v1`
 - `API Key` to your RunAPI API key
 
 ## Using an OpenAI Proxy


### PR DESCRIPTION
Adds a small RunAPI example to the OpenAI-compatible endpoint section.