### PR TITLE
Remove obsolete OpenHands state migration notes

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -33580,7 +33580,6 @@ docker run -it --rm --pull=always \
 
 </Accordion>
 
-> **Note**: If you used OpenHands before version 0.44, you may want to run `mv ~/.openhands-state ~/.openhands` to migrate your conversation history to the new location.
 
 You'll find OpenHands running at http://localhost:3000!
 
@@ -34693,7 +34692,6 @@ To fix this:
        docker.openhands.dev/openhands/openhands:latest
    ```
 
-   > **Note**: If you used OpenHands before version 0.44, you may want to run `mv ~/.openhands-state ~/.openhands` to migrate your conversation history to the new location.
 
 2. Make sure to expose the same port with `-p 41234:41234` in your Docker command.
 3. If running with the development workflow, you can set this in your `config.toml` file:

--- a/openhands/usage/run-openhands/local-setup.mdx
+++ b/openhands/usage/run-openhands/local-setup.mdx
@@ -138,7 +138,6 @@ docker run -it --rm --pull=always \
 
 </Accordion>
 
-> **Note**: If you used OpenHands before version 0.44, you may want to run `mv ~/.openhands-state ~/.openhands` to migrate your conversation history to the new location.
 
 You'll find OpenHands running at http://localhost:3000!
 

--- a/openhands/usage/troubleshooting/troubleshooting.mdx
+++ b/openhands/usage/troubleshooting/troubleshooting.mdx
@@ -97,7 +97,6 @@ To fix this:
        docker.openhands.dev/openhands/openhands:latest
    ```
 
-   > **Note**: If you used OpenHands before version 0.44, you may want to run `mv ~/.openhands-state ~/.openhands` to migrate your conversation history to the new location.
 
 2. Make sure to expose the same port with `-p 41234:41234` in your Docker command.
 3. If running with the development workflow, you can set this in your `config.toml` file:


### PR DESCRIPTION
## Summary
- Remove stale `~/.openhands-state` migration notes from local GUI Docker docs and troubleshooting docs.
- Remove the corresponding generated references from `llms-full.txt`.

## Validation
- `git diff --check`
- Verified `openhands-state` no longer appears in the docs repo with grep.

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/548a31cc-89bb-4c7a-b785-71131426e40a)