### PR TITLE
PLTF-2905: Document enabling Laminar Signals in OHE

### DIFF
--- a/enterprise/analytics.mdx
+++ b/enterprise/analytics.mdx
@@ -107,6 +107,45 @@ LLM_MODEL_LARGE: "gpt-5.5"
 
 For the full set of supported values, see Laminar's official [self-hosting configuration reference](https://laminar.sh/docs/self-hosting/configuration).
 
+## Enable Signals
+
+[Signals](https://laminar.sh/docs/signals/introduction) extract structured events from your traces using the same LLM provider configuration described above. They are enabled by default once an LLM key is configured, so enabling them is mostly a matter of pointing Laminar at a working LLM.
+
+1. **Configure an LLM provider and key.** Set `LLM_PROVIDER` and `LLM_API_KEY` (and `LLM_BASE_URL` when you use an OpenAI-compatible gateway). Signal extraction runs in the `app-server-consumer` component, so keep `llmProvider` consistent across the `frontend`, `appServer`, and `appServerConsumer` Laminar components:
+
+   ```yaml
+   frontend:
+     env:
+       llmProvider: "openai"
+   appServer:
+     env:
+       llmProvider: "openai"
+   appServerConsumer:
+     env:
+       llmProvider: "openai"
+   ```
+
+2. **Make sure Signals are turned on.** Signals are on by default once an LLM key is set. You can set the flag explicitly for clarity (and use `"false"` to turn them off):
+
+   ```yaml
+   frontend:
+     env:
+       signalsEnabled: "true"
+   ```
+
+3. **Provide the key the frontend feature flag checks.** Depending on your Laminar version, the frontend gates the **Signals** tab on a Gemini key. If you are not using the `gemini` provider, also set `GOOGLE_GENERATIVE_AI_API_KEY` (it can be the same key you use for `LLM_API_KEY`) so the tab appears:
+
+   ```yaml
+   frontend:
+     env:
+       signalsEnabled: "true"
+     extraEnv:
+       - name: GOOGLE_GENERATIVE_AI_API_KEY
+         value: "<your-llm-api-key>"
+   ```
+
+After saving and redeploying, the **Signals** tab appears in the Laminar UI. See Laminar's official [Signals configuration](https://laminar.sh/docs/self-hosting/configuration#signals) and [Signals guide](https://laminar.sh/docs/signals/introduction) for details.
+
 ## Deploy Updated Configuration
 
 Deploy the configuration change after setting the Laminar Project API Key in the Admin Console.


### PR DESCRIPTION
## Summary
- add an **Enable Signals** section to the OpenHands Enterprise analytics guide
- document the env vars / Helm values needed: `LLM_PROVIDER` (+ `LLM_API_KEY` / `LLM_BASE_URL`) kept consistent across `frontend`, `appServer`, and `appServerConsumer`, plus `signalsEnabled`
- note the `GOOGLE_GENERATIVE_AI_API_KEY` frontend feature-flag requirement for non-Gemini providers so the Signals tab appears
- link to the official Laminar [Signals configuration](https://laminar.sh/docs/self-hosting/configuration#signals) and [Signals guide](https://laminar.sh/docs/signals/introduction)

## Notes
- Guidance is described purely in terms of Laminar env vars / Helm values; no infrastructure-repo specifics (secret manifests, hostnames, environment paths) are included.

## Testing
- git diff --check

_This PR description was created by an AI agent (OpenHands) on behalf of the user._