### PR TITLE
docs: cover Agent Canvas 1.3.0 transcript export and automation export/import

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -208,6 +208,7 @@
           "openhands/usage/agent-canvas/conversations",
           "openhands/usage/agent-canvas/agent-profiles",
           "openhands/usage/agent-canvas/plugins",
+          "openhands/usage/agent-canvas/managing-automations",
           {
             "group": "Pre-built Automations",
             "pages": [

--- a/openhands/usage/agent-canvas/conversations.mdx
+++ b/openhands/usage/agent-canvas/conversations.mdx
@@ -82,6 +82,43 @@ Sending a normal message while a goal is running interrupts the goal and gives c
   The `/goal` command requires a backend that supports conversation goal routes. It uses both the agent LLM and a judge LLM, so goal runs may make additional model calls beyond the agent's normal work.
 </Note>
 
+## Export a transcript as Markdown or HTML
+
+You can download any conversation as a self-contained file to share, archive, or review outside Agent Canvas.
+
+**To export a transcript:**
+
+1. Open the conversation you want to export.
+2. Click the kebab menu (⋮) next to the conversation title.
+3. Select **Export transcript**.
+4. Choose a format and adjust the options, then click **Download**.
+
+### Format options
+
+| Format | File extension | Use it when |
+|--------|---------------|-------------|
+| Markdown document | `.md` | You want a plain-text file that renders in any Markdown viewer or editor |
+| Self-contained HTML | `.html` | You want a single file that opens formatted in any browser |
+
+The downloaded file is named `conversation-<conversation-id>.md` or `conversation-<conversation-id>.html`.
+
+### Export options
+
+| Option | Default | What it includes |
+|--------|---------|-----------------|
+| Include tool details | On | The full inputs and outputs of every tool call the agent made |
+| Include timestamps | On | The time of each event, inline |
+
+Turn off either option before downloading if you want a shorter or cleaner transcript.
+
+### Privacy
+
+The export is generated locally in your browser from the events Agent Canvas already has for that conversation. No conversation data is sent to a third party to produce the file.
+
+<Note>
+  For very large conversations, Agent Canvas loads the full event history before generating the file. This may take a moment. On cloud backends, the export uses the events the app currently has loaded.
+</Note>
+
 ## Related Guides
 
 - [Fork a Conversation](/sdk/guides/convo-fork)

--- a/openhands/usage/agent-canvas/managing-automations.mdx
+++ b/openhands/usage/agent-canvas/managing-automations.mdx
@@ -1,0 +1,92 @@
+---
+title: Managing automations
+description: Browse, export, import, enable, disable, and run automations from the Agent Canvas Automate view.
+---
+
+The **Automate** view in Agent Canvas is the in-app control center for your automations. From here you can see all automations on the active backend, inspect their configuration and run history, and manage their lifecycle without leaving the app.
+
+<Note>
+  Automations run on the active backend. Switch backends from [Connect and Manage Backends](/openhands/usage/agent-canvas/backends) to see automations on a different backend.
+</Note>
+
+## Browse and inspect automations
+
+Open the **Automate** tab in the sidebar to see all automations on the active backend. Each row shows the automation name, trigger type, and enabled state.
+
+Click an automation to open its detail view. The detail view shows:
+
+- The full prompt the automation runs
+- Trigger configuration (schedule, webhook, or event)
+- LLM profile used for runs
+- Recent run history and status
+
+## Enable and disable automations
+
+Toggle an automation on or off from the kebab menu (⋮) on the automation row, or from the detail view. Disabled automations do not fire on their scheduled trigger or in response to events, but their configuration is preserved.
+
+## Run an automation manually
+
+Select **Run now** from the automation's kebab menu to trigger an immediate run outside the normal schedule. Useful for testing or for one-off executions.
+
+## Export an automation
+
+Agent Canvas can export any automation as a portable JSON file. Use this to:
+
+- Share a reusable automation with teammates
+- Back up automation configuration in version control
+- Move an automation between backends or accounts
+
+**To export:**
+
+1. Open the **Automate** view.
+2. Click the kebab menu (⋮) on the automation you want to export.
+3. Select **Export**.
+
+The file downloads as `<slug>.automation.json`, where `<slug>` is derived from the automation's name.
+
+### Exported file format
+
+The file contains a versioned JSON document with the automation's full configuration:
+
+```json
+{
+  "version": 1,
+  "kind": "automation",
+  "spec": {
+    "name": "Daily GitHub Summary",
+    "trigger": {
+      "type": "schedule",
+      "schedule": "0 9 * * 1-5",
+      "schedule_human": "Weekdays at 9:00 AM",
+      "timezone": "America/New_York"
+    },
+    "enabled": true,
+    "prompt": "Summarize the previous day's PRs and post to #engineering.",
+    "repository": "openhands/docs",
+    "model": "anthropic/claude-sonnet-4-5"
+  }
+}
+```
+
+The `spec` object includes the automation's name, prompt, trigger, schedule, repository, model, plugins, and notification settings. You can hand-author, diff, or version-control this file using any standard tool.
+
+## Import an automation
+
+You can import an automation from a JSON file previously exported by Agent Canvas, or from a hand-authored file that follows the same versioned schema.
+
+**To import:**
+
+1. Open the **Automate** view.
+2. Click **Import automation** at the top of the list.
+3. Pick the `.json` file to import.
+4. Review the preview — it shows the automation's name, trigger type, and prompt.
+5. Confirm to create the automation.
+
+Imported automations are created **disabled**. After importing, open the automation from the list, review its configuration, and enable it when ready.
+
+## Related guides
+
+- [Creating automations](/openhands/usage/automations/creating-automations)
+- [Managing automations (CLI-style)](/openhands/usage/automations/managing-automations)
+- [Pre-built automations](/openhands/usage/agent-canvas/prebuilt-automations)
+- [Automations overview](/openhands/usage/automations/overview)

--- a/openhands/usage/settings/mcp-settings.mdx
+++ b/openhands/usage/settings/mcp-settings.mdx
@@ -87,7 +87,7 @@ MCP configuration can be defined in:
 
     - `name` (required)
       - Type: `str`
-      - Description: A unique name for the server.
+      - Description: A unique name for the server. Accepted characters are letters, digits, underscores (`_`), and hyphens (`-`). For example, `integrations-hub` is a valid name.
 
     - `command` (required)
       - Type: `str`


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [x] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

Agent Canvas 1.3.0 shipped two user-facing features with no existing doc coverage. This PR adds the missing pages and sections, plus a minor clarification from the same release.

**Conversation transcript export** — New section in `conversations.mdx` covers how to reach the export modal from the conversation kebab menu, the Markdown vs. self-contained HTML format choices, the two export toggles (tool details and timestamps, both on by default), the filename pattern, and the privacy guarantee that the export is generated entirely in the browser.

**Managing automations (new page)** — `openhands/usage/agent-canvas/managing-automations.mdx` documents the in-app Automate view lifecycle: browsing, enable/disable, manual run, export (including the versioned JSON format and an example block), and import (preview modal, imported automations land disabled). Added to the Agent Canvas tab in `docs.json` after `plugins`, following the same per-feature page pattern as `conversations.mdx`, `agent-profiles.mdx`, and `plugins.mdx`. The existing `openhands/usage/automations/managing-automations.mdx` (CLI-style) is unchanged.

**MCP stdio server name** — Updated the `name` field description to state that letters, digits, underscores, and hyphens are all accepted (e.g. `integrations-hub`), reflecting the 1.3.0 validator change.

Closes #620

