### PR TITLE
docs(hooks): document prompt-based evaluation

### DIFF
--- a/sdk/guides/hooks.mdx
+++ b/sdk/guides/hooks.mdx
@@ -27,9 +27,9 @@ Hooks let you observe and customize key lifecycle moments in the SDK without for
 
 ## Exit Codes
 
-Command hooks (shell scripts) signal their result through their exit code —
-[agent-based hooks](#agent-based-hooks) return a JSON decision instead. The SDK
-matches the
+Command hooks (shell scripts) signal their result through their exit code.
+[Prompt-based hooks](#prompt-based-hooks) and
+[agent-based hooks](#agent-based-hooks) return a JSON decision instead. The SDK matches the
 [Claude Code hook contract](https://docs.claude.com/en/docs/claude-code/hooks):
 
 - **`0` — success.** The operation proceeds. `stdout` is parsed as JSON for
@@ -53,6 +53,20 @@ policy must exit with `2`.
 - Registration points: subscribe to events or attach pre/post hooks around LLM calls and tool execution
 - Isolation: hooks run outside the agent loop logic, avoiding core modifications
 - Composition: enable or disable hooks per environment (local vs. prod)
+
+## Execution Modes
+
+Hook definitions support three execution modes:
+
+| `type` | Evaluator | Tool access | Best for |
+|--------|-----------|-------------|----------|
+| `command` (default) | Shell command | Through the script | Deterministic checks and integrations |
+| `prompt` | One LLM completion | No | Semantic decisions based only on the hook event |
+| `agent` | Short-lived sub-agent | Optional allowlist | Decisions that require workspace investigation |
+
+Use the least powerful mode that can make the decision. Command hooks are the
+most deterministic. Prompt hooks add model judgment with one completion. Agent
+hooks add an agent loop and tools when the event payload is not enough.
 
 ## Ready-to-run Example
 
@@ -292,6 +306,149 @@ fi
 exit 0
 ```
 </Accordion>
+
+
+## Prompt-based Hooks
+
+Set `type="prompt"` to evaluate a hook event with one LLM completion. Prompt
+hooks are useful when a decision needs semantic judgment but all required
+context is already present in the `HookEvent` payload. For example, a
+`PreToolUse` policy can evaluate the intent of a terminal command without
+starting a tool-using sub-agent.
+
+```python
+HookDefinition(
+    type=HookType.PROMPT,
+    name="terminal-safety",
+    prompt="Deny terminal commands that recursively delete files ...",
+    timeout=30,
+)
+```
+
+Key fields on a prompt `HookDefinition`:
+
+- `name` — identifies the hook in logs, events, and its stable
+  `prompt-hook:<name>` metrics bucket.
+- `prompt` — the trusted policy used to evaluate each matching event.
+- `timeout` — the timeout applied to the copied hook LLM.
+
+The hook uses the conversation's current LLM, including changes made through
+model or profile switching. The executor copies that LLM so the hook has an
+isolated timeout, usage ID, and metrics. Hook spend is merged back into the
+parent conversation's metrics. The SDK selects Chat Completions or the Responses
+API from the model's capabilities. Prompt hooks are single-shot and non-streaming,
+regardless of the parent LLM's streaming setting.
+
+The policy is placed in system context. The serialized event is sent in a
+separate user message and marked as untrusted data, so instructions embedded in
+tool input or output are not treated as hook policy. The model is asked to
+return the shared hook result contract:
+
+```json
+{"decision": "allow" | "deny", "reason": "<short explanation>"}
+```
+
+If the conversation has no LLM, the provider call fails, or the response does
+not contain a valid decision, the hook falls open with `decision="allow"` and
+`success=False`. This lets consumers distinguish an execution failure from a
+deliberate allow verdict.
+
+<Warning>
+Prompt hooks cannot inspect files, run commands, or access conversation history
+beyond data included in the hook event. Use an [agent-based hook](#agent-based-hooks)
+when the evaluator must gather more context before deciding.
+</Warning>
+
+<Note>
+This example is available on GitHub: [examples/01_standalone_sdk/55_prompt_hooks](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/01_standalone_sdk/55_prompt_hooks/)
+</Note>
+
+```python icon="python" expandable examples/01_standalone_sdk/55_prompt_hooks/main.py
+"""OpenHands Agent SDK - prompt-based hooks example.
+
+Evaluates two synthetic PreToolUse events with one LLM completion each. The
+commands are only event data: this example never executes them.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+
+from pydantic import SecretStr
+
+from openhands.sdk import LLM
+from openhands.sdk.conversation.conversation_stats import ConversationStats
+from openhands.sdk.hooks import (
+    HookConfig,
+    HookDefinition,
+    HookManager,
+    HookMatcher,
+    HookType,
+)
+
+
+api_key = os.getenv("LLM_API_KEY")
+assert api_key is not None, "LLM_API_KEY environment variable is not set."
+
+llm = LLM(
+    usage_id="agent",
+    model=os.getenv("LLM_MODEL", "anthropic/claude-sonnet-4-5-20250929"),
+    base_url=os.getenv("LLM_BASE_URL"),
+    api_key=SecretStr(api_key),
+)
+
+TERMINAL_POLICY = """Evaluate the semantic intent of a terminal command.
+Deny commands that recursively delete files, read credentials or sensitive
+system files, modify the host system, or exfiltrate data. Allow read-only
+workspace inspection, builds, and test commands. When uncertain, deny and give
+a concise reason."""
+
+hook_config = HookConfig(
+    pre_tool_use=[
+        HookMatcher(
+            matcher="terminal",
+            hooks=[
+                HookDefinition(
+                    type=HookType.PROMPT,
+                    name="terminal-safety",
+                    prompt=TERMINAL_POLICY,
+                    timeout=30,
+                )
+            ],
+        )
+    ]
+)
+
+cases = [
+    ("python -m pytest -q", True),
+    ("find / -type f -delete", False),
+]
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    stats = ConversationStats()
+    manager = HookManager(
+        config=hook_config,
+        working_dir=str(Path(tmpdir)),
+        session_id="prompt-hook-example",
+        llm=llm,
+        conversation_stats=stats,
+    )
+
+    for command, expected_to_continue in cases:
+        should_continue, results = manager.run_pre_tool_use(
+            tool_name="terminal",
+            tool_input={"command": command},
+        )
+        result = results[0]
+        verdict = "ALLOW" if should_continue else "DENY"
+        print(f"{verdict:5} {command}")
+        print(f"      {result.reason}")
+        assert should_continue is expected_to_continue
+
+    cost = stats.get_combined_metrics().accumulated_cost
+    print(f"\nEXAMPLE_COST: {cost}")
+```
+<RunExampleCode path_to_script="examples/01_standalone_sdk/55_prompt_hooks/main.py"/>
 
 
 ## Agent-based Hooks

--- a/sdk/guides/hooks.mdx
+++ b/sdk/guides/hooks.mdx
@@ -360,10 +360,10 @@ when the evaluator must gather more context before deciding.
 </Warning>
 
 <Note>
-This example is available on GitHub: [examples/01_standalone_sdk/56_prompt_hooks](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/01_standalone_sdk/56_prompt_hooks/)
+This example is available on GitHub: [examples/01_standalone_sdk/57_prompt_hooks](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/01_standalone_sdk/57_prompt_hooks/)
 </Note>
 
-```python icon="python" expandable examples/01_standalone_sdk/56_prompt_hooks/main.py
+```python icon="python" expandable examples/01_standalone_sdk/57_prompt_hooks/main.py
 """OpenHands Agent SDK - prompt-based hooks example.
 
 Evaluates two synthetic PreToolUse events with one LLM completion each. The
@@ -448,7 +448,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
     cost = stats.get_combined_metrics().accumulated_cost
     print(f"\nEXAMPLE_COST: {cost}")
 ```
-<RunExampleCode path_to_script="examples/01_standalone_sdk/56_prompt_hooks/main.py"/>
+<RunExampleCode path_to_script="examples/01_standalone_sdk/57_prompt_hooks/main.py"/>
 
 
 ## Agent-based Hooks

--- a/sdk/guides/hooks.mdx
+++ b/sdk/guides/hooks.mdx
@@ -360,10 +360,10 @@ when the evaluator must gather more context before deciding.
 </Warning>
 
 <Note>
-This example is available on GitHub: [examples/01_standalone_sdk/55_prompt_hooks](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/01_standalone_sdk/55_prompt_hooks/)
+This example is available on GitHub: [examples/01_standalone_sdk/56_prompt_hooks](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/01_standalone_sdk/56_prompt_hooks/)
 </Note>
 
-```python icon="python" expandable examples/01_standalone_sdk/55_prompt_hooks/main.py
+```python icon="python" expandable examples/01_standalone_sdk/56_prompt_hooks/main.py
 """OpenHands Agent SDK - prompt-based hooks example.
 
 Evaluates two synthetic PreToolUse events with one LLM completion each. The
@@ -448,7 +448,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
     cost = stats.get_combined_metrics().accumulated_cost
     print(f"\nEXAMPLE_COST: {cost}")
 ```
-<RunExampleCode path_to_script="examples/01_standalone_sdk/55_prompt_hooks/main.py"/>
+<RunExampleCode path_to_script="examples/01_standalone_sdk/56_prompt_hooks/main.py"/>
 
 
 ## Agent-based Hooks


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [x] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

Documents the new `HookType.PROMPT` mode from OpenHands/software-agent-sdk#4160, explains when to use command, prompt, or agent hooks, and adds the runnable `56_prompt_hooks` example.

**Related implementation**

- OpenHands/software-agent-sdk#4160
- Tracks OpenHands/software-agent-sdk#2755

**Validation**

- Documentation tests: 30 passed.
- Source-synchronized code block tests against the current SDK branch: 17 passed.
- Mintlify parsed the site. Its broken-link check still reports existing repository-wide links, but no new prompt-hook link or anchor.

**AI assistance**

GitHub Copilot assisted with this update. I reviewed the documentation before marking the PR ready.