### PR TITLE
Add Enterprise 0.28.0 release notes

### DIFF
--- a/.agents/skills/ohe-release-notes.md
+++ b/.agents/skills/ohe-release-notes.md
@@ -136,9 +136,10 @@ Create or update `enterprise/release-notes.mdx`. Prepend the new release at the 
 
 **Always write a short summary paragraph immediately under the `## X.Y.Z` heading**, before the
 first `### Component` section. Read all of the changelog entries for the release and summarize what
-the release encompasses. Only call out things worth highlighting like notable features. If the
-release contains only bug fixes and maintenance, keep it brief — for example: "This release was
-focused on stability and maintenance fixes." Keep the summary to 1-2 short paragraphs.
+the release encompasses. Keep it high-level and short (usually a single paragraph) — only call out
+things genuinely worth highlighting like notable features, and don't enumerate individual fixes or
+config flags. If the release contains only bug fixes and maintenance, just say something like
+"This release was focused on stability and maintenance fixes."
 
 **Page structure:**
 

--- a/.agents/skills/ohe-release-notes.md
+++ b/.agents/skills/ohe-release-notes.md
@@ -134,6 +134,12 @@ Remove these automated/housekeeping lines that don't add value to customer-facin
 Create or update `enterprise/release-notes.mdx`. Prepend the new release at the top of the file
 (after the frontmatter), so the most recent release appears first.
 
+**Always write a short summary paragraph immediately under the `## X.Y.Z` heading**, before the
+first `### Component` section. Read all of the changelog entries for the release and summarize what
+the release encompasses. Only call out things worth highlighting like notable features. If the
+release contains only bug fixes and maintenance, keep it brief — for example: "This release was
+focused on stability and maintenance fixes." Keep the summary to 1-2 short paragraphs.
+
 **Page structure:**
 
 ```mdx
@@ -144,6 +150,9 @@ icon: clipboard-list
 ---
 
 ## X.Y.Z
+
+<One or two short paragraphs summarizing what the release encompasses. Call out notable features;
+if it's only bug fixes, say something like "This release was focused on stability and maintenance fixes.">
 
 ### Enterprise Server
 
@@ -188,6 +197,7 @@ icon: clipboard-list
 ```
 
 **Key formatting rules:**
+- Start each release with a short summary paragraph under the `## X.Y.Z` heading (see above)
 - Split by component section — each component gets its own `### Heading`
 - Within each component, group by `#### Features`, `#### Bug Fixes`, `#### Maintenance`
 - Separate component sections with `---` horizontal rules

--- a/enterprise/release-notes.mdx
+++ b/enterprise/release-notes.mdx
@@ -6,7 +6,9 @@ icon: clipboard-list
 
 ## 0.28.0
 
-This release adds the embedded **Agent Canvas** (mounted under `/canvas`) and brings better Helm chart validation and more configuration options to make installs easier to configure and validate. The rest of the release is focused on stability and maintenance fixes.
+This release adds the embedded **Agent Canvas** (mounted under `{your-openhands-instance.example.com}/canvas`), which will coexist with the current OpenHands Enterprise conversation interface for the time being. A future release will announce the deprecation date for the existing interface, after which Agent Canvas will become the default UI; in the meantime, teams can begin experimenting with the new Agent Canvas experience and share feedback with the OpenHands product teams.
+
+Additionally, this release brings better Helm chart validation and more configuration options to make installs easier to configure and validate. The rest of the release is focused on stability and maintenance fixes.
 
 ### Enterprise Server
 

--- a/enterprise/release-notes.mdx
+++ b/enterprise/release-notes.mdx
@@ -8,25 +8,17 @@ icon: clipboard-list
 
 ### Enterprise Server
 
-#### Features
-* feat: protect Agent Canvas behind SaaS auth by @malhotra5 in https://github.com/OpenHands/OpenHands/pull/15286
-
 #### Bug Fixes
 * fix: retry idempotent runtime-api reads once on timeout by @ak684 in https://github.com/OpenHands/OpenHands/pull/15266
 * fix(agent-profiles): honor profile settings in cloud launches by @simonrosenberg in https://github.com/OpenHands/OpenHands/pull/15228
 * fix: Fix CVE-2026-53571: Update vite to 8.0.16, 7.3.5, 6.4.3 by @mamoodi in https://github.com/OpenHands/OpenHands/pull/14982
 * fix: restore automations login redirects by @malhotra5 in https://github.com/OpenHands/OpenHands/pull/15295
-* fix(enterprise): PLTF-3259 recognize openhands.dev in staging/feature + managed-domain detection by @aivong-openhands in https://github.com/OpenHands/OpenHands/pull/15304
 * fix: Avoid logout on transient provider get_user errors by @malhotra5 in https://github.com/OpenHands/OpenHands/pull/15305
 * fix: treat Integrations Hub as a cross-app route by @malhotra5 in https://github.com/OpenHands/OpenHands/pull/15324
 * fix: add managed LLM key refresh endpoint by @neubig in https://github.com/OpenHands/OpenHands/pull/15023
 * fix(app-server): restore previous DB pool_size default by @dylan-openhands in https://github.com/OpenHands/OpenHands/pull/15333
 * fix: Debounce last_used_at writes in ApiKeyStore.validate_api_key by @tofarr in https://github.com/OpenHands/OpenHands/pull/15331
 * fix(jira): allow conversations without repositories by @tofarr in https://github.com/OpenHands/OpenHands/pull/15328
-
-#### Maintenance
-* refactor: Expand better-error-logging patterns across the codebase by @tofarr in https://github.com/OpenHands/OpenHands/pull/15241
-* revert(agent-profiles): restore default tools in cloud launches by @jlav in https://github.com/OpenHands/OpenHands/pull/15339
 
 ---
 
@@ -39,7 +31,6 @@ icon: clipboard-list
 
 #### Maintenance
 * perf(cleanup): batch PVC snapshot waits instead of blocking serially by @jlav in https://github.com/OpenHands/runtime-api/pull/648
-* chore: patch paused runtimes off bad agent-server versions [PLTF-3245] by @dylan-openhands in https://github.com/OpenHands/runtime-api/pull/649
 * build(deps): bump python-multipart from 0.0.27 to 0.0.31 by @dependabot[bot] in https://github.com/OpenHands/runtime-api/pull/652
 * build(deps): bump cryptography from 46.0.7 to 48.0.1 by @dependabot[bot] in https://github.com/OpenHands/runtime-api/pull/651
 
@@ -62,7 +53,6 @@ icon: clipboard-list
 
 #### Maintenance
 * chore(postgres): remove obsolete emptyDir-to-PVC migration by @jlav in https://github.com/OpenHands/OpenHands-Cloud/pull/919
-* revert: "feat(openhands): PLTF-3258 fail render when postgresql disabled without an external database (#928)" by @tofarr in https://github.com/OpenHands/OpenHands-Cloud/pull/938
 
 ## 0.24.0
 

--- a/enterprise/release-notes.mdx
+++ b/enterprise/release-notes.mdx
@@ -6,6 +6,10 @@ icon: clipboard-list
 
 ## 0.28.0
 
+This release focuses on deployment flexibility and platform stability. On the Helm chart side, the embedded **Agent Canvas** is now mounted under `/canvas` and the **Integrations Hub** is routed on the primary OpenHands host, while new chart values validation (`values.schema.json`), post-install `NOTES.txt` output, an ingress fail-guard, a configurable `RUNTIME_API_BASE_URL`, and a configurable sandbox ephemeral-storage field make installs easier to configure and validate.
+
+The remainder of the release is centered on stability and maintenance: Enterprise Server hardens database connection pooling, authentication/login redirects, and managed LLM key handling (including a fix for CVE-2026-53571), and the Runtime API improves connection recycling and cleanup-job memory usage.
+
 ### Enterprise Server
 
 #### Bug Fixes

--- a/enterprise/release-notes.mdx
+++ b/enterprise/release-notes.mdx
@@ -4,6 +4,66 @@ description: Release notes for OpenHands Enterprise
 icon: clipboard-list
 ---
 
+## 0.28.0
+
+### Enterprise Server
+
+#### Features
+* feat: protect Agent Canvas behind SaaS auth by @malhotra5 in https://github.com/OpenHands/OpenHands/pull/15286
+
+#### Bug Fixes
+* fix: retry idempotent runtime-api reads once on timeout by @ak684 in https://github.com/OpenHands/OpenHands/pull/15266
+* fix(agent-profiles): honor profile settings in cloud launches by @simonrosenberg in https://github.com/OpenHands/OpenHands/pull/15228
+* fix: Fix CVE-2026-53571: Update vite to 8.0.16, 7.3.5, 6.4.3 by @mamoodi in https://github.com/OpenHands/OpenHands/pull/14982
+* fix: restore automations login redirects by @malhotra5 in https://github.com/OpenHands/OpenHands/pull/15295
+* fix(enterprise): PLTF-3259 recognize openhands.dev in staging/feature + managed-domain detection by @aivong-openhands in https://github.com/OpenHands/OpenHands/pull/15304
+* fix: Avoid logout on transient provider get_user errors by @malhotra5 in https://github.com/OpenHands/OpenHands/pull/15305
+* fix: treat Integrations Hub as a cross-app route by @malhotra5 in https://github.com/OpenHands/OpenHands/pull/15324
+* fix: add managed LLM key refresh endpoint by @neubig in https://github.com/OpenHands/OpenHands/pull/15023
+* fix(app-server): restore previous DB pool_size default by @dylan-openhands in https://github.com/OpenHands/OpenHands/pull/15333
+* fix: Debounce last_used_at writes in ApiKeyStore.validate_api_key by @tofarr in https://github.com/OpenHands/OpenHands/pull/15331
+* fix(jira): allow conversations without repositories by @tofarr in https://github.com/OpenHands/OpenHands/pull/15328
+
+#### Maintenance
+* refactor: Expand better-error-logging patterns across the codebase by @tofarr in https://github.com/OpenHands/OpenHands/pull/15241
+* revert(agent-profiles): restore default tools in cloud launches by @jlav in https://github.com/OpenHands/OpenHands/pull/15339
+
+---
+
+### Runtime API
+
+#### Bug Fixes
+* fix: recycle pooled DB connections and bound pg8000 socket reads by @ak684 in https://github.com/OpenHands/runtime-api/pull/640
+* fix(cleanup): paginate deployment listing to stop OOM in cleanup job by @rbren in https://github.com/OpenHands/runtime-api/pull/642
+* fix(cleanup): hold archive concurrency slot until worker finishes (#643) by @aivong-openhands in https://github.com/OpenHands/runtime-api/pull/644
+
+#### Maintenance
+* perf(cleanup): batch PVC snapshot waits instead of blocking serially by @jlav in https://github.com/OpenHands/runtime-api/pull/648
+* chore: patch paused runtimes off bad agent-server versions [PLTF-3245] by @dylan-openhands in https://github.com/OpenHands/runtime-api/pull/649
+* build(deps): bump python-multipart from 0.0.27 to 0.0.31 by @dependabot[bot] in https://github.com/OpenHands/runtime-api/pull/652
+* build(deps): bump cryptography from 46.0.7 to 48.0.1 by @dependabot[bot] in https://github.com/OpenHands/runtime-api/pull/651
+
+---
+
+### OpenHands Cloud (Helm Chart)
+
+#### Features
+* feat(openhands): PLTF-3256 add values.schema.json for chart values validation by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/920
+* feat(openhands): PLTF-3257 add NOTES.txt post-install output to the openhands chart by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/922
+* feat: mount Agent Canvas under /canvas by @malhotra5 in https://github.com/OpenHands/OpenHands-Cloud/pull/900
+* feat: Added environment variable for RUNTIME_API_BASE_URL by @tofarr in https://github.com/OpenHands/OpenHands-Cloud/pull/926
+* feat(openhands): PLTF-3258 add fail guard for ingress.enabled without ingress.host by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/923
+* feat: route Integrations Hub on the primary OpenHands host by @neubig in https://github.com/OpenHands/OpenHands-Cloud/pull/899
+* feat: expose sandbox ephemeral-storage as a configurable field by @ak684 in https://github.com/OpenHands/OpenHands-Cloud/pull/930
+
+#### Bug Fixes
+* fix(release): make lint pass --app [PLTF-3195] by @dylan-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/898
+* fix: preserve Integrations Hub API auth responses by @neubig in https://github.com/OpenHands/OpenHands-Cloud/pull/933
+
+#### Maintenance
+* chore(postgres): remove obsolete emptyDir-to-PVC migration by @jlav in https://github.com/OpenHands/OpenHands-Cloud/pull/919
+* revert: "feat(openhands): PLTF-3258 fail render when postgresql disabled without an external database (#928)" by @tofarr in https://github.com/OpenHands/OpenHands-Cloud/pull/938
+
 ## 0.24.0
 
 This release introduces a **Usage & Monitoring** dashboard, giving organization administrators visibility into AI spend and adoption across the organization. This dashboard provides high-level reports showing conversation counts, active sessions, and cost-per-conversation metrics, along with detailed conversation, user, and model-level breakdowns to help teams measure efficiency and ROI.

--- a/enterprise/release-notes.mdx
+++ b/enterprise/release-notes.mdx
@@ -6,9 +6,7 @@ icon: clipboard-list
 
 ## 0.28.0
 
-This release focuses on deployment flexibility and platform stability. On the Helm chart side, the embedded **Agent Canvas** is now mounted under `/canvas` and the **Integrations Hub** is routed on the primary OpenHands host, while new chart values validation (`values.schema.json`), post-install `NOTES.txt` output, an ingress fail-guard, a configurable `RUNTIME_API_BASE_URL`, and a configurable sandbox ephemeral-storage field make installs easier to configure and validate.
-
-The remainder of the release is centered on stability and maintenance: Enterprise Server hardens database connection pooling, authentication/login redirects, and managed LLM key handling (including a fix for CVE-2026-53571), and the Runtime API improves connection recycling and cleanup-job memory usage.
+This release adds the embedded **Agent Canvas** (mounted under `/canvas`) and brings better Helm chart validation and more configuration options to make installs easier to configure and validate. The rest of the release is focused on stability and maintenance fixes.
 
 ### Enterprise Server
 


### PR DESCRIPTION
Add consolidated release notes for OpenHands Enterprise 0.28.0.

## Component versions

| Component | Version range |
|-----------|--------------|
| Enterprise Server | cloud-1.46.2 → cloud-1.47.1 |
| Runtime API | v0.5.0 → v0.5.2 |
| OpenHands Cloud (Helm) | openhands/0.24.0 → openhands/0.28.0 |
| Software Agent SDK | No changes (1.36.0) |
| Automations | No changes (1.1.5) |

## Highlights

- **Enterprise Server**: 10 bug fixes including a CVE patch (CVE-2026-53571), Jira/Integrations Hub improvements, DB pool tuning, and auth resilience fixes.
- **Runtime API**: 3 bug fixes for DB connection recycling, cleanup OOM, and archive concurrency; plus dependency bumps and performance improvements.
- **OpenHands Cloud (Helm Chart)**: 7 features including chart values validation schema, Agent Canvas mount, Integrations Hub routing, and sandbox ephemeral-storage configuration; 2 bug fixes.

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@mamoodi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/69b8a223-9719-4df4-bca7-577692711927)