### PR TITLE
docs: fix load_skills_from_dir import path

### DIFF
--- a/sdk/guides/skill.mdx
+++ b/sdk/guides/skill.mdx
@@ -79,7 +79,7 @@ Content that's always in the system prompt.
 Place `AGENTS.md` at your repo root - it's loaded automatically. See [Permanent Context](/overview/skills/repo).
 
 ```python icon="python" focus={3, 4}
-from openhands.sdk.context.skills import load_project_skills
+from openhands.sdk.skills import load_project_skills
 
 # Automatically finds AGENTS.md, CLAUDE.md, GEMINI.md at workspace root
 skills = load_project_skills(workspace_dir="/path/to/repo")
@@ -200,7 +200,7 @@ Patterns use gitignore-style matching against the workspace-relative POSIX path 
 For the agent to trigger skills, use the [AgentSkills standard](https://agentskills.io/specification) `SKILL.md` format. The agent sees a summary and reads full content on demand.
 
 ```python icon="python"
-from openhands.sdk.context.skills import load_skills_from_dir
+from openhands.sdk.skills import load_skills_from_dir
 
 # Load SKILL.md files from a directory
 _, _, agent_skills = load_skills_from_dir("/path/to/skills")
@@ -834,7 +834,7 @@ from pathlib import Path
 from pydantic import SecretStr
 
 from openhands.sdk import LLM, Agent, AgentContext, Conversation
-from openhands.sdk.context.skills import (
+from openhands.sdk.skills import (
     discover_skill_resources,
     load_skills_from_dir,
 )
@@ -951,7 +951,7 @@ print(f"EXAMPLE_COST: {llm.metrics.accumulated_cost:.4f}")
 Loads all skills from a directory, returning three dictionaries:
 
 ```python icon="python" focus={3}
-from openhands.sdk.context.skills import load_skills_from_dir
+from openhands.sdk.skills import load_skills_from_dir
 
 repo_skills, knowledge_skills, agent_skills = load_skills_from_dir(skills_dir)
 ```
@@ -971,7 +971,7 @@ When passing to `AgentContext(skills=...)`, all three types are accepted. The in
 Discovers resource files in a skill directory:
 
 ```python icon="python" focus={3}
-from openhands.sdk.context.skills import discover_skill_resources
+from openhands.sdk.skills import discover_skill_resources
 
 resources = discover_skill_resources(skill_dir)
 print(resources.scripts)     # List of script files
@@ -1081,7 +1081,7 @@ agent_context = AgentContext(
 You can also load public skills manually and have more control:
 
 ```python icon="python"
-from openhands.sdk.context.skills import load_public_skills
+from openhands.sdk.skills import load_public_skills
 
 # Load all public skills
 public_skills = load_public_skills()
@@ -1101,7 +1101,7 @@ agent_context = AgentContext(skills=my_skills + public_skills)
 You can load skills from your own repository:
 
 ```python icon="python" focus={3-7}
-from openhands.sdk.context.skills import load_public_skills
+from openhands.sdk.skills import load_public_skills
 
 # Load from a custom repository
 custom_skills = load_public_skills(


### PR DESCRIPTION
## Summary
The SDK skills guide imports several functions (`load_skills_from_dir`, `load_project_skills`, `load_public_skills`, `discover_skill_resources`) from `openhands.sdk.context.skills`, which does not exist:

```
ModuleNotFoundError: No module named 'openhands.sdk.context.skills'
```

The correct module is `openhands.sdk.skills` (see `openhands-sdk/openhands/sdk/skills/__init__.py` in `software-agent-sdk`, which exports all of these). This fixes all 7 occurrences of the wrong import path in `sdk/guides/skill.mdx`; 4 other spots in the same file already used the correct path.

Verified on OpenHands SDK v1.33.0.

## Test plan
- [x] Confirmed `openhands.sdk.context.skills` does not exist in `software-agent-sdk`
- [x] Confirmed all replaced functions are exported from `openhands.sdk.skills`
- [x] `grep -n "openhands.sdk.context.skills" sdk/guides/skill.mdx` returns no matches after the fix