### PR TITLE
docs: add Atomic Chat to Local LLMs guide (security follow-up)

### DIFF
--- a/openhands/usage/llms/local-llms.mdx
+++ b/openhands/usage/llms/local-llms.mdx
@@ -144,7 +144,7 @@ If you're experiencing issues, try switching to one of these models before assum
 
 ## Advanced: Alternative LLM Backends
 
-This section describes how to run local LLMs with OpenHands using alternative backends like Ollama, SGLang, or vLLM — without relying on LM Studio.
+This section describes how to run local LLMs with OpenHands using alternative backends like Ollama, [Atomic Chat](https://atomic.chat/), SGLang, or vLLM — without relying on LM Studio.
 
 ### Create an OpenAI-Compatible Endpoint with Ollama
 
@@ -158,6 +158,48 @@ This section describes how to run local LLMs with OpenHands using alternative ba
 OLLAMA_CONTEXT_LENGTH=32768 OLLAMA_HOST=0.0.0.0:11434 OLLAMA_KEEP_ALIVE=-1 nohup ollama serve &
 ollama pull qwen3.6:35b-a3b
 ```
+
+### Create an OpenAI-Compatible Endpoint with Atomic Chat
+
+[Atomic Chat](https://atomic.chat/) is an open-source desktop app for running local models (and optional cloud providers). It exposes a **single OpenAI-compatible HTTP API** on your machine, typically at `http://127.0.0.1:1337/v1`. See the upstream [README](https://github.com/AtomicBot-ai/Atomic-Chat/blob/main/README.md) for downloads, system requirements, and release notes.
+
+#### 1. Install and start Atomic Chat
+
+1. Download Atomic Chat from [atomic.chat](https://atomic.chat/) or [GitHub Releases](https://github.com/AtomicBot-ai/Atomic-Chat/releases).
+2. Open Atomic Chat and **enable the local API server** in the app settings (defaults may vary by version; the API is usually served on **port 1337**).
+3. **Download and load a coding-capable model** with a **large context window**. OpenHands needs enough context for the system prompt and tools — use at least **~22k tokens**, and **32k+** when your hardware allows (same guidance as LM Studio on this page).
+
+<Note>
+  Atomic Chat binds the local API to **loopback (`127.0.0.1`) by default**, so the OpenAI-compatible endpoint is not exposed on your LAN unless you explicitly change the server host and set an API key. For Docker on the host, use `host.docker.internal:1337/v1` as described below.
+</Note>
+
+#### 2. Discover the model id OpenHands must use
+
+Atomic Chat lists served models via the OpenAI-compatible `GET /v1/models` endpoint. From the same machine:
+
+```bash
+curl -s http://127.0.0.1:1337/v1/models | head
+```
+
+Use the `id` field of the model you have loaded as the suffix after `openai/` in OpenHands (see [Configure OpenHands (Alternative Backends)](#configure-openhands-alternative-backends) below).
+
+#### 3. Point OpenHands at Atomic Chat
+
+Follow [Run OpenHands (Alternative Backends)](#run-openhands-alternative-backends) and [Configure OpenHands (Alternative Backends)](#configure-openhands-alternative-backends) below. When OpenHands runs **inside Docker** and Atomic Chat runs on the **host**, use:
+
+- **Base URL**: `http://host.docker.internal:1337/v1`
+- **Custom Model**: `openai/<model-id-from-/v1/models>` (prefix required, same convention as LM Studio on this page)
+- **API Key**: any placeholder string (for example `local-llm`) unless your Atomic Chat build requires a real key
+
+If OpenHands and Atomic Chat run on the **same host without Docker** for the web UI, you can use `http://127.0.0.1:1337/v1` instead.
+
+Atomic Chat also ships a **Launch → OpenHands** integration that can configure `LLM_BASE_URL`, `LLM_MODEL`, and `LLM_API_KEY` for the OpenHands CLI automatically.
+
+#### Troubleshooting
+
+- **Connection refused from Docker**: confirm Atomic Chat is running, the local server is enabled, and your `docker run` includes `--add-host host.docker.internal:host-gateway` as in [local setup](/openhands/usage/run-openhands/local-setup).
+- **Wrong model errors**: the Custom Model string must match an `id` returned by `GET /v1/models` after the `openai/` prefix.
+- **Agent ignores tools or acts like a chatbot**: try a stronger coding model or a larger context window; see [Community-Reported Notes and Troubleshooting](#community-reported-notes-and-troubleshooting) on this page.
 
 ### Create an OpenAI-Compatible Endpoint with vLLM or SGLang
 
@@ -239,8 +281,9 @@ Once OpenHands is running, open the Settings page in the UI and go to the `LLM` 
    - **Custom Model**: `openai/<served-model-name>`
      - For **Ollama**: `openai/qwen3.6:35b-a3b`
      - For **SGLang/vLLM**: `openai/Qwen3.6-35B-A3B`
+     - For **Atomic Chat**: `openai/<model-id-from-/v1/models>` (see [Atomic Chat](#create-an-openai-compatible-endpoint-with-atomic-chat) above)
    - **Base URL**: `http://host.docker.internal:<port>/v1`
-     Use port `11434` for Ollama, or `8000` for SGLang and vLLM.
+     Use port `11434` for Ollama, `1337` for Atomic Chat (default), or `8000` for SGLang and vLLM.
    - **API Key**:
-     - For **Ollama**: any placeholder value (e.g. `dummy`, `local-llm`)
+     - For **Ollama** or **Atomic Chat**: any placeholder value (e.g. `dummy`, `local-llm`) unless your server requires a real key
      - For **SGLang** or **vLLM**: use the same key provided when starting the server (e.g. `mykey`)

--- a/openhands/usage/llms/local-llms.mdx
+++ b/openhands/usage/llms/local-llms.mdx
@@ -144,7 +144,7 @@ If you're experiencing issues, try switching to one of these models before assum
 
 ## Advanced: Alternative LLM Backends
 
-This section describes how to run local LLMs with OpenHands using alternative backends like Ollama, [Atomic Chat](https://atomic.chat/), SGLang, or vLLM — without relying on LM Studio.
+This section describes how to run local LLMs with OpenHands using alternative backends like Ollama, Atomic Chat, SGLang, or vLLM — without relying on LM Studio.
 
 ### Create an OpenAI-Compatible Endpoint with Ollama
 


### PR DESCRIPTION
## Summary

Re-submits documentation for [Atomic Chat](https://atomic.chat/) as an OpenAI-compatible local backend for OpenHands, following up on #504.

This PR adds the same Local LLMs guide content as #504 (install, enable local API, discover model id via `GET /v1/models`, Docker `host.docker.internal:1337/v1` vs same-host base URL, placeholder API key, troubleshooting) and documents the **loopback-by-default** local API behavior.

## What we fixed since #504

Reviewers in #504 raised security and adoption concerns. Since that PR was closed, we addressed the upstream issues in [AtomicBot-ai/Atomic-Chat](https://github.com/AtomicBot-ai/Atomic-Chat):

### Security posture (raised by @Fieldnote-Echo)

| Concern in #504 | Remediation in Atomic Chat |
|-----------------|----------------------------|
| **Local API bound to `0.0.0.0` by default** | Default server host is now **`127.0.0.1` (loopback)** ([`2f0e35e`](https://github.com/AtomicBot-ai/Atomic-Chat/commit/2f0e35e0a5c0bf070baea779a7f47d01f0c1dce7)). Binding to all interfaces requires an explicit user choice plus an API key. |
| **Telemetry on with consent check commented out** | Crash/error telemetry (Sentry) is now **gated behind the existing `productAnalytic` consent toggle** with fail-closed `beforeSend`/`beforeBreadcrumb` hooks on both frontend and Rust desktop ([ATO-113](https://linear.app/atomicchat/issue/ATO-113), [`a5aadbe`](https://github.com/AtomicBot-ai/Atomic-Chat/commit/a5aadbe43c6e1713c5211bca0a1857921b650a0a)). |
| **Cloud API keys in browser storage** | Remote provider registry entries are **sanitized on load** (`api_key` is always stripped from the manifest). User-entered cloud keys remain in local app storage; the OpenHands integration path documented here uses only the **local loopback API** with a placeholder key. |
| **Supply-chain risk** | Release pipeline uses **HMAC-signed update checks**, **re-codesigned/notarized desktop binaries**, and **Dependabot security patches** for dependencies. |

### OpenHands-specific integration

- Atomic Chat now ships a **Launch → OpenHands** card that configures `LLM_BASE_URL`, `LLM_MODEL`, and `LLM_API_KEY` for the OpenHands CLI automatically (see upstream `configure_openhands`).

## Changes in this PR

- Mention Atomic Chat in the **Advanced: Alternative LLM Backends** intro.
- Add **Create an OpenAI-Compatible Endpoint with Atomic Chat** section with loopback-default note.
- Extend **Configure OpenHands (Alternative Backends)** with Atomic Chat model string, port **1337**, and API key note.

## References

- Supersedes: #504
- Upstream project: https://github.com/AtomicBot-ai/Atomic-Chat
- Website: https://atomic.chat/

## Test plan

- [ ] MDX renders without broken anchors on the Local LLMs page
- [ ] Atomic Chat section links resolve within the same page
- [ ] Docker and same-host base URL examples are consistent with the rest of the guide


Made with [Cursor](https://cursor.com)