### PR TITLE
docs: fix OpenHands REST OpenAPI path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ The site is built with **Mintlify** and deployed automatically by Mintlify on pu
 - `openhands/usage/` — product docs for Web/Cloud/CLI/etc.
 - `sdk/` — Agent SDK docs (guides, architecture, API reference pages)
 - `openapi/` — OpenAPI specs consumed by Mintlify
-  - `openapi/openapi.json` — OpenHands REST API schema
+  - `openapi/V0_openapi.json` — OpenHands REST API schema
   - `openapi/agent-sdk.json` — Agent SDK agent-server schema (synced from `software-agent-sdk`)
 - `scripts/` — automation for generating SDK API reference docs
 - `.github/workflows/` — CI workflows (broken link checks, sync jobs)


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [ ] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

Point the repository orientation guide at the tracked `openapi/V0_openapi.json` REST schema. The replacement exists at the submitted base commit, and `AGENTS.md` reports zero broken bindings under attest. This docs-only correction was found with the attest static instruction-binding scan.
