### PR TITLE
Document Enterprise conversations and sandboxes

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -485,6 +485,7 @@
               "enterprise/index",
               "enterprise/enterprise-vs-oss",
               "enterprise/quick-start",
+              "enterprise/conversations-and-sandboxes",
               "enterprise/custom-sandbox-image",
               "enterprise/docker-in-sandbox",
               "enterprise/analytics",

--- a/enterprise/conversations-and-sandboxes.mdx
+++ b/enterprise/conversations-and-sandboxes.mdx
@@ -1,0 +1,210 @@
+---
+title: Conversations And Sandboxes
+description: Understand and manage conversation execution, sandbox placement, sharing, and lifecycle in OpenHands Enterprise.
+icon: boxes-stacked
+---
+
+OpenHands Enterprise separates the user's coding session from the environment
+where the coding agent runs:
+
+- A **conversation** is the session shown in the OpenHands application. It has
+  its own messages, events, agent state, repository selection, and usage
+  metrics.
+- A **sandbox** is the execution environment. It provides the filesystem,
+  processes, credentials, tools, and compute used by one or more conversations.
+- An **Agent Server** runs inside the sandbox and executes the OpenHands coding
+  agent for each conversation attached to that sandbox.
+
+The Enterprise V1 API manages conversations and sandboxes at the application
+level. Most customer integrations should begin with this API.
+
+## How The Components Relate
+
+```mermaid
+flowchart LR
+    API["Enterprise V1 API"]
+    subgraph Sandbox["Sandbox"]
+        Conversation1["Conversation A"]
+        Conversation2["Conversation B"]
+        Shared["Shared filesystem, tools, credentials, and compute"]
+        Conversation1 --> Shared
+        Conversation2 --> Shared
+    end
+
+    API --> Conversation1
+    API --> Conversation2
+```
+
+The Enterprise V1 API creates and manages the user-visible conversations. A
+sandbox can contain one conversation or several, depending on placement.
+
+Two conversations in the same sandbox keep separate conversation histories,
+but they share the sandbox's filesystem, credentials, compute limits, and
+failure domain.
+
+## Choose The Sandbox Boundary
+
+Use separate sandboxes when conversations cross a security, trust, repository,
+or failure boundary. Use a shared sandbox when the conversations are trusted
+to share the same environment and reducing startup time or sandbox count is
+more important than isolation.
+
+| Placement | Appropriate When | Tradeoff |
+| --- | --- | --- |
+| One sandbox per conversation | Work requires isolation or independent cleanup | Uses the most sandbox capacity |
+| Several conversations per sandbox | Trusted work can share files, credentials, and compute | A failure or resource problem can affect every attached conversation |
+| Explicitly selected sandbox | An application prepares an environment or maintains a small warm pool | The application must coordinate placement and cleanup |
+
+<Warning>
+  A separate conversation is not a security boundary when it shares a
+  sandbox with another conversation.
+</Warning>
+
+## Configure Automatic Placement
+
+The user's `Sandbox Grouping Strategy` application setting controls automatic
+placement:
+
+| Setting | Placement Behavior |
+| --- | --- |
+| No grouping | Start a new sandbox for each conversation |
+| Group by newest | Use the newest available sandbox |
+| Least recently used | Use the least recently used available sandbox |
+| Fewest conversations | Use the available sandbox with the fewest conversations |
+| Add to any | Use the first available sandbox |
+
+To change the setting:
+
+1. Navigate to `Settings > Application`.
+2. Select a value under `Sandbox Grouping Strategy`.
+3. Click `Save Changes`.
+
+The setting applies to conversations started with that user's application
+settings. It does not change the installation's sandbox capacity.
+
+Grouping is a placement rule, not a resource scheduler. It does not determine
+whether a sandbox has enough CPU, memory, disk, or credentials for another
+conversation. Applications running concurrent workloads must still limit
+admission based on their tested sandbox capacity.
+
+## Manage Conversations With V1
+
+The V1 API uses the Enterprise base URL and Bearer authentication:
+
+```http
+Authorization: Bearer YOUR_API_KEY
+```
+
+The main conversation endpoints are:
+
+| Operation | Endpoint |
+| --- | --- |
+| Start a conversation | `POST /api/v1/app-conversations` |
+| Check asynchronous startup | `GET /api/v1/app-conversations/start-tasks?ids={start_task_id}` |
+| Get conversations by ID | `GET /api/v1/app-conversations?ids={conversation_id}` |
+| Search conversations | `GET /api/v1/app-conversations/search` |
+| Send a follow-up message | `POST /api/v1/app-conversations/{conversation_id}/send-message` |
+| Read events | `GET /api/v1/conversation/{conversation_id}/events/search` |
+| Update conversation metadata | `PATCH /api/v1/app-conversations/{conversation_id}` |
+| Download the trajectory | `GET /api/v1/app-conversations/{conversation_id}/download` |
+| Delete a conversation | `DELETE /api/v1/app-conversations/{conversation_id}` |
+
+### Start A Conversation
+
+```bash
+curl -X POST \
+  "https://OPENHANDS_HOST/api/v1/app-conversations" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "initial_message": {
+      "role": "user",
+      "content": [
+        {
+          "type": "text",
+          "text": "Run the repository tests and explain any failures."
+        }
+      ],
+      "run": true
+    },
+    "selected_repository": "yourorganization/yourrepository",
+    "selected_branch": "main"
+  }'
+```
+
+Conversation startup is asynchronous. The response is a start task. Poll the
+start task until it reaches `READY` and returns `app_conversation_id` and
+`sandbox_id`.
+
+### Select An Existing Sandbox
+
+For explicit placement:
+
+1. Create a sandbox with `POST /api/v1/sandboxes`.
+2. Wait until its status is `RUNNING`.
+3. Include its ID as `sandbox_id` when starting the conversation.
+4. Verify that the completed start task returns the expected sandbox ID.
+
+```json
+{
+  "sandbox_id": "SANDBOX_ID",
+  "initial_message": {
+    "role": "user",
+    "content": [
+      {
+        "type": "text",
+        "text": "Run the compatibility check."
+      }
+    ],
+    "run": true
+  }
+}
+```
+
+Explicit placement overrides automatic grouping for that conversation. It
+does not add isolation between conversations attached to the selected
+sandbox.
+
+## Inspect Work Through V1
+
+Enterprise exposes application-level endpoints for reviewing work without
+connecting directly to the Agent Server:
+
+| Operation | Endpoint |
+| --- | --- |
+| Read a workspace file | `GET /api/v1/app-conversations/{conversation_id}/file` |
+| List Git changes | `GET /api/v1/app-conversations/{conversation_id}/git/changes` |
+| Read the Git diff | `GET /api/v1/app-conversations/{conversation_id}/git/diff` |
+| List loaded skills | `GET /api/v1/app-conversations/{conversation_id}/skills` |
+| List configured hooks | `GET /api/v1/app-conversations/{conversation_id}/hooks` |
+
+The app-conversation record also includes sandbox status, agent execution
+status, and model usage metrics.
+
+Use the events endpoint for messages, tool actions, tool observations, state
+changes, and errors. Use the current app-conversation record to reconcile
+status after a process restart or missed event.
+
+## Manage Sandbox Lifecycle
+
+The V1 sandbox endpoints include:
+
+| Operation | Endpoint |
+| --- | --- |
+| Create a sandbox | `POST /api/v1/sandboxes` |
+| Search sandboxes | `GET /api/v1/sandboxes/search` |
+| Get a sandbox | `GET /api/v1/sandboxes?id={sandbox_id}` |
+| Pause a sandbox | `POST /api/v1/sandboxes/{sandbox_id}/pause` |
+| Resume a sandbox | `POST /api/v1/sandboxes/{sandbox_id}/resume` |
+| Delete a sandbox | `DELETE /api/v1/sandboxes/{sandbox_id}` |
+
+Pause retains the conversation and recoverable workspace while releasing
+active runtime capacity. Delete only after required results and artifacts are
+stored elsewhere.
+
+Before pausing or deleting a shared sandbox, check every conversation attached
+to it. The operation affects all of them.
+
+Deleting the last conversation can also remove its sandbox. After deleting a
+conversation, check whether the sandbox still exists before sending a separate
+sandbox delete request.

--- a/enterprise/conversations-and-sandboxes.mdx
+++ b/enterprise/conversations-and-sandboxes.mdx
@@ -136,6 +136,53 @@ Conversation startup is asynchronous. The response is a start task. Poll the
 start task until it reaches `READY` and returns `app_conversation_id` and
 `sandbox_id`.
 
+### Pass Secrets At Conversation Start
+
+For credentials needed by only one conversation, include a `secrets` map in
+the start request:
+
+```json
+{
+  "initial_message": {
+    "role": "user",
+    "content": [
+      {
+        "type": "text",
+        "text": "Review the repository and open a pull request."
+      }
+    ],
+    "run": true
+  },
+  "secrets": {
+    "GITHUB_TOKEN": "YOUR_SHORT_LIVED_TOKEN"
+  }
+}
+```
+
+Conversation-specific secrets are available before the first agent action.
+They take precedence over stored secrets with the same permitted name for that
+conversation. Prefer short-lived, narrowly scoped credentials, and do not put
+secret values in the initial message or write them to the workspace.
+
+The same request can include `plugins`. Secrets present at startup can fill
+`${NAME}` placeholders in an attached plugin's MCP configuration before the
+MCP connection opens. Pass both `secrets` and `plugins` in the start request
+when a plugin requires a conversation-specific credential.
+
+<Warning>
+  If `GITHUB_TOKEN` represents a different GitHub user than the Enterprise
+  account, start the conversation without `selected_repository`. Clone the
+  repository after the conversation starts, or prepare a sandbox and then
+  attach the conversation. Configure `git user.name` and `git user.email`
+  separately because the push credential does not set commit authorship.
+</Warning>
+
+For tested implementations, see the
+[per-conversation secrets](https://github.com/jpshackelford/oh-examples/tree/main/per-conversation-secrets)
+and
+[service-account GitHub PAT](https://github.com/jpshackelford/oh-examples/tree/main/service-account-github-pat)
+examples.
+
 ### Select An Existing Sandbox
 
 For explicit placement:

--- a/enterprise/index.mdx
+++ b/enterprise/index.mdx
@@ -89,13 +89,20 @@ Enterprise customers receive:
 
 ## Getting Started
 
-<CardGroup cols={2}>
+<CardGroup cols={3}>
   <Card
     title="Quick Start"
     icon="rocket"
     href="/enterprise/quick-start"
   >
     Trial OpenHands Enterprise for free!
+  </Card>
+  <Card
+    title="Conversations And Sandboxes"
+    icon="boxes-stacked"
+    href="/enterprise/conversations-and-sandboxes"
+  >
+    Configure conversation placement, sharing, and sandbox lifecycle.
   </Card>
   <Card
     title="Contact Us"

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -45848,6 +45848,53 @@ Conversation startup is asynchronous. The response is a start task. Poll the
 start task until it reaches `READY` and returns `app_conversation_id` and
 `sandbox_id`.
 
+### Pass Secrets At Conversation Start
+
+For credentials needed by only one conversation, include a `secrets` map in
+the start request:
+
+```json
+{
+  "initial_message": {
+    "role": "user",
+    "content": [
+      {
+        "type": "text",
+        "text": "Review the repository and open a pull request."
+      }
+    ],
+    "run": true
+  },
+  "secrets": {
+    "GITHUB_TOKEN": "YOUR_SHORT_LIVED_TOKEN"
+  }
+}
+```
+
+Conversation-specific secrets are available before the first agent action.
+They take precedence over stored secrets with the same permitted name for that
+conversation. Prefer short-lived, narrowly scoped credentials, and do not put
+secret values in the initial message or write them to the workspace.
+
+The same request can include `plugins`. Secrets present at startup can fill
+`${NAME}` placeholders in an attached plugin's MCP configuration before the
+MCP connection opens. Pass both `secrets` and `plugins` in the start request
+when a plugin requires a conversation-specific credential.
+
+<Warning>
+  If `GITHUB_TOKEN` represents a different GitHub user than the Enterprise
+  account, start the conversation without `selected_repository`. Clone the
+  repository after the conversation starts, or prepare a sandbox and then
+  attach the conversation. Configure `git user.name` and `git user.email`
+  separately because the push credential does not set commit authorship.
+</Warning>
+
+For tested implementations, see the
+[per-conversation secrets](https://github.com/jpshackelford/oh-examples/tree/main/per-conversation-secrets)
+and
+[service-account GitHub PAT](https://github.com/jpshackelford/oh-examples/tree/main/service-account-github-pat)
+examples.
+
 ### Select An Existing Sandbox
 
 For explicit placement:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -37893,6 +37893,33 @@ To override the defaults:
   for commits and pull requests. OpenHands will remain as a co-author.
 </Note>
 
+## Sandbox Grouping Strategy
+
+The `Sandbox Grouping Strategy` setting controls where OpenHands places new
+conversations started with your application settings.
+
+| Setting | Placement Behavior |
+| --- | --- |
+| No grouping | Start a new sandbox for each conversation |
+| Group by newest | Use the newest available sandbox |
+| Least recently used | Use the least recently used available sandbox |
+| Fewest conversations | Use the available sandbox with the fewest conversations |
+| Add to any | Use the first available sandbox |
+
+To change the setting:
+
+1. Navigate to `Settings > Application`.
+2. Select a value under `Sandbox Grouping Strategy`.
+3. Click `Save Changes`.
+
+Grouping can reduce sandbox startup time and sandbox count. Conversations in
+one sandbox share its filesystem, credentials, compute limits, and failure
+domain. The setting does not check whether a sandbox has enough CPU, memory, or
+disk for another conversation.
+
+For API placement and sandbox lifecycle options, see
+[Conversations And Sandboxes](/enterprise/conversations-and-sandboxes).
+
 ### Integrations Settings
 Source: https://docs.openhands.dev/openhands/usage/settings/integrations-settings.md
 
@@ -45365,13 +45392,20 @@ Enterprise customers receive:
 
 ## Getting Started
 
-<CardGroup cols={2}>
+<CardGroup cols={3}>
   <Card
     title="Quick Start"
     icon="rocket"
     href="/enterprise/quick-start"
   >
     Trial OpenHands Enterprise for free!
+  </Card>
+  <Card
+    title="Conversations And Sandboxes"
+    icon="boxes-stacked"
+    href="/enterprise/conversations-and-sandboxes"
+  >
+    Configure conversation placement, sharing, and sandbox lifecycle.
   </Card>
   <Card
     title="Contact Us"
@@ -45678,6 +45712,214 @@ Once traces are flowing, use Laminar's official docs to go deeper:
     Reach out to the OpenHands team for deployment assistance or questions.
   </Card>
 </CardGroup>
+
+### Conversations And Sandboxes
+Source: https://docs.openhands.dev/enterprise/conversations-and-sandboxes.md
+
+OpenHands Enterprise separates the user's coding session from the environment
+where the coding agent runs:
+
+- A **conversation** is the session shown in the OpenHands application. It has
+  its own messages, events, agent state, repository selection, and usage
+  metrics.
+- A **sandbox** is the execution environment. It provides the filesystem,
+  processes, credentials, tools, and compute used by one or more conversations.
+- An **Agent Server** runs inside the sandbox and executes the OpenHands coding
+  agent for each conversation attached to that sandbox.
+
+The Enterprise V1 API manages conversations and sandboxes at the application
+level. Most customer integrations should begin with this API.
+
+## How The Components Relate
+
+```mermaid
+flowchart LR
+    API["Enterprise V1 API"]
+    subgraph Sandbox["Sandbox"]
+        Conversation1["Conversation A"]
+        Conversation2["Conversation B"]
+        Shared["Shared filesystem, tools, credentials, and compute"]
+        Conversation1 --> Shared
+        Conversation2 --> Shared
+    end
+
+    API --> Conversation1
+    API --> Conversation2
+```
+
+The Enterprise V1 API creates and manages the user-visible conversations. A
+sandbox can contain one conversation or several, depending on placement.
+
+Two conversations in the same sandbox keep separate conversation histories,
+but they share the sandbox's filesystem, credentials, compute limits, and
+failure domain.
+
+## Choose The Sandbox Boundary
+
+Use separate sandboxes when conversations cross a security, trust, repository,
+or failure boundary. Use a shared sandbox when the conversations are trusted
+to share the same environment and reducing startup time or sandbox count is
+more important than isolation.
+
+| Placement | Appropriate When | Tradeoff |
+| --- | --- | --- |
+| One sandbox per conversation | Work requires isolation or independent cleanup | Uses the most sandbox capacity |
+| Several conversations per sandbox | Trusted work can share files, credentials, and compute | A failure or resource problem can affect every attached conversation |
+| Explicitly selected sandbox | An application prepares an environment or maintains a small warm pool | The application must coordinate placement and cleanup |
+
+<Warning>
+  A separate conversation is not a security boundary when it shares a
+  sandbox with another conversation.
+</Warning>
+
+## Configure Automatic Placement
+
+The user's `Sandbox Grouping Strategy` application setting controls automatic
+placement:
+
+| Setting | Placement Behavior |
+| --- | --- |
+| No grouping | Start a new sandbox for each conversation |
+| Group by newest | Use the newest available sandbox |
+| Least recently used | Use the least recently used available sandbox |
+| Fewest conversations | Use the available sandbox with the fewest conversations |
+| Add to any | Use the first available sandbox |
+
+To change the setting:
+
+1. Navigate to `Settings > Application`.
+2. Select a value under `Sandbox Grouping Strategy`.
+3. Click `Save Changes`.
+
+The setting applies to conversations started with that user's application
+settings. It does not change the installation's sandbox capacity.
+
+Grouping is a placement rule, not a resource scheduler. It does not determine
+whether a sandbox has enough CPU, memory, disk, or credentials for another
+conversation. Applications running concurrent workloads must still limit
+admission based on their tested sandbox capacity.
+
+## Manage Conversations With V1
+
+The V1 API uses the Enterprise base URL and Bearer authentication:
+
+```http
+Authorization: Bearer YOUR_API_KEY
+```
+
+The main conversation endpoints are:
+
+| Operation | Endpoint |
+| --- | --- |
+| Start a conversation | `POST /api/v1/app-conversations` |
+| Check asynchronous startup | `GET /api/v1/app-conversations/start-tasks?ids={start_task_id}` |
+| Get conversations by ID | `GET /api/v1/app-conversations?ids={conversation_id}` |
+| Search conversations | `GET /api/v1/app-conversations/search` |
+| Send a follow-up message | `POST /api/v1/app-conversations/{conversation_id}/send-message` |
+| Read events | `GET /api/v1/conversation/{conversation_id}/events/search` |
+| Update conversation metadata | `PATCH /api/v1/app-conversations/{conversation_id}` |
+| Download the trajectory | `GET /api/v1/app-conversations/{conversation_id}/download` |
+| Delete a conversation | `DELETE /api/v1/app-conversations/{conversation_id}` |
+
+### Start A Conversation
+
+```bash
+curl -X POST \
+  "https://OPENHANDS_HOST/api/v1/app-conversations" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "initial_message": {
+      "role": "user",
+      "content": [
+        {
+          "type": "text",
+          "text": "Run the repository tests and explain any failures."
+        }
+      ],
+      "run": true
+    },
+    "selected_repository": "yourorganization/yourrepository",
+    "selected_branch": "main"
+  }'
+```
+
+Conversation startup is asynchronous. The response is a start task. Poll the
+start task until it reaches `READY` and returns `app_conversation_id` and
+`sandbox_id`.
+
+### Select An Existing Sandbox
+
+For explicit placement:
+
+1. Create a sandbox with `POST /api/v1/sandboxes`.
+2. Wait until its status is `RUNNING`.
+3. Include its ID as `sandbox_id` when starting the conversation.
+4. Verify that the completed start task returns the expected sandbox ID.
+
+```json
+{
+  "sandbox_id": "SANDBOX_ID",
+  "initial_message": {
+    "role": "user",
+    "content": [
+      {
+        "type": "text",
+        "text": "Run the compatibility check."
+      }
+    ],
+    "run": true
+  }
+}
+```
+
+Explicit placement overrides automatic grouping for that conversation. It
+does not add isolation between conversations attached to the selected
+sandbox.
+
+## Inspect Work Through V1
+
+Enterprise exposes application-level endpoints for reviewing work without
+connecting directly to the Agent Server:
+
+| Operation | Endpoint |
+| --- | --- |
+| Read a workspace file | `GET /api/v1/app-conversations/{conversation_id}/file` |
+| List Git changes | `GET /api/v1/app-conversations/{conversation_id}/git/changes` |
+| Read the Git diff | `GET /api/v1/app-conversations/{conversation_id}/git/diff` |
+| List loaded skills | `GET /api/v1/app-conversations/{conversation_id}/skills` |
+| List configured hooks | `GET /api/v1/app-conversations/{conversation_id}/hooks` |
+
+The app-conversation record also includes sandbox status, agent execution
+status, and model usage metrics.
+
+Use the events endpoint for messages, tool actions, tool observations, state
+changes, and errors. Use the current app-conversation record to reconcile
+status after a process restart or missed event.
+
+## Manage Sandbox Lifecycle
+
+The V1 sandbox endpoints include:
+
+| Operation | Endpoint |
+| --- | --- |
+| Create a sandbox | `POST /api/v1/sandboxes` |
+| Search sandboxes | `GET /api/v1/sandboxes/search` |
+| Get a sandbox | `GET /api/v1/sandboxes?id={sandbox_id}` |
+| Pause a sandbox | `POST /api/v1/sandboxes/{sandbox_id}/pause` |
+| Resume a sandbox | `POST /api/v1/sandboxes/{sandbox_id}/resume` |
+| Delete a sandbox | `DELETE /api/v1/sandboxes/{sandbox_id}` |
+
+Pause retains the conversation and recoverable workspace while releasing
+active runtime capacity. Delete only after required results and artifacts are
+stored elsewhere.
+
+Before pausing or deleting a shared sandbox, check every conversation attached
+to it. The operation affects all of them.
+
+Deleting the last conversation can also remove its sandbox. After deleting a
+conversation, check whether the sandbox still exists before sending a separate
+sandbox delete request.
 
 ### Custom Sandbox Images
 Source: https://docs.openhands.dev/enterprise/custom-sandbox-image.md
@@ -48860,6 +49102,60 @@ OpenHands Enterprise is now running. You can open a repository or start a new co
 
 ### Release Notes
 Source: https://docs.openhands.dev/enterprise/release-notes.md
+
+## 0.28.0
+
+This release adds the embedded **Agent Canvas** (mounted under `{your-openhands-instance.example.com}/canvas`), which will coexist with the current OpenHands Enterprise conversation interface for the time being. A future release will announce the deprecation date for the existing interface, after which Agent Canvas will become the default UI; in the meantime, teams can begin experimenting with the new Agent Canvas experience and share feedback with the OpenHands product teams.
+
+Additionally, this release brings better Helm chart validation and more configuration options to make installs easier to configure and validate. The rest of the release is focused on stability and maintenance fixes.
+
+### Enterprise Server
+
+#### Bug Fixes
+* fix: retry idempotent runtime-api reads once on timeout by @ak684 in https://github.com/OpenHands/OpenHands/pull/15266
+* fix(agent-profiles): honor profile settings in cloud launches by @simonrosenberg in https://github.com/OpenHands/OpenHands/pull/15228
+* fix: Fix CVE-2026-53571: Update vite to 8.0.16, 7.3.5, 6.4.3 by @mamoodi in https://github.com/OpenHands/OpenHands/pull/14982
+* fix: restore automations login redirects by @malhotra5 in https://github.com/OpenHands/OpenHands/pull/15295
+* fix: Avoid logout on transient provider get_user errors by @malhotra5 in https://github.com/OpenHands/OpenHands/pull/15305
+* fix: treat Integrations Hub as a cross-app route by @malhotra5 in https://github.com/OpenHands/OpenHands/pull/15324
+* fix: add managed LLM key refresh endpoint by @neubig in https://github.com/OpenHands/OpenHands/pull/15023
+* fix(app-server): restore previous DB pool_size default by @dylan-openhands in https://github.com/OpenHands/OpenHands/pull/15333
+* fix: Debounce last_used_at writes in ApiKeyStore.validate_api_key by @tofarr in https://github.com/OpenHands/OpenHands/pull/15331
+* fix(jira): allow conversations without repositories by @tofarr in https://github.com/OpenHands/OpenHands/pull/15328
+
+---
+
+### Runtime API
+
+#### Bug Fixes
+* fix: recycle pooled DB connections and bound pg8000 socket reads by @ak684 in https://github.com/OpenHands/runtime-api/pull/640
+* fix(cleanup): paginate deployment listing to stop OOM in cleanup job by @rbren in https://github.com/OpenHands/runtime-api/pull/642
+* fix(cleanup): hold archive concurrency slot until worker finishes (#643) by @aivong-openhands in https://github.com/OpenHands/runtime-api/pull/644
+
+#### Maintenance
+* perf(cleanup): batch PVC snapshot waits instead of blocking serially by @jlav in https://github.com/OpenHands/runtime-api/pull/648
+* build(deps): bump python-multipart from 0.0.27 to 0.0.31 by @dependabot[bot] in https://github.com/OpenHands/runtime-api/pull/652
+* build(deps): bump cryptography from 46.0.7 to 48.0.1 by @dependabot[bot] in https://github.com/OpenHands/runtime-api/pull/651
+
+---
+
+### OpenHands Cloud (Helm Chart)
+
+#### Features
+* feat(openhands): PLTF-3256 add values.schema.json for chart values validation by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/920
+* feat(openhands): PLTF-3257 add NOTES.txt post-install output to the openhands chart by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/922
+* feat: mount Agent Canvas under /canvas by @malhotra5 in https://github.com/OpenHands/OpenHands-Cloud/pull/900
+* feat: Added environment variable for RUNTIME_API_BASE_URL by @tofarr in https://github.com/OpenHands/OpenHands-Cloud/pull/926
+* feat(openhands): PLTF-3258 add fail guard for ingress.enabled without ingress.host by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/923
+* feat: route Integrations Hub on the primary OpenHands host by @neubig in https://github.com/OpenHands/OpenHands-Cloud/pull/899
+* feat: expose sandbox ephemeral-storage as a configurable field by @ak684 in https://github.com/OpenHands/OpenHands-Cloud/pull/930
+
+#### Bug Fixes
+* fix(release): make lint pass --app [PLTF-3195] by @dylan-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/898
+* fix: preserve Integrations Hub API auth responses by @neubig in https://github.com/OpenHands/OpenHands-Cloud/pull/933
+
+#### Maintenance
+* chore(postgres): remove obsolete emptyDir-to-PVC migration by @jlav in https://github.com/OpenHands/OpenHands-Cloud/pull/919
 
 ## 0.24.0
 

--- a/llms.txt
+++ b/llms.txt
@@ -240,6 +240,7 @@ from the OpenHands Software Agent SDK.
 - [Analytics](https://docs.openhands.dev/enterprise/analytics.md): Deploy Laminar for trace analysis in OpenHands Enterprise.
 - [Azure DevOps](https://docs.openhands.dev/enterprise/integrations/azure-devops.md): Configure Azure DevOps authentication and automation triggers for OpenHands Enterprise.
 - [Bitbucket Data Center](https://docs.openhands.dev/enterprise/integrations/bitbucket-data-center.md): Configure Bitbucket Data Center authentication and repository webhooks for OpenHands Enterprise.
+- [Conversations And Sandboxes](https://docs.openhands.dev/enterprise/conversations-and-sandboxes.md): Understand and manage conversation execution, sandbox placement, sharing, and lifecycle in OpenHands Enterprise.
 - [Custom Sandbox Images](https://docs.openhands.dev/enterprise/custom-sandbox-image.md): Preload repos, dependencies, and tooling into a custom sandbox image to make your agents faster and more reliable.
 - [DNS and TLS](https://docs.openhands.dev/enterprise/k8s-install/dns-and-tls.md): Automate DNS records and TLS certificates with external-dns and cert-manager
 - [Enterprise vs. Open Source](https://docs.openhands.dev/enterprise/enterprise-vs-oss.md): Compare OpenHands Enterprise and Open Source offerings to choose the right option for your team

--- a/openhands/usage/settings/application-settings.mdx
+++ b/openhands/usage/settings/application-settings.mdx
@@ -36,3 +36,30 @@ To override the defaults:
   When you configure a custom Git author, OpenHands will use your specified username and email as the primary author
   for commits and pull requests. OpenHands will remain as a co-author.
 </Note>
+
+## Sandbox Grouping Strategy
+
+The `Sandbox Grouping Strategy` setting controls where OpenHands places new
+conversations started with your application settings.
+
+| Setting | Placement Behavior |
+| --- | --- |
+| No grouping | Start a new sandbox for each conversation |
+| Group by newest | Use the newest available sandbox |
+| Least recently used | Use the least recently used available sandbox |
+| Fewest conversations | Use the available sandbox with the fewest conversations |
+| Add to any | Use the first available sandbox |
+
+To change the setting:
+
+1. Navigate to `Settings > Application`.
+2. Select a value under `Sandbox Grouping Strategy`.
+3. Click `Save Changes`.
+
+Grouping can reduce sandbox startup time and sandbox count. Conversations in
+one sandbox share its filesystem, credentials, compute limits, and failure
+domain. The setting does not check whether a sandbox has enough CPU, memory, or
+disk for another conversation.
+
+For API placement and sandbox lifecycle options, see
+[Conversations And Sandboxes](/enterprise/conversations-and-sandboxes).


### PR DESCRIPTION
## Summary

- Add an Enterprise guide explaining conversations, sandboxes, grouping, and the V1 lifecycle.
- Document passing per-conversation secrets, including GitHub credentials and plugin MCP configuration.
- Document Sandbox Grouping Strategy in Application Settings.
- Add the guide to the Enterprise navigation and landing page.
- Regenerate `llms.txt` and `llms-full.txt`.

## Why

Enterprise users need a clear explanation of how user-visible conversations map to sandbox execution environments, when conversations can share a sandbox, how API-created conversations receive credentials, and which V1 endpoints manage their lifecycle.

## Validation

- 30 documentation tests passed.
- `docs.json` parsed successfully.
- Internal links on the changed pages were validated.
- Generated LLM context files were refreshed.
