### PR TITLE
docs: update moonshot provider docs to only include exposed models an…

### DIFF
--- a/openhands/usage/llms/moonshot.mdx
+++ b/openhands/usage/llms/moonshot.mdx
@@ -21,8 +21,7 @@ description: How to use Moonshot AI models with OpenHands
 
 ### Recommended Models
 
-- `moonshot/kimi-k3` - Moonshot's most powerful model with a 1M context window, image input support, and reasoning capabilities.
-- `moonshot/kimi-k2.7-code` - Optimized for code tasks with a 256K context window and reasoning support.
-- `moonshot/kimi-k2.7-code-highspeed` - High-speed variant of Kimi-K2.7-code with a 256K context window.
-- `moonshot/kimi-k2.6` - Capable model with a 256K context window, image/video input support, and reasoning capabilities.
+- `moonshot/kimi-k3` - Moonshot's most powerful model with a 1M context window, multimodal input support, strong reasoning, and tool calling capabilities.
+- `moonshot/kimi-k2.7-code` - Optimized for code tasks with a 256K context window.
+- `moonshot/kimi-k2.7-code-highspeed` - High-speed variant of Kimi-K2.7-code.
 

--- a/openhands/usage/llms/moonshot.mdx
+++ b/openhands/usage/llms/moonshot.mdx
@@ -5,7 +5,7 @@ description: How to use Moonshot AI models with OpenHands
 
 ## Using Moonshot AI with OpenHands
 
-[Moonshot AI](https://platform.moonshot.ai/) offers several powerful models, including Kimi-K2, which has been verified to work well with OpenHands.
+[Moonshot AI](https://platform.moonshot.ai/) offers several powerful models, including Kimi-K3, which has been verified to work well with OpenHands.
 
 ### Setup
 
@@ -16,10 +16,13 @@ description: How to use Moonshot AI models with OpenHands
 | Setting | Value |
 | --- | --- |
 | LLM Provider | `moonshot` |
-| LLM Model | `kimi-k2-0711-preview` |
+| LLM Model | `kimi-k3` |
 | API Key | Your Moonshot API key |
 
 ### Recommended Models
 
-- `moonshot/kimi-k2-0711-preview` - Kimi-K2 is Moonshot's most powerful model with a 131K context window, function calling support, and web search capabilities.
+- `moonshot/kimi-k3` - Moonshot's most powerful model with a 1M context window, image input support, and reasoning capabilities.
+- `moonshot/kimi-k2.7-code` - Optimized for code tasks with a 256K context window and reasoning support.
+- `moonshot/kimi-k2.7-code-highspeed` - High-speed variant of Kimi-K2.7-code with a 256K context window.
+- `moonshot/kimi-k2.6` - Capable model with a 256K context window, image/video input support, and reasoning capabilities.
 


### PR DESCRIPTION
…d deprecate kimi-k2-0711-preview

- [✅] I have read and reviewed the documentation changes to the best of my ability.
- [✅] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**
- Removed deprecated kimi-k2-0711-preview model
- Added currently available models by moonshot
- Changed overview line to mention kimi k3 rather than 2
- Changed example to use kimi k3 instead of deprecated model