### PR TITLE
docs: rewrite Custom Sandbox guide for v1, archive v0 content

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -118,6 +118,7 @@
                     ]
                   },
                   "openhands/usage/v0/advanced/V0_configuration-options",
+                  "openhands/usage/v0/advanced/V0_custom-sandbox-guide",
                   {
                     "group": "V0 REST API",
                     "openapi": "openapi/V0_openapi.json"

--- a/openhands/usage/advanced/custom-sandbox-guide.mdx
+++ b/openhands/usage/advanced/custom-sandbox-guide.mdx
@@ -1,105 +1,105 @@
 ---
 title: Custom Sandbox
-description: This guide is for users that would like to use their own custom Docker image for the runtime.
-  For example, with certain tools or programming languages pre-installed.
+description: Build and use your own agent-server image when you need extra tools, system
+  packages, or language runtimes pre-installed in the sandbox.
 ---
 
 <Note>
   These settings are only available in [Local GUI](/openhands/usage/run-openhands/local-setup). OpenHands Cloud uses managed sandbox environments.
 </Note>
 
+<Note>
+  Looking for the legacy `SANDBOX_BASE_CONTAINER_IMAGE` / `base_container_image`
+  workflow? That only applies to OpenHands V0. See the
+  [V0 Custom Sandbox reference](/openhands/usage/v0/advanced/V0_custom-sandbox-guide).
+</Note>
+
 The sandbox is where the agent performs its tasks. Instead of running commands directly on your computer
 (which could be risky), the agent runs them inside a Docker container.
 
-The default OpenHands sandbox (`python-nodejs:python3.12-nodejs22`
-from [nikolaik/python-nodejs](https://hub.docker.com/r/nikolaik/python-nodejs)) comes with some packages installed such
-as python and Node.js but may need other software installed by default.
+## How the sandbox works in V1
 
-You have two options for customization:
+In OpenHands V1 the sandbox container **is** the OpenHands agent-server. By default OpenHands runs
+`ghcr.io/openhands/agent-server:<release>-python`, which already includes Python and Node.js. The image is
+resolved from two environment variables:
 
-- Use an existing image with the required software.
-- Create your own custom Docker image.
+- `AGENT_SERVER_IMAGE_REPOSITORY` (default `ghcr.io/openhands/agent-server`)
+- `AGENT_SERVER_IMAGE_TAG` (default `<release>-python`)
 
-If you choose the first option, you can skip the `Create Your Docker Image` section.
+Because the sandbox is the agent-server, you can't just swap in an arbitrary base image — the container has
+to keep running the agent-server. To add custom tooling you build a **custom agent-server image** on top of
+your chosen base image, then point OpenHands at it.
 
-## Create Your Docker Image
+## Building a custom agent-server image
 
-To create a custom Docker image, it must be Debian based.
+The agent-server is built from a [Dockerfile in the OpenHands SDK](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-agent-server/openhands/agent_server/docker/Dockerfile)
+that accepts a `BASE_IMAGE` build argument. Any Debian-based image works as the base.
 
-For example, if you want OpenHands to have `ruby` installed, you could create a `Dockerfile` with the following content:
+For example, to layer the agent-server onto an image that has `ruby` installed, first build (or pick) your base
+image. To build one:
 
 ```dockerfile
+# Dockerfile.base
 FROM nikolaik/python-nodejs:python3.12-nodejs22
 
 # Install required packages
 RUN apt-get update && apt-get install -y ruby
 ```
 
-Or you could use a Ruby-specific base image:
-
-```dockerfile
-FROM ruby:latest
-```
-
-Save this file in a folder. Then, build your Docker image (e.g., named custom-image) by navigating to the folder in
-the terminal and running::
 ```bash
-docker build -t custom-image .
+docker build -t my-base:latest -f Dockerfile.base .
 ```
 
-This will produce a new image called `custom-image`, which will be available in Docker.
+Then build the agent-server image on top of it. Clone the
+[OpenHands SDK](https://github.com/OpenHands/software-agent-sdk) and, from the repository root, run:
 
-## Using the Docker Command
+```bash
+docker buildx build \
+  --build-arg BASE_IMAGE=my-base:latest \
+  --target source \
+  -f openhands-agent-server/openhands/agent_server/docker/Dockerfile \
+  -t my-agent-server:custom \
+  --load \
+  .
+```
 
-When running OpenHands using [the docker command](/openhands/usage/run-openhands/local-setup#start-the-app), replace
-the `AGENT_SERVER_IMAGE_REPOSITORY` and `AGENT_SERVER_IMAGE_TAG` environment variables with `-e SANDBOX_BASE_CONTAINER_IMAGE=<custom image name>`:
+- `--build-arg BASE_IMAGE=` selects the base image to layer the agent-server onto.
+- `--target source` matches the default `-python` image (it includes VSCode and VNC and runs from a Python
+  virtual environment). Use `--target binary` for a self-contained build with no Python venv.
+- `--load` makes the resulting image available to your local Docker daemon.
 
-```commandline
+This produces a local image called `my-agent-server:custom`.
+
+## Pointing OpenHands at your image
+
+Set both environment variables so OpenHands launches your image as the sandbox. They must be set together —
+if either is missing, OpenHands falls back to the default image:
+
+```bash
 docker run -it --rm --pull=always \
-    -e SANDBOX_BASE_CONTAINER_IMAGE=custom-image \
+    -e AGENT_SERVER_IMAGE_REPOSITORY=my-agent-server \
+    -e AGENT_SERVER_IMAGE_TAG=custom \
     ...
 ```
 
-## Using the Development Workflow
+If you start OpenHands with Docker Compose, set the same variables there:
 
-### Setup
-
-First, ensure you can run OpenHands by following the instructions in [Development.md](https://github.com/OpenHands/OpenHands/blob/main/Development.md).
-
-### Specify the Base Sandbox Image
-
-In the `config.toml` file within the OpenHands directory, set the `base_container_image` to the image you want to use.
-This can be an image you’ve already pulled or one you’ve built:
-
-```bash
-[core]
-...
-[sandbox]
-base_container_image="custom-image"
+```yaml
+environment:
+  - AGENT_SERVER_IMAGE_REPOSITORY=my-agent-server
+  - AGENT_SERVER_IMAGE_TAG=custom
 ```
 
-### Additional Configuration Options
+When the sandbox starts, OpenHands launches your image on port `8000` and polls `/health` until the
+agent-server is ready.
 
-The `config.toml` file supports several other options for customizing your sandbox:
+<Note>
+  When you publish your image to a registry, set `AGENT_SERVER_IMAGE_REPOSITORY` to the fully qualified
+  repository (e.g. `ghcr.io/your-org/my-agent-server`) and make sure the host running OpenHands can pull it.
+</Note>
 
-```toml
-[core]
-# Install additional dependencies when the runtime is built
-# Can contain any valid shell commands
-# If you need the path to the Python interpreter in any of these commands, you can use the $OH_INTERPRETER_PATH variable
-runtime_extra_deps = """
-pip install numpy pandas
-apt-get update && apt-get install -y ffmpeg
-"""
+## Related
 
-# Set environment variables for the runtime
-# Useful for configuration that needs to be available at runtime
-runtime_startup_env_vars = { DATABASE_URL = "postgresql://user:pass@localhost/db" }
-
-# Specify platform for multi-architecture builds (e.g., "linux/amd64" or "linux/arm64")
-platform = "linux/amd64"
-```
-
-### Run
-
-Run OpenHands by running ```make run``` in the top level directory.
+- [Docker Sandbox](/openhands/usage/sandboxes/docker) — the default sandbox provider for Local GUI.
+- [Agent Server in Docker (SDK)](/sdk/guides/agent-server/docker-sandbox) — deeper details on the
+  agent-server image and how it is built.

--- a/openhands/usage/advanced/custom-sandbox-guide.mdx
+++ b/openhands/usage/advanced/custom-sandbox-guide.mdx
@@ -56,7 +56,7 @@ Then build the agent-server image on top of it. Clone the
 ```bash
 docker buildx build \
   --build-arg BASE_IMAGE=my-base:latest \
-  --target source \
+  --target binary \
   -f openhands-agent-server/openhands/agent_server/docker/Dockerfile \
   -t my-agent-server:custom \
   --load \
@@ -64,8 +64,11 @@ docker buildx build \
 ```
 
 - `--build-arg BASE_IMAGE=` selects the base image to layer the agent-server onto.
-- `--target source` matches the default `-python` image (it includes VSCode and VNC and runs from a Python
-  virtual environment). Use `--target binary` for a self-contained build with no Python venv.
+- `--target binary` matches how the default published `-python` image is built — it bundles a self-contained
+  agent-server binary (no Python virtual environment at runtime) and includes VSCode and VNC. Other targets
+  are available if you need them: `source` runs the agent-server from a Python virtual environment (handy for
+  development and debugging), and the `binary-minimal` / `source-minimal` targets drop VSCode and VNC for a
+  smaller image.
 - `--load` makes the resulting image available to your local Docker daemon.
 
 This produces a local image called `my-agent-server:custom`.

--- a/openhands/usage/v0/advanced/V0_custom-sandbox-guide.mdx
+++ b/openhands/usage/v0/advanced/V0_custom-sandbox-guide.mdx
@@ -1,0 +1,108 @@
+---
+title: Custom Sandbox
+description: This guide is for users that would like to use their own custom Docker image for the runtime.
+  For example, with certain tools or programming languages pre-installed.
+---
+<Note>
+  This page documents **legacy OpenHands V0** behavior. For the current V1
+  sandbox model, see [Custom Sandbox (V1)](/openhands/usage/advanced/custom-sandbox-guide).
+</Note>
+
+<Note>
+  These settings are only available in [Local GUI](/openhands/usage/run-openhands/local-setup). OpenHands Cloud uses managed sandbox environments.
+</Note>
+
+The sandbox is where the agent performs its tasks. Instead of running commands directly on your computer
+(which could be risky), the agent runs them inside a Docker container.
+
+The default OpenHands sandbox (`python-nodejs:python3.12-nodejs22`
+from [nikolaik/python-nodejs](https://hub.docker.com/r/nikolaik/python-nodejs)) comes with some packages installed such
+as python and Node.js but may need other software installed by default.
+
+You have two options for customization:
+
+- Use an existing image with the required software.
+- Create your own custom Docker image.
+
+If you choose the first option, you can skip the `Create Your Docker Image` section.
+
+## Create Your Docker Image
+
+To create a custom Docker image, it must be Debian based.
+
+For example, if you want OpenHands to have `ruby` installed, you could create a `Dockerfile` with the following content:
+
+```dockerfile
+FROM nikolaik/python-nodejs:python3.12-nodejs22
+
+# Install required packages
+RUN apt-get update && apt-get install -y ruby
+```
+
+Or you could use a Ruby-specific base image:
+
+```dockerfile
+FROM ruby:latest
+```
+
+Save this file in a folder. Then, build your Docker image (e.g., named custom-image) by navigating to the folder in
+the terminal and running::
+```bash
+docker build -t custom-image .
+```
+
+This will produce a new image called `custom-image`, which will be available in Docker.
+
+## Using the Docker Command
+
+When running OpenHands using the docker command, set `-e SANDBOX_BASE_CONTAINER_IMAGE=<custom image name>`:
+
+```commandline
+docker run -it --rm --pull=always \
+    -e SANDBOX_BASE_CONTAINER_IMAGE=custom-image \
+    ...
+```
+
+## Using the Development Workflow
+
+### Setup
+
+First, ensure you can run OpenHands by following the instructions in [Development.md](https://github.com/OpenHands/OpenHands/blob/main/Development.md).
+
+### Specify the Base Sandbox Image
+
+In the `config.toml` file within the OpenHands directory, set the `base_container_image` to the image you want to use.
+This can be an image you’ve already pulled or one you’ve built:
+
+```bash
+[core]
+...
+[sandbox]
+base_container_image="custom-image"
+```
+
+### Additional Configuration Options
+
+The `config.toml` file supports several other options for customizing your sandbox:
+
+```toml
+[core]
+# Install additional dependencies when the runtime is built
+# Can contain any valid shell commands
+# If you need the path to the Python interpreter in any of these commands, you can use the $OH_INTERPRETER_PATH variable
+runtime_extra_deps = """
+pip install numpy pandas
+apt-get update && apt-get install -y ffmpeg
+"""
+
+# Set environment variables for the runtime
+# Useful for configuration that needs to be available at runtime
+runtime_startup_env_vars = { DATABASE_URL = "postgresql://user:pass@localhost/db" }
+
+# Specify platform for multi-architecture builds (e.g., "linux/amd64" or "linux/arm64")
+platform = "linux/amd64"
+```
+
+### Run
+
+Run OpenHands by running ```make run``` in the top level directory.

--- a/openhands/usage/v0/runtimes/V0_docker.mdx
+++ b/openhands/usage/v0/runtimes/V0_docker.mdx
@@ -12,7 +12,7 @@ description: This is the default Runtime that's used when you start OpenHands.
 The runtime image from nikolaik is a pre-built runtime image
 that contains our Runtime server, as well as some basic utilities for Python and NodeJS.
 You can specify a custom runtime image using the `AGENT_SERVER_IMAGE_REPOSITORY` and `AGENT_SERVER_IMAGE_TAG` environment variables.
-You can also [build your own runtime image](/openhands/usage/advanced/custom-sandbox-guide).
+You can also [build your own runtime image](/openhands/usage/v0/advanced/V0_custom-sandbox-guide).
 
 ## Connecting to Your filesystem
 A useful feature is the ability to connect to your local filesystem. To mount your filesystem into the runtime:


### PR DESCRIPTION
## Problem

`usage/advanced/custom-sandbox-guide.mdx` ("Custom Sandbox") was never migrated from v0. It lives in the current docs tree (`Local GUI → Advanced`), has no version banner, and is linked from the v1 Docker sandbox page — yet it documents v0-only settings that don't exist in 1.x:

- `-e SANDBOX_BASE_CONTAINER_IMAGE=custom-image`
- `base_container_image="custom-image"` in `config.toml`
- the v0 default image `nikolaik/python-nodejs:python3.12-nodejs22`

`SANDBOX_BASE_CONTAINER_IMAGE` is read nowhere in v1, so the custom image is silently ignored and users hit `Sandbox failed to start` (reported in OpenHands/OpenHands#15018).

## Changes

Per the issue, this both archives the v0 content **and** puts a correct v1 guide in place:

- **Rewrote** `usage/advanced/custom-sandbox-guide.mdx` for v1. In v1 the sandbox container *is* the agent-server, so customization means building a custom **agent-server image** on top of your base via `--build-arg BASE_IMAGE=` against the SDK Dockerfile, then pointing OpenHands at it with `AGENT_SERVER_IMAGE_REPOSITORY` / `AGENT_SERVER_IMAGE_TAG`.
- **Moved** the original v0 content to `usage/v0/advanced/V0_custom-sandbox-guide.mdx` and added it to the **V0 Reference** group in `docs.json`, with the standard legacy banner.
- **Updated** the V0 Docker runtime page link to point at the new V0 reference page.

The link in `usage/sandboxes/docker.mdx` keeps the same path and now resolves to the corrected v1 guide.

## Verification

- v1 facts checked against source: `get_agent_server_image()` resolves `AGENT_SERVER_IMAGE_REPOSITORY`+`AGENT_SERVER_IMAGE_TAG` (default `ghcr.io/openhands/agent-server:<release>-python`); the agent-server Dockerfile accepts `ARG BASE_IMAGE`; the container runs on port `8000` and is polled at `/health`.
- `docs.json` is valid JSON.
- `mint broken-links` reports no new broken links (the 2 pre-existing ones are in untouched SDK files).

Closes #597