### PR TITLE
Remove Agent Canvas beta notice

### DIFF
--- a/openhands/usage/agent-canvas/overview.mdx
+++ b/openhands/usage/agent-canvas/overview.mdx
@@ -3,10 +3,6 @@ title: Agent Canvas Overview
 description: A lightweight platform to run agents and automations — locally or in the cloud.
 ---
 
-<Note>
-  Agent Canvas is in Beta. Expect the install path, packaging, and some UI details to keep evolving.
-</Note>
-
 ## Why Agent Canvas
 
 - **One UI to drive any agent**: run conversations with OpenHands, Claude Code, Codex, or Gemini CLI through the same browser interface.


### PR DESCRIPTION
## Summary
- Removed the beta notice from the Agent Canvas overview page.

## Testing
- Not run (docs-only change).

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/20361814-e38f-48b4-a481-9d1a7d6c2943)