### PR TITLE
docs(sdk): document conversation-scoped LLM headers

### DIFF
--- a/sdk/guides/observability.mdx
+++ b/sdk/guides/observability.mdx
@@ -141,6 +141,43 @@ Each conversation gets its own session ID (the conversation UUID), allowing you 
 
 In `tool.execute`, the tool calls are traced individually, such as `bash`, `file_editor`, or `task_tracker`.
 
+### Correlate LLM Requests With Application Requests
+
+Pass `llm_extra_headers` to attach application metadata to every LLM call made
+by a conversation:
+
+```python icon="python" wrap
+conversation = Conversation(
+    agent=agent,
+    workspace=workspace,
+    llm_extra_headers={"X-Request-ID": request_id},
+)
+conversation.send_message("Investigate the failing deployment")
+conversation.run()
+```
+
+The same option works with local and remote conversations and with synchronous or
+asynchronous runs. For direct Agent Server clients, include it in the conversation
+creation request alongside the required agent and workspace fields:
+
+```json wrap
+{
+  "llm_extra_headers": {
+    "X-Request-ID": "request-123"
+  }
+}
+```
+
+The headers remain active for every run of the live conversation, including retries,
+condensation, sub-agents, and agent hooks. They override static `LLM.extra_headers`
+with the same name, while SDK-managed headers are preserved. The headers are not
+persisted, so a new conversation or a server restart requires supplying them again.
+
+<Note>
+Header values are sent to the configured LLM provider. Treat them as sensitive and
+avoid logging them or placing secrets in correlation headers.
+</Note>
+
 ## Configuration Reference
 
 ### Environment Variables


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [x] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

- Document how to configure conversation-scoped LLM headers for local and remote conversations.
- Explain that Agent Server clients provide them when creating a conversation, while the `/run` contract remains unchanged.
- Document scope, precedence, runtime-only persistence, and security considerations.
- Related SDK implementation: https://github.com/OpenHands/software-agent-sdk/pull/4066

Validation: 30 non-pricing documentation tests passed. The unrelated pricing checks currently error because their upstream raw GitHub source returns HTTP 404.
