### PR TITLE
Fix outdated SDK source link in introduction

### DIFF
--- a/overview/introduction.mdx
+++ b/overview/introduction.mdx
@@ -40,7 +40,7 @@ The SDK is a composable Python library that contains all of our agentic tech. It
 
 Define agents in code, then run them locally, or scale to 1000s of agents in the cloud.
 
-[Check out the docs](https://docs.openhands.dev/sdk) or [view the source](https://github.com/All-Hands-AI/agent-sdk/)
+[Check out the docs](https://docs.openhands.dev/sdk) or [view the source](https://github.com/OpenHands/software-agent-sdk)
 
 ## Legacy
 


### PR DESCRIPTION
## What

On the [Introduction page](https://docs.openhands.dev/overview/introduction), the **OpenHands Software Agent SDK** section's *"view the source"* link points to `https://github.com/All-Hands-AI/agent-sdk/`.

That repo was renamed/transferred and no longer exists under that name — it only loads via GitHub's silent redirect:

```
$ gh api repos/All-Hands-AI/agent-sdk --jq .full_name
OpenHands/software-agent-sdk
```

This is also the only repo link on the page still using the old `All-Hands-AI` org; every other link already uses `OpenHands/*`.

## Change

Point the link directly at the current repo: `https://github.com/OpenHands/software-agent-sdk`.