### PR TITLE
Move Local GUI and CLI to Deprecated Projects section

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -127,6 +127,41 @@
                 ]
               },
               {
+                "group": "LLM Configuration",
+                "pages": [
+                  "openhands/usage/llms/llms",
+                  {
+                    "group": "LLM Providers",
+                    "pages": [
+                      "openhands/usage/llms/openhands-llms",
+                      "openhands/usage/llms/aws-bedrock",
+                      "openhands/usage/llms/azure-llms",
+                      "openhands/usage/llms/google-llms",
+                      "openhands/usage/llms/groq",
+                      "openhands/usage/llms/local-llms",
+                      "openhands/usage/llms/litellm-proxy",
+                      "openhands/usage/llms/moonshot",
+                      "openhands/usage/llms/openai-llms",
+                      "openhands/usage/llms/openrouter"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Developers",
+                "pages": [
+                  "openhands/usage/developers/development-overview",
+                  "openhands/usage/developers/debugging",
+                  "openhands/usage/developers/websocket-connection",
+                  "openhands/usage/developers/evaluation-harness"
+                ]
+              }
+            ]
+          },
+          {
+            "group": "Deprecated Projects",
+            "pages": [
+              {
                 "group": "Local GUI",
                 "pages": [
                   "openhands/usage/run-openhands/local-setup",
@@ -157,33 +192,54 @@
                 ]
               },
               {
-                "group": "LLM Configuration",
+                "group": "CLI",
                 "pages": [
-                  "openhands/usage/llms/llms",
                   {
-                    "group": "LLM Providers",
+                    "group": "Getting Started",
                     "pages": [
-                      "openhands/usage/llms/openhands-llms",
-                      "openhands/usage/llms/aws-bedrock",
-                      "openhands/usage/llms/azure-llms",
-                      "openhands/usage/llms/google-llms",
-                      "openhands/usage/llms/groq",
-                      "openhands/usage/llms/local-llms",
-                      "openhands/usage/llms/litellm-proxy",
-                      "openhands/usage/llms/moonshot",
-                      "openhands/usage/llms/openai-llms",
-                      "openhands/usage/llms/openrouter"
+                      "openhands/usage/cli/installation",
+                      "openhands/usage/cli/quick-start"
+                    ]
+                  },
+                  {
+                    "group": "Ways to Run",
+                    "pages": [
+                      "openhands/usage/cli/terminal",
+                      "openhands/usage/cli/headless",
+                      "openhands/usage/cli/web-interface",
+                      "openhands/usage/cli/gui-server",
+                      {
+                        "group": "IDE Integration (ACP)",
+                        "pages": [
+                          "openhands/usage/cli/ide/overview",
+                          "openhands/usage/cli/ide/zed",
+                          "openhands/usage/cli/ide/toad",
+                          "openhands/usage/cli/ide/vscode",
+                          "openhands/usage/cli/ide/jetbrains"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Cloud",
+                    "pages": [
+                      "openhands/usage/cli/cloud"
+                    ]
+                  },
+                  {
+                    "group": "Extensions",
+                    "pages": [
+                      "openhands/usage/cli/mcp-servers",
+                      "openhands/usage/cli/critic"
+                    ]
+                  },
+                  {
+                    "group": "Reference",
+                    "pages": [
+                      "openhands/usage/cli/command-reference",
+                      "openhands/usage/cli/resume"
                     ]
                   }
-                ]
-              },
-              {
-                "group": "Developers",
-                "pages": [
-                  "openhands/usage/developers/development-overview",
-                  "openhands/usage/developers/debugging",
-                  "openhands/usage/developers/websocket-connection",
-                  "openhands/usage/developers/evaluation-harness"
                 ]
               }
             ]
@@ -367,57 +423,6 @@
               "sdk/api-reference/openhands.sdk.tool",
               "sdk/api-reference/openhands.sdk.utils",
               "sdk/api-reference/openhands.sdk.workspace"
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "CLI",
-        "pages": [
-          {
-            "group": "Getting Started",
-            "pages": [
-              "openhands/usage/cli/installation",
-              "openhands/usage/cli/quick-start"
-            ]
-          },
-          {
-            "group": "Ways to Run",
-            "pages": [
-              "openhands/usage/cli/terminal",
-              "openhands/usage/cli/headless",
-              "openhands/usage/cli/web-interface",
-              "openhands/usage/cli/gui-server",
-              {
-                "group": "IDE Integration (ACP)",
-                "pages": [
-                  "openhands/usage/cli/ide/overview",
-                  "openhands/usage/cli/ide/zed",
-                  "openhands/usage/cli/ide/toad",
-                  "openhands/usage/cli/ide/vscode",
-                  "openhands/usage/cli/ide/jetbrains"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Cloud",
-            "pages": [
-              "openhands/usage/cli/cloud"
-            ]
-          },
-          {
-            "group": "Extensions",
-            "pages": [
-              "openhands/usage/cli/mcp-servers",
-              "openhands/usage/cli/critic"
-            ]
-          },
-          {
-            "group": "Reference",
-            "pages": [
-              "openhands/usage/cli/command-reference",
-              "openhands/usage/cli/resume"
             ]
           }
         ]


### PR DESCRIPTION
## Summary

This PR reorganizes the documentation navigation by moving deprecated project sections into a new "Deprecated Projects" group under the Home tab.

### Changes

1. **Moved "Local GUI"** from `Home > Additional Documentation` to `Home > Deprecated Projects > Local GUI`
   - Includes: local-setup, gui-mode, troubleshooting, Sandbox Configuration, Advanced

2. **Moved "CLI" tab** content to `Home > Deprecated Projects > CLI`
   - All CLI pages are now accessible under a new "CLI" sub-group within Deprecated Projects
   - The standalone CLI tab has been removed

3. **New "Deprecated Projects" group** added to Home tab, positioned between "Additional Documentation" and "OpenHands Community"

### Motivation

As these projects (Local GUI and CLI) are deprecated, grouping them under a dedicated "Deprecated Projects" section helps users understand their status and reduces confusion about which interface to use.

---

*This PR was created by an AI agent on behalf of the user.*

@jpelletier1 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c97e5838-8d3b-4fa2-b8e6-673ec2366aca)