### PR TITLE
docs(llms): add DaoXE OpenAI-compatible gateway guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -166,6 +166,7 @@
                       "openhands/usage/llms/openhands-llms",
                       "openhands/usage/llms/aws-bedrock",
                       "openhands/usage/llms/azure-llms",
+                      "openhands/usage/llms/daoxe",
                       "openhands/usage/llms/google-llms",
                       "openhands/usage/llms/groq",
                       "openhands/usage/llms/local-llms",

--- a/openhands/usage/llms/daoxe.mdx
+++ b/openhands/usage/llms/daoxe.mdx
@@ -1,0 +1,48 @@
+---
+title: DaoXE
+description: Use DaoXE as an OpenAI-compatible multi-model multi-protocol API gateway with OpenHands via LiteLLM.
+---
+
+## Overview
+
+[DaoXE](https://daoxe.com) is a multi-model multi-protocol API gateway. OpenHands talks to LLMs through LiteLLM, so you can point OpenHands at DaoXE with an OpenAI-compatible base URL and your DaoXE API key.
+
+DaoXE exposes OpenAI Chat Completions (and other protocols such as OpenAI Responses and Anthropic Messages for other clients). This page covers the OpenAI-compatible path that OpenHands uses.
+
+DaoXE is not available in mainland China. Use an exact model ID from your DaoXE account catalog rather than a hard-coded public list.
+
+## Configuration (UI)
+
+When running OpenHands, set the following under **Settings → LLM**:
+
+1. Enable **Advanced** options.
+2. Set:
+   - **Custom Model** to `openai/<your-exact-daoxe-model-id>` (LiteLLM OpenAI-compatible form), for example `openai/YOUR_DAOXE_MODEL_ID`
+   - **Base URL** to `https://daoxe.com/v1`
+   - **API Key** to the key created in your [DaoXE dashboard](https://daoxe.com)
+
+If a built-in provider dropdown entry for DaoXE is not present, the Advanced custom model + base URL path is the supported integration.
+
+## Configuration (`config.toml`)
+
+```toml
+[llm]
+# LiteLLM OpenAI-compatible model string; replace with an exact ID from your DaoXE account
+model = "openai/YOUR_DAOXE_MODEL_ID"
+api_key = "YOUR_DAOXE_API_KEY"
+base_url = "https://daoxe.com/v1"
+```
+
+Discover model IDs with `GET https://daoxe.com/v1/models` (authorized with your key) or from the live catalog in your DaoXE account / [pricing page](https://daoxe.com/pricing) for discovery only.
+
+## Notes
+
+- Prefer tool-capable models from your account when you need agent tool use.
+- Requests may be billed by DaoXE.
+- Examples and client setup: [DaoXE-AI](https://github.com/seven7763/DaoXE-AI)
+
+## See also
+
+- [OpenAI / OpenAI-compatible endpoints](./openai-llms)
+- [Custom LLM configurations](./custom-llm-configs)
+- [LiteLLM OpenAI-compatible providers](https://docs.litellm.ai/docs/providers/openai_compatible)


### PR DESCRIPTION
## Summary
- Add `openhands/usage/llms/daoxe.mdx` for using [DaoXE](https://daoxe.com) with OpenHands via LiteLLM OpenAI-compatible endpoints.
- Base URL `https://daoxe.com/v1`, model form `openai/<exact-account-model-id>`, no static model price list.
- Link from LLM Providers nav in `docs.json` (after Azure).

DaoXE is a multi-model multi-protocol API gateway. This page documents the OpenAI-compatible path OpenHands uses; DaoXE also exposes OpenAI Responses and Anthropic Messages for other clients.

I am a DaoXE maintainer. Examples: https://github.com/seven7763/DaoXE-AI

## Test plan
- [ ] Page renders in docs site
- [ ] Nav entry works
- [ ] No hardcoded public model pricing table