### PR TITLE
Move Laminar VM walkthrough video

### DIFF
--- a/enterprise/analytics.mdx
+++ b/enterprise/analytics.mdx
@@ -236,6 +236,14 @@ Deploy the configuration change after setting the Laminar Project API Key.
     Click **Deploy** in the Admin Console.
 
     ![Laminar Deploy Again](./images/laminar-deploy-again.png)
+
+    For a VM install walkthrough, watch the recap:
+
+    <video
+      controls
+      className="w-full aspect-video"
+      src="https://github.com/user-attachments/assets/0cdf1625-3246-4388-a989-765f00d33ffb"
+    ></video>
   </Tab>
   <Tab title="Kubernetes (Helm)">
     Apply your updated `values.yaml` override file:
@@ -259,12 +267,6 @@ Navigate to the OpenHands UI at `https://app.<your-base-domain>`. Start a new co
 Your conversations will now automatically send traces to Laminar.
 
 ![Laminar Trace](./images/laminar-trace.png)
-
-<video
-  controls
-  className="w-full aspect-video"
-  src="https://github.com/user-attachments/assets/0cdf1625-3246-4388-a989-765f00d33ffb"
-></video>
 
 ## What to Do Next in Laminar
 


### PR DESCRIPTION
## Summary
- Move the Laminar walkthrough video into the VM install tab under deploy configuration
- Keep the shared post-conversation section focused on the trace result and next Laminar steps

## Testing
- git diff --check
- make llms-check (fails: existing generated llms.txt / llms-full.txt drift from unrelated docs content on main; generated files restored to keep this PR scoped)

Follow-up to review nit in #593: https://github.com/OpenHands/docs/pull/593#pullrequestreview-4595267316