### PR TITLE
Add Agent Settings page and link Settings sections in Customize & Settings

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -85,6 +85,7 @@
               {
                 "group": "Settings",
                 "pages": [
+                  "openhands/usage/settings/agent-settings",
                   "openhands/usage/settings/application-settings",
                   "openhands/usage/settings/llm-settings",
                   "openhands/usage/settings/secrets-settings",

--- a/openhands/usage/agent-canvas/customize-and-settings.mdx
+++ b/openhands/usage/agent-canvas/customize-and-settings.mdx
@@ -27,12 +27,12 @@ The `Settings` area currently includes the following sections:
 
 | Section | Purpose |
 |---------|---------|
-| `Agent` | Agent behavior and agent-specific capabilities |
-| `LLM` | Provider, model, API key, and profile configuration |
+| [`Agent`](/openhands/usage/settings/agent-settings) | Agent behavior and agent-specific capabilities |
+| [`LLM`](/openhands/usage/settings/llm-settings) | Provider, model, API key, and profile configuration |
 | `Condenser` | Context compression and summarization behavior |
 | `Verification` | Approval, critic evaluation, and verification-related behavior |
-| `Application` | UI-level preferences and app behavior |
-| `Secrets` | Stored secrets used by the active backend |
+| [`Application`](/openhands/usage/settings/application-settings) | UI-level preferences and app behavior |
+| [`Secrets`](/openhands/usage/settings/secrets-settings) | Stored secrets used by the active backend |
 
 On local backends, the `LLM` page also includes an `Available Profiles` area for saved profiles.
 

--- a/openhands/usage/settings/agent-settings.mdx
+++ b/openhands/usage/settings/agent-settings.mdx
@@ -1,0 +1,34 @@
+---
+title: Agent Settings
+description: Configure agent behavior, including sub-agent support and agent selection.
+---
+
+## Overview
+
+The Agent settings page controls how the OpenHands agent behaves during conversations — from enabling sub-agents to choosing a different agent entirely.
+
+Navigate to `Settings > Agent` to configure these options.
+
+## Sub-Agent Support
+
+The OpenHands agent supports spawning **sub-agents** to handle parallel or delegated work within a single conversation. When sub-agent support is enabled, the agent can create child agents directly inside the main conversation thread, delegating subtasks to them without leaving the current context.
+
+Enabling this setting adds the `task` tool to the agent's tool set, which it uses to spawn and coordinate sub-agents. Sub-agents share the same conversation thread, so their results surface inline alongside the main agent's output.
+
+<Note>
+  Sub-agent support is available on the built-in OpenHands agent. ACP agents manage their own execution model and are not affected by this setting.
+</Note>
+
+## Choosing a Different Agent
+
+The Agent settings page is also where you switch from the built-in OpenHands agent to an external **ACP agent** — such as Claude Code, Codex, or Gemini CLI. ACP agents run as subprocesses managed by the Agent Server and use the [Agent Client Protocol](https://agentclientprotocol.com/protocol/overview) to communicate with Agent Canvas.
+
+This lets you bring your own preferred coding agent while keeping the full Agent Canvas experience — conversation history, backend management, secrets, and more.
+
+For step-by-step instructions on onboarding and configuring an ACP agent, see the [ACP Agents guide](/openhands/usage/agent-canvas/acp-agents).
+
+## Related Guides
+
+- [ACP Agents](/openhands/usage/agent-canvas/acp-agents) — Bring your own agent with Claude Code, Codex, or Gemini CLI
+- [Customize and Settings](/openhands/usage/agent-canvas/customize-and-settings) — Overview of all settings sections
+- [Secrets Management](/openhands/usage/settings/secrets-settings) — Store credentials used by the agent


### PR DESCRIPTION
- [ ] I have read and reviewed the documentation changes to the best of my ability.
- [ ] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

- **New page: `openhands/usage/settings/agent-settings.mdx`** — Documents the `Settings > Agent` panel, covering:
  - Sub-agent support: explains that enabling it spawns sub-agents inside the main conversation thread using the `task` tool
  - ACP agent selection: explains how to switch to an external agent (Claude Code, Codex, Gemini CLI) and links to the ACP Agents guide
  - Added to the `Settings` navigation group in `docs.json` under the Home tab

- **Updated: `openhands/usage/agent-canvas/customize-and-settings.mdx`** — The Settings sections table now links four entries to their dedicated docs pages:
  - `Agent` → `/openhands/usage/settings/agent-settings` (new page)
  - `LLM` → `/openhands/usage/settings/llm-settings`
  - `Application` → `/openhands/usage/settings/application-settings`
  - `Secrets` → `/openhands/usage/settings/secrets-settings`
  - `Condenser` and `Verification` left unlinked (no dedicated pages exist in the Home Settings group)

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@jpelletier1 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d045b464-5412-4bf9-90e4-493aff487e05)