### PR TITLE
docs: add Laminar SQL query examples

### DIFF
--- a/enterprise/analytics.mdx
+++ b/enterprise/analytics.mdx
@@ -268,6 +268,39 @@ Your conversations will now automatically send traces to Laminar.
 
 ![Laminar Trace](./images/laminar-trace.png)
 
+## Query Traces with SQL
+
+Use [Laminar's CLI](https://laminar.sh/docs/platform/cli) for expected read-only access to trace data. The CLI authenticates as your Laminar user, not with the ingest-only project API key configured for OpenHands trace collection.
+
+For Laminar Cloud:
+
+```bash
+lmnr-cli login
+lmnr-cli sql query "SELECT * FROM traces ORDER BY start_time DESC LIMIT 1"
+```
+
+For self-hosted Laminar, point the CLI at your frontend and API before logging in:
+
+```bash
+export LMNR_FRONTEND_URL=https://example.com
+export LMNR_BASE_URL=https://api.example.com
+export LMNR_HTTP_PORT=8000
+
+lmnr-cli login
+lmnr-cli sql query "SELECT * FROM traces ORDER BY start_time DESC LIMIT 1"
+```
+
+For scripts that need to call the SQL endpoint directly, send a `POST` request to `/v1/sql/query` with a read-capable Laminar project API key:
+
+```bash
+curl https://api.lmnr.ai/v1/sql/query \
+  -H "Authorization: Bearer $LMNR_PROJECT_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"SELECT * FROM traces ORDER BY start_time DESC LIMIT 10"}'
+```
+
+For self-hosted Laminar, replace `https://api.lmnr.ai` with your Laminar API endpoint.
+
 ## What to Do Next in Laminar
 
 Once traces are flowing, use Laminar's official docs to go deeper:


### PR DESCRIPTION
## Summary
- Add CLI examples for querying Laminar traces with SQL from Laminar Cloud and self-hosted deployments
- Add direct HTTP SQL API curl example for scripts
- Clarify that OpenHands ingest-only keys are for trace collection, while query access needs CLI user auth or a read-capable project API key

## Validation
- Ran `git diff --check`
- Ran `uv run --with pytest --with requests pytest -q tests/` (failed: missing `yaml` dependency in documented test command)
- Ran `uv run --with pytest --with requests --with pyyaml pytest -q tests/` (34 passed, 2 errors from existing 404 fetching `https://raw.githubusercontent.com/OpenHands/OpenHands/main/openhands/utils/llm.py`)