### PR TITLE
docs: add Laminar self-hosted base URL

### DIFF
--- a/sdk/guides/observability.mdx
+++ b/sdk/guides/observability.mdx
@@ -40,10 +40,11 @@ That's it. Run your agent code normally and traces will be sent to Laminar autom
 For Laminar-specific walkthroughs, see the official docs for [OpenHands SDK tracing](https://laminar.sh/docs/tracing/integrations/openhands-sdk), [session replay for browser agents](https://laminar.sh/docs/tracing/browser-agent-observability), [viewing traces](https://laminar.sh/docs/platform/viewing-traces), and [signals](https://laminar.sh/docs/signals/introduction).
 </Note>
 
-For **self-hosted Laminar** deployments, you can also configure custom ports:
+For **self-hosted Laminar** deployments, configure the instance base URL and ports:
 
 ```bash icon="terminal" wrap
 export LMNR_PROJECT_API_KEY="your-laminar-api-key"
+export LMNR_BASE_URL=http://localhost
 export LMNR_HTTP_PORT=8000
 export LMNR_GRPC_PORT=8001
 ```
@@ -149,6 +150,7 @@ The SDK checks for these environment variables (in order of precedence):
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `LMNR_PROJECT_API_KEY` | Laminar project API key | `your-laminar-api-key` |
+| `LMNR_BASE_URL` | Base URL for self-hosted Laminar | `http://localhost` |
 | `LMNR_HTTP_PORT` | HTTP port for self-hosted Laminar | `8000` |
 | `LMNR_GRPC_PORT` | gRPC port for self-hosted Laminar | `8001` |
 | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Full OTLP traces endpoint URL | `https://api.honeycomb.io:443/v1/traces` |
@@ -190,10 +192,11 @@ The SDK supports both HTTP and gRPC protocols:
 export LMNR_PROJECT_API_KEY="your-laminar-api-key"
 ```
 
-**Self-hosted Laminar**: If you are running a self-hosted Laminar instance, you can configure the HTTP and gRPC ports via environment variables:
+**Self-hosted Laminar**: If you are running a self-hosted Laminar instance, configure its base URL and the HTTP and gRPC ports via environment variables:
 
 ```bash icon="terminal" wrap
 export LMNR_PROJECT_API_KEY="your-laminar-api-key"
+export LMNR_BASE_URL=http://localhost
 export LMNR_HTTP_PORT=8000
 export LMNR_GRPC_PORT=8001
 ```


### PR DESCRIPTION
## Summary

- add `LMNR_BASE_URL` next to the self-hosted Laminar port examples
- document it in the observability environment-variable reference
- use the local OSS default, `http://localhost`

## Validation

- `mint broken-links`