### PR TITLE
Add TLS warning for private CA certs

### DIFF
--- a/enterprise/quick-start.mdx
+++ b/enterprise/quick-start.mdx
@@ -43,6 +43,13 @@ You will need a VM to host OpenHands Enterprise. Choose one of the options below
     <Card title="OpenHands AWS Terraform Module" icon="github" href="https://github.com/All-Hands-AI/OpenHands-Cloud/tree/main/terraform/aws">
       Follow the README instructions to configure and apply the Terraform configuration.
     </Card>
+
+    <Warning>
+      The recommended Terraform path provisions a publicly trusted TLS certificate. If you bring
+      your own certificate instead, use a publicly trusted CA whenever possible. Private CA
+      certificates require every external webhook or OAuth provider that calls OpenHands to trust
+      your CA.
+    </Warning>
   </Tab>
 
   <Tab title="Manual VM Setup">
@@ -282,6 +289,11 @@ If the install command fails after preflight checks pass, run `sudo ./openhands 
   If you provisioned manually and have your own certificates on the VM, pass them the same way.
   You can also omit the `--tls-cert` and `--tls-key` flags and upload certificates later through
   the Admin Console.
+
+  For trials and production deployments, use a publicly trusted TLS certificate whenever possible.
+  Private CA certificates may work for users after manual trust setup, but external integrations
+  such as GitHub, GitLab, Slack, Jira, and Bitbucket must also trust the certificate chain. If they
+  do not, webhook or OAuth callbacks can fail TLS verification and repeatedly retry.
 </Warning>
 
 ![Installation commands](./images/install-commands.png)
@@ -301,6 +313,9 @@ Click **Advanced**, then **Proceed** to continue to the Admin Console.
 
 If you did not provide certificates with the `install` command, select **"Upload your own"**,
 enter your base domain under **Hostname**, upload your private key and SSL certificate, then click **Continue**.
+
+If you upload a private CA certificate, make sure any external webhook or OAuth provider that
+calls OpenHands also trusts that CA.
 
 ![Upload TLS certificate](./images/upload-tls-certificate.png)
 


### PR DESCRIPTION
## Summary

- add a Terraform-path TLS warning for bring-your-own private CA certificates
- extend the installer TLS warning with external webhook and OAuth provider trust implications
- add a reminder in the Admin Console certificate upload step

Closes #611.

## Validation

- `git diff --check`
- `make llms-check` failed after regenerating unrelated `llms.txt` and `llms-full.txt` diffs outside this PR's scope; those generated files are not included
