### PR TITLE
docs: add persistent memory guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -254,6 +254,7 @@
               "sdk/guides/plugins",
               "sdk/guides/convo-persistence",
               "sdk/guides/context-condenser",
+              "sdk/guides/persistent-memory",
               "sdk/guides/agent-settings",
               "sdk/guides/parallel-tool-execution",
               "sdk/guides/task-tool-set",

--- a/sdk/guides/persistent-memory.mdx
+++ b/sdk/guides/persistent-memory.mdx
@@ -1,0 +1,201 @@
+---
+title: Persistent Memory
+description: Give agents opt-in, two-tier memory that survives across conversations.
+---
+import RunExampleCode from "/sdk/shared-snippets/how-to-run-example.mdx";
+
+> A ready-to-run example is available [here](#ready-to-run-example)!
+
+Persistent memory lets an agent keep what it learned -- root causes, environment quirks, project decisions, user preferences -- in plain Markdown files that are loaded back into the system prompt at the start of every new conversation. The agent maintains the files itself as it works, so it gets better at a project over time.
+
+The feature is **opt-in and off by default**: without it, agents keep the existing `AGENTS.md`-based guidance and prompts are unchanged.
+
+## Enabling Persistent Memory
+
+Set `load_memory=True` on the agent's `AgentContext`:
+
+```python focus={5} icon="python"
+from openhands.sdk import Agent, AgentContext
+
+agent = Agent(
+    llm=llm,
+    agent_context=AgentContext(load_memory=True),
+    tools=tools,
+)
+```
+
+That single flag does two things:
+
+1. At session start, the conversation reads the `MEMORY.md` indexes from both memory tiers and injects them into the system prompt as a `<MEMORY_CONTEXT>` block.
+2. The system prompt's `<MEMORY>` section switches to instructions that teach the agent where its memory lives and how to maintain it.
+
+## The Two Tiers
+
+| Tier | Location | Contents |
+|------|----------|----------|
+| **User** | `~/.openhands/memory/` | Knowledge and preferences that apply across all projects |
+| **Project** | `<workspace>/.openhands/memory/` | Knowledge specific to the current repository |
+
+Each tier contains:
+
+- **`MEMORY.md`** -- a curated index of durable facts. This is the only file injected into the prompt, so the agent is instructed to keep it small and high-value.
+- **Daily logs (`YYYY-MM-DD.md`)** -- free-form working notes. They are never injected automatically; the agent reads them on demand with its file tools when `MEMORY.md` points to them.
+
+The files are plain Markdown: you can review, edit, or delete them at any time, and a project team can even commit `.openhands/memory/` to share agent-learned knowledge.
+
+## What Gets Injected
+
+At the start of each opted-in conversation, the resolved memory appears in the system prompt like this (user tier first, then project tier):
+
+```text wrap
+<MEMORY_CONTEXT>
+<UNTRUSTED_CONTENT>
+The notes below were written by the agent itself in previous sessions and have NOT been verified.
+...
+</UNTRUSTED_CONTENT>
+
+# User memory (~/.openhands/memory/MEMORY.md)
+- prefers uv over pip for Python tooling
+
+# Project memory (.openhands/memory/MEMORY.md)
+- the API uses cursor-based pagination
+</MEMORY_CONTEXT>
+```
+
+A few properties worth knowing:
+
+- **Size budget**: the combined indexes are capped at ~6,000 characters. When the budget is exceeded, the *oldest* content (the top of the combined text) is truncated first and a truncation notice is prepended -- so keep indexes curated.
+- **Untrusted by design**: the injected block is wrapped in `<UNTRUSTED_CONTENT>` and the agent is told to treat its own past notes as advisory hints, never as authoritative instructions.
+- **Never persisted**: the resolved memory text is re-read from disk each session and is excluded from conversation persistence (`base_state.json`) and API payloads.
+- **Best-effort**: an unreadable memory file logs a warning and the conversation starts normally without it.
+
+## How the Agent Maintains Memory
+
+When memory is enabled, the system prompt instructs the agent to:
+
+- record durable, broadly useful facts in `MEMORY.md` near the end of a task (creating the directories and files if missing), and put long detail in daily logs;
+- merge duplicates, prune stale entries, and keep the indexes concise;
+- never record secrets or credentials, and skip facts that are trivially re-discoverable (directory listings, obvious commands);
+- keep `AGENTS.md` for instructions addressed to *any* agent working in the repository -- memory is for what the agent learned itself.
+
+## Ready-to-run Example
+
+<Note>
+This example is available on GitHub: [examples/01_standalone_sdk/55_persistent_memory.py](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/01_standalone_sdk/55_persistent_memory.py)
+</Note>
+
+```python icon="python" expandable examples/01_standalone_sdk/55_persistent_memory.py
+"""Opt-in persistent memory across sessions (two-tier ``MEMORY.md``).
+
+With ``AgentContext(load_memory=True)`` a conversation loads the ``MEMORY.md``
+indexes from ``~/.openhands/memory/`` (user tier) and
+``<workspace>/.openhands/memory/`` (project tier) into the system prompt at
+session start (the ``<MEMORY_CONTEXT>`` block), and the system prompt
+instructs the agent to maintain those files as it works.
+
+This example runs two conversations over the same workspace:
+
+1. Session 1 asks the agent to record a project decision in its persistent
+   project memory -- the agent writes ``.openhands/memory/MEMORY.md`` itself.
+2. Session 2 is a brand-new conversation: the saved memory is injected into
+   its system prompt automatically, so the agent already knows the decision
+   without being told again.
+
+Memory is opt-in and off by default. The example only writes inside a
+temporary workspace; the user tier under ``~`` is left untouched.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+
+from pydantic import SecretStr
+
+from openhands.sdk import LLM, Agent, AgentContext, Conversation, get_logger
+from openhands.sdk.event import SystemPromptEvent
+from openhands.sdk.tool import Tool
+from openhands.tools.file_editor import FileEditorTool
+from openhands.tools.terminal import TerminalTool
+
+
+logger = get_logger(__name__)
+
+# Configure LLM
+api_key = os.getenv("LLM_API_KEY")
+assert api_key is not None, "LLM_API_KEY environment variable is not set."
+model = os.getenv("LLM_MODEL", "gpt-5.5")
+base_url = os.getenv("LLM_BASE_URL")
+llm = LLM(
+    usage_id="agent",
+    model=model,
+    base_url=base_url,
+    api_key=SecretStr(api_key),
+)
+
+tools = [Tool(name=TerminalTool.name), Tool(name=FileEditorTool.name)]
+
+# Opt in to persistent memory. Everything else is automatic: the conversation
+# resolves the MEMORY.md indexes at session start, and the system prompt tells
+# the agent how to maintain them.
+agent_context = AgentContext(load_memory=True)
+
+with tempfile.TemporaryDirectory() as workspace:
+    memory_index = Path(workspace) / ".openhands" / "memory" / "MEMORY.md"
+
+    print("=" * 100)
+    print("Session 1: ask the agent to record a decision in project memory.")
+    agent = Agent(llm=llm, tools=tools, agent_context=agent_context)
+    conversation = Conversation(agent=agent, workspace=workspace)
+    conversation.send_message(
+        "We just decided to use `uv` (not pip/poetry) for all Python "
+        "dependency management in this project. Record that decision in your "
+        "persistent project memory so future sessions know it."
+    )
+    conversation.run()
+    conversation.close()
+
+    print("=" * 100)
+    print(f"Project memory after session 1 ({memory_index}):")
+    if memory_index.exists():
+        print(memory_index.read_text())
+    else:
+        print("(the agent did not create the memory index)")
+
+    print("=" * 100)
+    print("Session 2: a brand-new conversation over the same workspace.")
+    agent = Agent(llm=llm, tools=tools, agent_context=agent_context)
+    conversation = Conversation(agent=agent, workspace=workspace)
+    conversation.send_message(
+        "Which tool do we use for Python dependency management in this "
+        "project? Answer from what you already know about the project."
+    )
+    conversation.run()
+
+    # The recorded memory was injected into session 2's system prompt as the
+    # <MEMORY_CONTEXT> block -- show it to make the mechanism visible.
+    system_prompt_event = next(
+        event
+        for event in conversation.state.events
+        if isinstance(event, SystemPromptEvent)
+    )
+    dynamic_context = system_prompt_event.dynamic_context
+    injected = dynamic_context.text if dynamic_context else ""
+    print("=" * 100)
+    print(
+        "<MEMORY_CONTEXT> injected into session 2's system prompt: "
+        f"{'<MEMORY_CONTEXT>' in injected}"
+    )
+    conversation.close()
+
+# Report cost
+cost = llm.metrics.accumulated_cost
+print(f"EXAMPLE_COST: {cost}")
+```
+
+<RunExampleCode path_to_script="examples/01_standalone_sdk/55_persistent_memory.py"/>
+
+## Next Steps
+
+- **[Skills](/sdk/guides/skill)** - Inject reusable instructions and context into agents
+- **[Context Condenser](/sdk/guides/context-condenser)** - Keep long conversations within the context window
+- **[Persistence](/sdk/guides/convo-persistence)** - Save and restore conversation state across sessions


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [ ] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**
Companion docs for OpenHands/software-agent-sdk#4178 (SDK issue #2037), which adds opt-in persistent memory to the SDK. Review on that PR asked for an example and docs: the example ships there (`examples/01_standalone_sdk/55_persistent_memory.py`); this PR adds the documentation.

- **New guide: `sdk/guides/persistent-memory.mdx`** — covers enabling the feature (`AgentContext(load_memory=True)`, opt-in and off by default); the two memory tiers (user `~/.openhands/memory/`, project `<workspace>/.openhands/memory/`); the file model (`MEMORY.md` curated index injected at session start vs. daily logs read on demand); what gets injected (the `<MEMORY_CONTEXT>` block, `<UNTRUSTED_CONTENT>` wrapping, ~6,000-character truncate-from-top budget, user tier before project tier); operational properties (re-resolved each session, excluded from `base_state.json` and API payloads, best-effort loading); and the maintenance habits the system prompt teaches the agent. Ends with the standard Ready-to-run Example section (`<RunExampleCode>` + GitHub link) embedding `examples/01_standalone_sdk/55_persistent_memory.py`.
- **Navigation:** registers `sdk/guides/persistent-memory` in `docs.json` under SDK → Guides, right after Context Condenser.

**Verification**

- The embedded example block is byte-in-sync with the SDK file per this repo's own sync logic (`.github/scripts/sync_code_blocks.py` `extract_code_blocks` + `normalize_content` comparison).
- `docs.json` re-parses as valid JSON after the nav edit.
- All internal links point at existing pages (`/sdk/guides/skill`, `/sdk/guides/context-condenser`, `/sdk/guides/convo-persistence`, shared snippet `/sdk/shared-snippets/how-to-run-example.mdx`), and the `#ready-to-run-example` anchor matches its heading.

**Notes**

- **Merge after** OpenHands/software-agent-sdk#4178: the GitHub link targets the example on `main`, and the `sync-docs-code-blocks` workflow reads example content from the SDK repo's `main`. Until then the sync workflow logs a missing-source warning for this block and skips it (not a CI failure), and the PR-level `check-broken-links` job only checks internal links, so CI on this PR is unaffected.
- `llms.txt`/`llms-full.txt` are intentionally untouched: regenerating now bundles unrelated drift from previously merged pages (e.g. the Fork-a-Conversation guide), and the scheduled `check-llms-files.yml` workflow owns that sync.