### PR TITLE
Document automation run timeouts

### DIFF
--- a/openhands/usage/automations/creating-automations.mdx
+++ b/openhands/usage/automations/creating-automations.mdx
@@ -47,6 +47,7 @@ When asking OpenHands to create an automation, include:
 - **What it should do**: Describe the task clearly
 - **When it should run**: Daily, weekly, every hour, etc.
 - **Timezone** (optional): Defaults to UTC if not specified
+- **Run timeout** (optional): Defaults to 10 minutes; maximum 30 minutes
 - **Name** (optional): The agent can suggest one based on your description
 - **Plugins** (optional): Mention specific plugins if you need extended capabilities
 
@@ -125,6 +126,10 @@ The agent converts this to the appropriate cron schedule.
 <Tip>
 If you're familiar with cron expressions, you can specify them directly: "Run on cron schedule `0 9 * * 1-5`"
 </Tip>
+
+## Run Timeouts
+
+Each run stops after its timeout. The default is 10 minutes; you can request up to 30 minutes, for example: "Use a 20-minute timeout."
 
 ## After Creation
 

--- a/openhands/usage/automations/managing-automations.mdx
+++ b/openhands/usage/automations/managing-automations.mdx
@@ -43,6 +43,14 @@ Change the "Daily Report" automation to run at 10 AM instead of 9 AM
 Update the "Weekly Cleanup" automation to run on Sundays at 2 AM UTC
 ```
 
+## Changing the Run Timeout
+
+```
+Set the "Weekly Cleanup" automation timeout to 20 minutes
+```
+
+Timeouts can be up to 30 minutes. Runs that exceed their timeout fail automatically.
+
 ## Running Manually
 
 Test an automation or run it outside its normal schedule:


### PR DESCRIPTION
## Summary
- Add run timeout guidance to automation creation docs
- Add a concise example for updating an automation timeout
- Note the 10-minute default and 30-minute maximum

## Verification
- `git diff --check`

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/dd0447c1-8407-4aee-9d36-147fad3165a7)