### PR TITLE
docs(security): sync confirmation preview with action summary

### DIFF
--- a/sdk/guides/security.mdx
+++ b/sdk/guides/security.mdx
@@ -91,7 +91,14 @@ def _print_action_preview(pending_actions) -> None:
     print(f"\n🔍 Agent created {len(pending_actions)} action(s) awaiting confirmation:")
     for i, action in enumerate(pending_actions, start=1):
         snippet = str(action.action)[:100].replace("\n", " ")
-        print(f"  {i}. {action.tool_name}: {snippet}...")
+        # Lead with the LLM's natural-language summary when available, keeping
+        # the raw action snippet as secondary detail. When no summary was
+        # provided, the raw action itself is the most useful headline.
+        if action.summary:
+            print(f"  {i}. [{action.tool_name}] {action.summary}")
+            print(f"     {snippet}...")
+        else:
+            print(f"  {i}. [{action.tool_name}] {snippet}...")
 
 
 def confirm_in_console(pending_actions) -> bool:
@@ -299,7 +306,14 @@ def _print_blocked_actions(pending_actions) -> None:
     print(f"\n🔒 Security analyzer blocked {len(pending_actions)} high-risk action(s):")
     for i, action in enumerate(pending_actions, start=1):
         snippet = str(action.action)[:100].replace("\n", " ")
-        print(f"  {i}. {action.tool_name}: {snippet}...")
+        # Lead with the LLM's natural-language summary when available, keeping
+        # the raw action snippet as secondary detail. When no summary was
+        # provided, the raw action itself is the most useful headline.
+        if action.summary:
+            print(f"  {i}. [{action.tool_name}] {action.summary}")
+            print(f"     {snippet}...")
+        else:
+            print(f"  {i}. [{action.tool_name}] {snippet}...")
 
 
 def confirm_high_risk_in_console(pending_actions) -> bool:


### PR DESCRIPTION
## Why

Keeps `sdk/guides/security.mdx` in sync with OpenHands/software-agent-sdk#4211, which changes the confirmation-mode / security-analyzer previews in `examples/01_standalone_sdk/04_confirmation_mode_example.py` and `16_llm_security_analyzer.py`.

Both files are embedded in this guide via the `expandable examples/...py` code-block sync, so their rendered source drifts once #4211 merges.

## What

- `_print_action_preview` and `_print_blocked_actions` now lead with the LLM's natural-language `action.summary` when present, keeping the raw action snippet as secondary detail.
- When `summary` is `None`, the preview leads with the raw action itself instead of a `(no summary provided)` placeholder.

## Notes

- Scoped intentionally to **only** the two changed blocks. The full `sync_code_blocks.py` run surfaces unrelated pre-existing drift across ~47 guides (e.g. `LLM_MODEL` defaults, security-policy wording); that belongs to the daily auto-sync job, not this PR.
- Should merge alongside OpenHands/software-agent-sdk#4211. Until then the `check-examples` gate on the SDK PR still passes (both examples remain referenced here).