### PR TITLE
docs: fix broken links to project-management integration guides

### DIFF
--- a/openhands/usage/cloud/project-management/overview.mdx
+++ b/openhands/usage/cloud/project-management/overview.mdx
@@ -18,9 +18,9 @@ Integration requires two levels of setup:
 2. **Workspace Integration** - Self-service configuration through the OpenHands Cloud UI to link your OpenHands account to the target workspace
 
 ### Platform-Specific Setup Guides:
-- [Jira Cloud Integration (Coming soon...)](./jira-integration.md)
-- [Jira Data Center Integration (Coming soon...)](./jira-dc-integration.md)
-- [Linear Integration (Coming soon...)](./linear-integration.md)
+- [Jira Cloud Integration (Coming soon...)](/openhands/usage/cloud/project-management/jira-integration)
+- [Jira Data Center Integration (Coming soon...)](/openhands/usage/cloud/project-management/jira-dc-integration)
+- [Linear Integration (Coming soon...)](/openhands/usage/cloud/project-management/linear-integration)
 
 ## Usage
 


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [x] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

The three "Platform-Specific Setup Guides" links on the Project Management overview page currently 404.

They point at relative paths with a `.md` extension:

```
./jira-integration.md
./jira-dc-integration.md
./linear-integration.md
```

But the target files are `.mdx` (`jira-integration.mdx`, `jira-dc-integration.mdx`, `linear-integration.mdx`), and Mintlify serves those pages at extensionless routes — so none of the three links resolve.

These were also the only `.md`-suffixed internal page links in the repo; every other internal link is extensionless.

This PR points them at the correct absolute, extensionless routes, matching the convention in `openhands/DOC_STYLE_GUIDE.md`:

> When linking other pages in the docs, always use absolute paths.

Only the three link targets changed — no copy or page content was touched.

**Verification**

`mint broken-links` passes cleanly (`✓ success no broken links found`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)