### PR TITLE
docs: attach security analyzer on the conversation, not the Agent constructor

### DIFF
--- a/sdk/guides/security.mdx
+++ b/sdk/guides/security.mdx
@@ -232,17 +232,24 @@ The **LLMSecurityAnalyzer** is the default implementation provided in the agent-
 
 Create an LLM-based security analyzer to review actions before execution:
 
-```python icon="python" focus={9}
-from openhands.sdk import LLM
+```python icon="python"
+from openhands.sdk import LLM, Agent, Conversation
+from openhands.sdk.security.confirmation_policy import ConfirmRisky
 from openhands.sdk.security.llm_analyzer import LLMSecurityAnalyzer
+
 llm = LLM(
     usage_id="security-analyzer",
     model=model,
     base_url=base_url,
     api_key=SecretStr(api_key),
 )
-security_analyzer = LLMSecurityAnalyzer(llm=security_llm)
-agent = Agent(llm=llm, tools=tools, security_analyzer=security_analyzer)
+security_analyzer = LLMSecurityAnalyzer(llm=llm)
+
+# Attach the analyzer on the conversation, not the Agent constructor.
+agent = Agent(llm=llm, tools=tools)
+conversation = Conversation(agent=agent, workspace=".")
+conversation.set_security_analyzer(security_analyzer)
+conversation.set_confirmation_policy(ConfirmRisky())
 ```
 
 The security analyzer:
@@ -437,7 +444,7 @@ class CustomSecurityAnalyzer(SecurityAnalyzerBase):
 
 # Use your custom analyzer
 security_analyzer = CustomSecurityAnalyzer()
-agent = Agent(llm=llm, tools=tools, security_analyzer=security_analyzer)
+conversation.set_security_analyzer(security_analyzer)
 ```
 
 <Tip>


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [ ] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

Two snippets in the security guide attach a security analyzer by passing `security_analyzer=` to the `Agent` constructor (the "Security Analyzer Configuration" and "Custom Security Analyzer Implementation" examples). The current SDK `Agent` has no `security_analyzer` field, and because the model uses pydantic's default `extra="ignore"`, this does not raise: the argument is silently dropped, so no analyzer is attached and the user gets no warning. Anyone following either section ends up with no security analyzer in place.

This PR attaches the analyzer the way the rest of this same guide already does (the ready-to-run example just below, and the defense-in-depth example):

    conversation.set_security_analyzer(...)
    conversation.set_confirmation_policy(ConfirmRisky())

It also fixes an undefined `security_llm` reference in the first block (the LLM is named `llm`).

Verified against openhands-sdk 1.17.0: `"security_analyzer" in Agent.model_fields` is `False`, and `Agent(llm=..., tools=[], security_analyzer=...)` does not raise and drops the argument (absent from `model_dump()`). The corrected snippets match the SDK's own example `examples/01_standalone_sdk/16_llm_security_analyzer.py`.