### PR TITLE
docs(sdk/security): add rein-openhands as a deterministic, no-LLM analyzer example

### DIFF
--- a/sdk/guides/security.mdx
+++ b/sdk/guides/security.mdx
@@ -444,6 +444,22 @@ agent = Agent(llm=llm, tools=tools, security_analyzer=security_analyzer)
     For more details on the base class implementation, see the [source code](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-sdk/openhands/sdk/security/analyzer.py).
 </Tip>
 
+#### A deterministic, no-LLM analyzer (rein)
+
+[`rein-openhands`](https://github.com/SametAtas/rein-openhands) implements `SecurityAnalyzerBase` with no LLM in the loop. It runs the [rein](https://github.com/SametAtas/rein) static engine over an action's code content and maps the result to `SecurityRisk`, so the same action always yields the same risk and prompt injection cannot change the classification.
+
+```bash
+pip install rein-openhands
+```
+
+```python icon="python"
+from rein_openhands import ReinSecurityAnalyzer
+
+agent = Agent(llm=llm, tools=tools, security_analyzer=ReinSecurityAnalyzer())
+```
+
+It returns `HIGH` for unsafe execution (`os.system`, `subprocess` with `shell=True`, `eval`, `exec`), unsafe deserialization (`pickle`, `yaml.load`, `marshal`), an unverified TLS context, and hard-coded credentials; weaker risks such as `md5`/`sha1` map to `MEDIUM`. It fails closed, returning `HIGH`, when a `.py` action cannot be parsed, since unanalyzed code is not safe code. As a code-content analyzer it complements the pattern analyzer below, run both for defense in depth.
+
 ### Defense-in-Depth Security Analyzer
 
 #### The problem


### PR DESCRIPTION
The SDK security guide shows how to build a custom SecurityAnalyzer. This adds a short example pointing to a ready-made one: rein-openhands, a deterministic, no-LLM analyzer that runs the rein static engine over an action's code content and maps it to SecurityRisk. It makes the SecurityAnalyzer to ConfirmationPolicy path auditable and replayable (same action, same risk, no model call), fails closed on unparseable Python, and complements the pattern analyzer for defense in depth. Discussed in #3524. Package: pip install rein-openhands.