### PR TITLE
docs: add VM Install Admin Console configuration

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -504,6 +504,12 @@
             ]
           },
           {
+            "group": "VM Install",
+            "pages": [
+              "enterprise/vm-install/admin-console-configuration"
+            ]
+          },
+          {
             "group": "K8s Install",
             "pages": [
               "enterprise/k8s-install/index",

--- a/enterprise/vm-install/admin-console-configuration.mdx
+++ b/enterprise/vm-install/admin-console-configuration.mdx
@@ -1,0 +1,276 @@
+---
+title: Admin Console Configuration
+description: Configure an OpenHands Enterprise VM deployment from the Replicated Admin Console.
+icon: sliders
+---
+
+Use the Replicated Admin Console to configure an OpenHands Enterprise deployment installed with Replicated Embedded Cluster.
+
+<Note>
+  The available options depend on your OpenHands Enterprise release. This page follows the current release. If a field is not present in your Admin Console, check `Version history` for an available update.
+</Note>
+
+## Open the Configuration Screen
+
+1. Open `https://<your-base-domain>:30000`.
+2. Log in with the Admin Console password created during installation.
+3. Select `Config`.
+
+For initial installation instructions, see [Quick Start](/enterprise/quick-start).
+
+<Warning>
+  Configuration pages contain credentials and other sensitive values. Do not include populated configuration screens in tickets, screenshots, or support messages. Use a support bundle when requested by OpenHands Support.
+</Warning>
+
+## Apply a Configuration Change
+
+1. Update the required fields.
+2. Select `Save config`.
+3. Review the pending configuration change.
+4. Deploy the new sequence.
+5. On `Dashboard`, wait for the application status to return to `Ready`.
+
+Some changes restart one or more OpenHands components. Make changes during a maintenance window when required by your operating policies.
+
+## Domain Configuration
+
+Choose how OpenHands hostnames are defined.
+
+| Field | Description |
+|---|---|
+| `Hostname Configuration Mode` | Derive service hostnames from one base domain, or enter every hostname manually. The derived mode is recommended. |
+| `Base Domain` | Base domain used to derive application, authentication, analytics, LLM proxy, runtime API, and sandbox hostnames. |
+| `Application Hostname` | Custom hostname for the OpenHands application. Shown in manual mode. |
+| `Analytics Hostname` | Custom hostname for the analytics service. Shown in manual mode. |
+| `Authentication Hostname` | Custom hostname for Keycloak. Shown in manual mode. |
+| `LLM Proxy Hostname` | Custom hostname for the bundled LiteLLM proxy. Shown in manual mode. |
+| `Runtime API Hostname` | Custom hostname for the Runtime API. Shown in manual mode. |
+| `Runtime Base Hostname` | Base hostname for sandbox routes. Shown in manual mode. |
+| `Additional Permitted CORS Origins` | Optional comma-separated browser origins. Include the scheme and host, with no path or trailing slash. |
+
+Your DNS records and TLS certificate must cover every configured hostname, including the wildcard runtime hostname.
+
+## Certificate Configuration
+
+| Field | Description |
+|---|---|
+| `TLS Certificate` | Required PEM-encoded server certificate. Include intermediate certificates when needed. |
+| `TLS Private Key` | Required PEM-encoded private key matching the server certificate. |
+| `Additional Trusted CA Certificates` | Optional PEM bundle added to the cluster trust store. Use this for private certificate authorities and concatenate multiple certificates into one file. |
+
+<Warning>
+  A private CA must also be trusted by external systems that call OpenHands, including OAuth and webhook providers. Otherwise, sign-in callbacks and integration webhooks may fail TLS validation.
+</Warning>
+
+## LLM Configuration
+
+Select the administrator-managed LLM provider. The Admin Console shows only the fields required by the selected provider.
+
+| Provider | Fields |
+|---|---|
+| `Anthropic (Claude)` | API key and one or more Anthropic model IDs |
+| `OpenAI (GPT)` | API key |
+| `Google` | Google AI Studio API key, or Vertex AI project, location, service-account file, and model IDs |
+| `DeepSeek` | API key |
+| `Mistral AI` | API key |
+| `Azure` | Authentication method, endpoint, API version, deployment names, and either an API key or Microsoft Entra service-principal credentials |
+| `Groq` | API key |
+| `OpenRouter` | API key |
+| `AWS Bedrock` | Authentication method, AWS Region, model IDs, and optionally an access-key pair |
+| `Custom/Local LLM` | Base URL, optional API key, and full LiteLLM model strings |
+
+### Provider Notes
+
+- For Azure, deployment names must exist at the configured endpoint and API version.
+- For AWS Bedrock, use an EC2 instance profile where possible. Pods must be able to reach the instance metadata service, and the role needs model invocation permissions.
+- For custom OpenAI-compatible endpoints, prefix model names with `openai/`.
+- Model lists accept one model per line.
+
+### Bring Your Own Key
+
+Enable `Allow users to configure their own LLM providers (BYOK)` to let users add provider credentials and custom models in their OpenHands settings. Leave it disabled to restrict users to administrator-managed models.
+
+## LiteLLM Admin Console
+
+`LiteLLM Admin Password` sets the password for the LiteLLM UI at `https://<llm-proxy-hostname>/ui`. The username is `admin`.
+
+Changing this password restarts LiteLLM. Models added in LiteLLM appear in the OpenHands model selector after a short delay. Leave the LiteLLM `Team` field blank to make a model available to all users, and do not reuse a model name already configured in the Replicated LLM section.
+
+## Default OpenHands Organization
+
+| Field | Description |
+|---|---|
+| `Enable Default OpenHands Organization` | Lets the first user who signs in create and own the default organization. |
+| `Automatically Add Signed-In Users` | Adds authenticated users to the default organization as members. |
+| `Hide Personal Workspaces` | Shows the default organization as the only workspace. Existing personal data is hidden, not deleted. |
+
+These settings are additive. Disabling them does not delete organizations, remove members, or demote users.
+
+## Authentication and Integrations
+
+The following groups appear independently and reveal additional required fields when enabled.
+
+### Bitbucket Data Center Authentication
+
+Configure the server domain, OAuth application credentials, and bot identity used for repository operations. See [Bitbucket Data Center](/enterprise/integrations/bitbucket-data-center).
+
+### Azure DevOps Authentication
+
+Configure the Microsoft Entra tenant, Azure DevOps organization, client ID, and client secret. See [Azure DevOps](/enterprise/integrations/azure-devops).
+
+### Jira Data Center Integration
+
+Configure the Jira base URL, account-linking method, and either OAuth or service-account credentials. See [Jira Data Center](/enterprise/integrations/jira-data-center).
+
+### GitHub Authentication
+
+Enable the GitHub App used for sign-in and repository access, then provide:
+
+- `GitHub App Client ID`
+- `GitHub App Client Secret`
+- `GitHub App ID`
+- `GitHub App Slug`
+- `GitHub App Webhook Secret`
+- `GitHub App Private Key`
+
+Use a GitHub App, not a GitHub OAuth App.
+
+### GitLab Authentication
+
+Provide the GitLab host and OAuth client credentials. Leave the host at `gitlab.com` for GitLab SaaS, or enter the hostname of your self-managed GitLab instance.
+
+### Slack
+
+Provide the Slack client ID, client secret, and signing secret. After deployment, complete the OpenHands-side installation and account-linking flow. See [Slack](/enterprise/integrations/slack).
+
+## SMTP Email Delivery
+
+Enable SMTP to send budget alerts and administrator notifications.
+
+| Field | Description |
+|---|---|
+| `SMTP Host` | SMTP server hostname. |
+| `SMTP Port` | SMTP server port. The default is `587`. |
+| `SMTP From Email` | Sender address for OpenHands notifications. |
+| `Use SMTP SSL` | Uses implicit TLS/SMTPS. |
+| `Use SMTP STARTTLS` | Upgrades a plain connection with STARTTLS. Enabled by default. |
+| `SMTP Username` | Optional authentication username. |
+| `SMTP Password` | Optional authentication password. |
+
+Match the SSL and STARTTLS options to the behavior required by your mail server.
+
+## Database Configuration
+
+Choose the bundled PostgreSQL database or an external PostgreSQL service.
+
+For an external database, configure:
+
+- Host and port
+- SSL mode
+- Username and password
+- Whether OpenHands should create databases automatically
+- Database names for OpenHands, Keycloak, LiteLLM, Runtime API, and Automations
+
+See [External PostgreSQL](/enterprise/external-postgres) for version, encoding, privilege, and database requirements.
+
+<Warning>
+  Do not switch an existing deployment from embedded to external PostgreSQL without a migration and rollback plan. Changing connection settings does not migrate existing data.
+</Warning>
+
+## Sandbox Configuration
+
+| Field | Description |
+|---|---|
+| `Sandbox Isolation` | Selects the sandbox isolation mechanism supported by the deployment. |
+| `Sandbox Routing Mode` | Uses subdomains or another supported routing mode for sandbox traffic. |
+| `Idle Time (seconds)` | Pauses idle conversations after the configured period, releasing CPU and memory. |
+| `Deletion Time (seconds)` | Permanently deletes paused conversations and their storage after the configured period. |
+| `Storage Size` | Persistent storage allocated to each sandbox. |
+| `Ephemeral Storage Size` | Ephemeral-storage reservation for each sandbox. This affects node scheduling capacity. |
+| `Memory Request` | Memory reserved for each sandbox. |
+| `Memory Limit` | Maximum memory available to each sandbox. |
+| `CPU Request` | CPU reserved for each sandbox. |
+| `CPU Limit` | Maximum CPU available to each sandbox. |
+| `Warm Runtime Count` | Number of ready sandboxes kept for faster conversation startup. Set to `0` for cold starts only. |
+| `Additional Host Path Mounts` | Host paths mounted into every sandbox, one per line as `host_path:container_path[:ro\|rw]`. |
+| `Enable /dev/kvm passthrough (QEMU/KVM)` | Makes host KVM acceleration available inside sandboxes. The node must expose `/dev/kvm`. |
+
+Resource requests are scheduling reservations. Multiply per-sandbox requests by the expected concurrent sandbox count and leave capacity for the platform services.
+
+### Custom Sandbox Image
+
+Enable `Use a Custom Sandbox Image` to configure an image repository, tag, and optional private-registry credentials. See [Custom Sandbox Images](/enterprise/custom-sandbox-image).
+
+## Proxy Configuration
+
+Enable the HTTP proxy when outbound traffic must pass through a corporate proxy.
+
+| Field | Description |
+|---|---|
+| `HTTP_PROXY` | Proxy URL for HTTP traffic. |
+| `HTTPS_PROXY` | Proxy URL for HTTPS traffic. |
+| `NO_PROXY` | Additional comma-separated hosts that bypass the proxy. OpenHands adds internal services and configured deployment hostnames automatically. |
+| `SSL Verification` | Verifies outbound TLS certificates. Keep enabled unless a trusted proxy configuration requires otherwise. |
+
+Prefer adding the proxy CA under `Additional Trusted CA Certificates` instead of disabling TLS verification.
+
+## Troubleshooting
+
+`Log Level` defaults to `INFO`. Use `DEBUG` only while investigating a problem because it produces significantly more log output. Return to `INFO` after collecting the necessary diagnostics.
+
+## Experimental
+
+`Enable Plugin Directory` deploys the experimental plugin marketplace at `/plugins`. When enabled, configure a marketplace source beginning with `github://`, `https://`, or `http://`.
+
+See [Plugin Marketplace](/enterprise/plugin-marketplace) for setup and limitations.
+
+## Analytics Configuration
+
+Enable analytics to deploy the bundled Laminar observability services. Optionally provide a Laminar project API key; an ingest-only key is recommended.
+
+See [Analytics](/enterprise/analytics) for the complete setup and verification flow.
+
+## Automations
+
+`Enable Automations` deploys the Automations UI and backend.
+
+If you use external PostgreSQL, create and grant access to the Automations database before enabling this option.
+
+## Advanced Options
+
+| Field | Description |
+|---|---|
+| `OpenHands Resolver Label` | Label and `@mention` that trigger supported issue and pull-request integrations. |
+| `Enable Forwarding Client Headers Through LiteLLM to LLM Providers` | Forwards selected client headers. It does not forward `Authorization` or arbitrary non-`x-*` gateway headers. |
+| `Enable Custom LLM Extra HTTP Headers (JSON)` | Adds static headers to requests sent through a custom LLM gateway. |
+| `Custom LLM Extra HTTP Headers (JSON)` | JSON object containing static string header values. Treat these values as secrets when they contain credentials. |
+| `Login Session Idle Timeout (seconds)` | Maximum inactivity period before a user must sign in again. |
+| `Login Session Max Duration (seconds)` | Maximum total login-session lifetime, regardless of activity. |
+| `Enable OEM User Creation Flow` | Lets OEM deployments provision organizations and users through the supported OEM flow. |
+
+Change advanced options only when the corresponding integration or deployment requirement is understood.
+
+## Installer-Managed Secrets
+
+Replicated generates internal PostgreSQL, Redis, JWT, Keycloak, LiteLLM, sandbox, plugin-directory, and Automations secrets during installation. These values are intentionally hidden from the configuration screen.
+
+<Warning>
+  Do not rotate installer-managed secrets manually unless OpenHands Support provides a component-specific procedure. In particular, changing the LiteLLM salt key makes provider credentials already stored by LiteLLM undecryptable.
+</Warning>
+
+## Related Guides
+
+<CardGroup cols={2}>
+  <Card title="Quick Start" icon="rocket" href="/enterprise/quick-start">
+    Install an OpenHands Enterprise VM deployment.
+  </Card>
+  <Card title="External PostgreSQL" icon="database" href="/enterprise/external-postgres">
+    Prepare and configure an external database.
+  </Card>
+  <Card title="Custom Sandbox Images" icon="box" href="/enterprise/custom-sandbox-image">
+    Build and deploy a custom agent-server image.
+  </Card>
+  <Card title="Analytics" icon="chart-line" href="/enterprise/analytics">
+    Configure Laminar observability.
+  </Card>
+</CardGroup>

--- a/enterprise/vm-install/admin-console-configuration.mdx
+++ b/enterprise/vm-install/admin-console-configuration.mdx
@@ -34,21 +34,48 @@ Some changes restart one or more OpenHands components. Make changes during a mai
 
 ## Domain Configuration
 
-Choose how OpenHands hostnames are defined.
+### Recommended: Derive Hostnames From One Domain
 
-| Field | Description |
+Use the default `Derive hostnames from domain (recommended)` mode unless your organization requires a custom hostname for each service.
+
+1. Leave `Hostname Configuration Mode` set to `Derive hostnames from domain (recommended)`.
+2. Enter your `Base Domain`, such as `openhands.example.com`.
+3. Create DNS records and TLS coverage for the derived hostnames.
+
+For a base domain of `openhands.example.com`, OpenHands uses:
+
+| Service | Derived Hostname |
 |---|---|
-| `Hostname Configuration Mode` | Derive service hostnames from one base domain, or enter every hostname manually. The derived mode is recommended. |
-| `Base Domain` | Base domain used to derive application, authentication, analytics, LLM proxy, runtime API, and sandbox hostnames. |
-| `Application Hostname` | Custom hostname for the OpenHands application. Shown in manual mode. |
-| `Analytics Hostname` | Custom hostname for the analytics service. Shown in manual mode. |
-| `Authentication Hostname` | Custom hostname for Keycloak. Shown in manual mode. |
-| `LLM Proxy Hostname` | Custom hostname for the bundled LiteLLM proxy. Shown in manual mode. |
-| `Runtime API Hostname` | Custom hostname for the Runtime API. Shown in manual mode. |
-| `Runtime Base Hostname` | Base hostname for sandbox routes. Shown in manual mode. |
-| `Additional Permitted CORS Origins` | Optional comma-separated browser origins. Include the scheme and host, with no path or trailing slash. |
+| Admin Console | `openhands.example.com:30000` |
+| OpenHands application | `app.openhands.example.com` |
+| Analytics | `analytics.app.openhands.example.com` |
+| Authentication | `auth.app.openhands.example.com` |
+| LLM proxy | `llm-proxy.openhands.example.com` |
+| Runtime API | `runtime-api.openhands.example.com` |
+| Sandboxes | `*.runtime.openhands.example.com` |
 
-Your DNS records and TLS certificate must cover every configured hostname, including the wildcard runtime hostname.
+<Note>
+  The derived mode keeps DNS, certificates, OAuth callbacks, and webhook URLs consistent with the standard OpenHands deployment. It is the recommended path for most installations.
+</Note>
+
+<Accordion title="Customize every hostname">
+  Select `Enter all hostnames manually` only when your DNS or network requirements do not allow the derived layout.
+
+  | Field | Description |
+  |---|---|
+  | `Application Hostname` | Hostname for the OpenHands application. |
+  | `Analytics Hostname` | Hostname for the analytics service. |
+  | `Authentication Hostname` | Hostname for Keycloak. |
+  | `LLM Proxy Hostname` | Hostname for the bundled LiteLLM proxy. |
+  | `Runtime API Hostname` | Hostname for the Runtime API. |
+  | `Runtime Base Hostname` | Base hostname used to create sandbox routes. |
+
+  You must create DNS records, issue certificates, and configure external OAuth and webhook callbacks for the complete custom hostname set.
+</Accordion>
+
+### Additional CORS Origins
+
+`Additional Permitted CORS Origins` is optional in either hostname mode. Enter a comma-separated list of browser origins, including the scheme and host with no path or trailing slash. The OpenHands application origin is always allowed automatically.
 
 ## Certificate Configuration
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -48861,6 +48861,60 @@ OpenHands Enterprise is now running. You can open a repository or start a new co
 ### Release Notes
 Source: https://docs.openhands.dev/enterprise/release-notes.md
 
+## 0.28.0
+
+This release adds the embedded **Agent Canvas** (mounted under `{your-openhands-instance.example.com}/canvas`), which will coexist with the current OpenHands Enterprise conversation interface for the time being. A future release will announce the deprecation date for the existing interface, after which Agent Canvas will become the default UI; in the meantime, teams can begin experimenting with the new Agent Canvas experience and share feedback with the OpenHands product teams.
+
+Additionally, this release brings better Helm chart validation and more configuration options to make installs easier to configure and validate. The rest of the release is focused on stability and maintenance fixes.
+
+### Enterprise Server
+
+#### Bug Fixes
+* fix: retry idempotent runtime-api reads once on timeout by @ak684 in https://github.com/OpenHands/OpenHands/pull/15266
+* fix(agent-profiles): honor profile settings in cloud launches by @simonrosenberg in https://github.com/OpenHands/OpenHands/pull/15228
+* fix: Fix CVE-2026-53571: Update vite to 8.0.16, 7.3.5, 6.4.3 by @mamoodi in https://github.com/OpenHands/OpenHands/pull/14982
+* fix: restore automations login redirects by @malhotra5 in https://github.com/OpenHands/OpenHands/pull/15295
+* fix: Avoid logout on transient provider get_user errors by @malhotra5 in https://github.com/OpenHands/OpenHands/pull/15305
+* fix: treat Integrations Hub as a cross-app route by @malhotra5 in https://github.com/OpenHands/OpenHands/pull/15324
+* fix: add managed LLM key refresh endpoint by @neubig in https://github.com/OpenHands/OpenHands/pull/15023
+* fix(app-server): restore previous DB pool_size default by @dylan-openhands in https://github.com/OpenHands/OpenHands/pull/15333
+* fix: Debounce last_used_at writes in ApiKeyStore.validate_api_key by @tofarr in https://github.com/OpenHands/OpenHands/pull/15331
+* fix(jira): allow conversations without repositories by @tofarr in https://github.com/OpenHands/OpenHands/pull/15328
+
+---
+
+### Runtime API
+
+#### Bug Fixes
+* fix: recycle pooled DB connections and bound pg8000 socket reads by @ak684 in https://github.com/OpenHands/runtime-api/pull/640
+* fix(cleanup): paginate deployment listing to stop OOM in cleanup job by @rbren in https://github.com/OpenHands/runtime-api/pull/642
+* fix(cleanup): hold archive concurrency slot until worker finishes (#643) by @aivong-openhands in https://github.com/OpenHands/runtime-api/pull/644
+
+#### Maintenance
+* perf(cleanup): batch PVC snapshot waits instead of blocking serially by @jlav in https://github.com/OpenHands/runtime-api/pull/648
+* build(deps): bump python-multipart from 0.0.27 to 0.0.31 by @dependabot[bot] in https://github.com/OpenHands/runtime-api/pull/652
+* build(deps): bump cryptography from 46.0.7 to 48.0.1 by @dependabot[bot] in https://github.com/OpenHands/runtime-api/pull/651
+
+---
+
+### OpenHands Cloud (Helm Chart)
+
+#### Features
+* feat(openhands): PLTF-3256 add values.schema.json for chart values validation by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/920
+* feat(openhands): PLTF-3257 add NOTES.txt post-install output to the openhands chart by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/922
+* feat: mount Agent Canvas under /canvas by @malhotra5 in https://github.com/OpenHands/OpenHands-Cloud/pull/900
+* feat: Added environment variable for RUNTIME_API_BASE_URL by @tofarr in https://github.com/OpenHands/OpenHands-Cloud/pull/926
+* feat(openhands): PLTF-3258 add fail guard for ingress.enabled without ingress.host by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/923
+* feat: route Integrations Hub on the primary OpenHands host by @neubig in https://github.com/OpenHands/OpenHands-Cloud/pull/899
+* feat: expose sandbox ephemeral-storage as a configurable field by @ak684 in https://github.com/OpenHands/OpenHands-Cloud/pull/930
+
+#### Bug Fixes
+* fix(release): make lint pass --app [PLTF-3195] by @dylan-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/898
+* fix: preserve Integrations Hub API auth responses by @neubig in https://github.com/OpenHands/OpenHands-Cloud/pull/933
+
+#### Maintenance
+* chore(postgres): remove obsolete emptyDir-to-PVC migration by @jlav in https://github.com/OpenHands/OpenHands-Cloud/pull/919
+
 ## 0.24.0
 
 This release introduces a **Usage & Monitoring** dashboard, giving organization administrators visibility into AI spend and adoption across the organization. This dashboard provides high-level reports showing conversation counts, active sessions, and cost-per-conversation metrics, along with detailed conversation, user, and model-level breakdowns to help teams measure efficiency and ROI.
@@ -49260,5 +49314,279 @@ a conversation created before the setting changed with a new conversation create
   </Card>
   <Card title="Plugin Launcher" icon="rocket" href="/openhands/usage/cloud/plugin-launcher">
     Create shareable links that open conversations with plugins attached.
+  </Card>
+</CardGroup>
+
+### Admin Console Configuration
+Source: https://docs.openhands.dev/enterprise/vm-install/admin-console-configuration.md
+
+Use the Replicated Admin Console to configure an OpenHands Enterprise deployment installed with Replicated Embedded Cluster.
+
+<Note>
+  The available options depend on your OpenHands Enterprise release. This page follows the current release. If a field is not present in your Admin Console, check `Version history` for an available update.
+</Note>
+
+## Open the Configuration Screen
+
+1. Open `https://<your-base-domain>:30000`.
+2. Log in with the Admin Console password created during installation.
+3. Select `Config`.
+
+For initial installation instructions, see [Quick Start](/enterprise/quick-start).
+
+<Warning>
+  Configuration pages contain credentials and other sensitive values. Do not include populated configuration screens in tickets, screenshots, or support messages. Use a support bundle when requested by OpenHands Support.
+</Warning>
+
+## Apply a Configuration Change
+
+1. Update the required fields.
+2. Select `Save config`.
+3. Review the pending configuration change.
+4. Deploy the new sequence.
+5. On `Dashboard`, wait for the application status to return to `Ready`.
+
+Some changes restart one or more OpenHands components. Make changes during a maintenance window when required by your operating policies.
+
+## Domain Configuration
+
+Choose how OpenHands hostnames are defined.
+
+| Field | Description |
+|---|---|
+| `Hostname Configuration Mode` | Derive service hostnames from one base domain, or enter every hostname manually. The derived mode is recommended. |
+| `Base Domain` | Base domain used to derive application, authentication, analytics, LLM proxy, runtime API, and sandbox hostnames. |
+| `Application Hostname` | Custom hostname for the OpenHands application. Shown in manual mode. |
+| `Analytics Hostname` | Custom hostname for the analytics service. Shown in manual mode. |
+| `Authentication Hostname` | Custom hostname for Keycloak. Shown in manual mode. |
+| `LLM Proxy Hostname` | Custom hostname for the bundled LiteLLM proxy. Shown in manual mode. |
+| `Runtime API Hostname` | Custom hostname for the Runtime API. Shown in manual mode. |
+| `Runtime Base Hostname` | Base hostname for sandbox routes. Shown in manual mode. |
+| `Additional Permitted CORS Origins` | Optional comma-separated browser origins. Include the scheme and host, with no path or trailing slash. |
+
+Your DNS records and TLS certificate must cover every configured hostname, including the wildcard runtime hostname.
+
+## Certificate Configuration
+
+| Field | Description |
+|---|---|
+| `TLS Certificate` | Required PEM-encoded server certificate. Include intermediate certificates when needed. |
+| `TLS Private Key` | Required PEM-encoded private key matching the server certificate. |
+| `Additional Trusted CA Certificates` | Optional PEM bundle added to the cluster trust store. Use this for private certificate authorities and concatenate multiple certificates into one file. |
+
+<Warning>
+  A private CA must also be trusted by external systems that call OpenHands, including OAuth and webhook providers. Otherwise, sign-in callbacks and integration webhooks may fail TLS validation.
+</Warning>
+
+## LLM Configuration
+
+Select the administrator-managed LLM provider. The Admin Console shows only the fields required by the selected provider.
+
+| Provider | Fields |
+|---|---|
+| `Anthropic (Claude)` | API key and one or more Anthropic model IDs |
+| `OpenAI (GPT)` | API key |
+| `Google` | Google AI Studio API key, or Vertex AI project, location, service-account file, and model IDs |
+| `DeepSeek` | API key |
+| `Mistral AI` | API key |
+| `Azure` | Authentication method, endpoint, API version, deployment names, and either an API key or Microsoft Entra service-principal credentials |
+| `Groq` | API key |
+| `OpenRouter` | API key |
+| `AWS Bedrock` | Authentication method, AWS Region, model IDs, and optionally an access-key pair |
+| `Custom/Local LLM` | Base URL, optional API key, and full LiteLLM model strings |
+
+### Provider Notes
+
+- For Azure, deployment names must exist at the configured endpoint and API version.
+- For AWS Bedrock, use an EC2 instance profile where possible. Pods must be able to reach the instance metadata service, and the role needs model invocation permissions.
+- For custom OpenAI-compatible endpoints, prefix model names with `openai/`.
+- Model lists accept one model per line.
+
+### Bring Your Own Key
+
+Enable `Allow users to configure their own LLM providers (BYOK)` to let users add provider credentials and custom models in their OpenHands settings. Leave it disabled to restrict users to administrator-managed models.
+
+## LiteLLM Admin Console
+
+`LiteLLM Admin Password` sets the password for the LiteLLM UI at `https://<llm-proxy-hostname>/ui`. The username is `admin`.
+
+Changing this password restarts LiteLLM. Models added in LiteLLM appear in the OpenHands model selector after a short delay. Leave the LiteLLM `Team` field blank to make a model available to all users, and do not reuse a model name already configured in the Replicated LLM section.
+
+## Default OpenHands Organization
+
+| Field | Description |
+|---|---|
+| `Enable Default OpenHands Organization` | Lets the first user who signs in create and own the default organization. |
+| `Automatically Add Signed-In Users` | Adds authenticated users to the default organization as members. |
+| `Hide Personal Workspaces` | Shows the default organization as the only workspace. Existing personal data is hidden, not deleted. |
+
+These settings are additive. Disabling them does not delete organizations, remove members, or demote users.
+
+## Authentication and Integrations
+
+The following groups appear independently and reveal additional required fields when enabled.
+
+### Bitbucket Data Center Authentication
+
+Configure the server domain, OAuth application credentials, and bot identity used for repository operations. See [Bitbucket Data Center](/enterprise/integrations/bitbucket-data-center).
+
+### Azure DevOps Authentication
+
+Configure the Microsoft Entra tenant, Azure DevOps organization, client ID, and client secret. See [Azure DevOps](/enterprise/integrations/azure-devops).
+
+### Jira Data Center Integration
+
+Configure the Jira base URL, account-linking method, and either OAuth or service-account credentials. See [Jira Data Center](/enterprise/integrations/jira-data-center).
+
+### GitHub Authentication
+
+Enable the GitHub App used for sign-in and repository access, then provide:
+
+- `GitHub App Client ID`
+- `GitHub App Client Secret`
+- `GitHub App ID`
+- `GitHub App Slug`
+- `GitHub App Webhook Secret`
+- `GitHub App Private Key`
+
+Use a GitHub App, not a GitHub OAuth App.
+
+### GitLab Authentication
+
+Provide the GitLab host and OAuth client credentials. Leave the host at `gitlab.com` for GitLab SaaS, or enter the hostname of your self-managed GitLab instance.
+
+### Slack
+
+Provide the Slack client ID, client secret, and signing secret. After deployment, complete the OpenHands-side installation and account-linking flow. See [Slack](/enterprise/integrations/slack).
+
+## SMTP Email Delivery
+
+Enable SMTP to send budget alerts and administrator notifications.
+
+| Field | Description |
+|---|---|
+| `SMTP Host` | SMTP server hostname. |
+| `SMTP Port` | SMTP server port. The default is `587`. |
+| `SMTP From Email` | Sender address for OpenHands notifications. |
+| `Use SMTP SSL` | Uses implicit TLS/SMTPS. |
+| `Use SMTP STARTTLS` | Upgrades a plain connection with STARTTLS. Enabled by default. |
+| `SMTP Username` | Optional authentication username. |
+| `SMTP Password` | Optional authentication password. |
+
+Match the SSL and STARTTLS options to the behavior required by your mail server.
+
+## Database Configuration
+
+Choose the bundled PostgreSQL database or an external PostgreSQL service.
+
+For an external database, configure:
+
+- Host and port
+- SSL mode
+- Username and password
+- Whether OpenHands should create databases automatically
+- Database names for OpenHands, Keycloak, LiteLLM, Runtime API, and Automations
+
+See [External PostgreSQL](/enterprise/external-postgres) for version, encoding, privilege, and database requirements.
+
+<Warning>
+  Do not switch an existing deployment from embedded to external PostgreSQL without a migration and rollback plan. Changing connection settings does not migrate existing data.
+</Warning>
+
+## Sandbox Configuration
+
+| Field | Description |
+|---|---|
+| `Sandbox Isolation` | Selects the sandbox isolation mechanism supported by the deployment. |
+| `Sandbox Routing Mode` | Uses subdomains or another supported routing mode for sandbox traffic. |
+| `Idle Time (seconds)` | Pauses idle conversations after the configured period, releasing CPU and memory. |
+| `Deletion Time (seconds)` | Permanently deletes paused conversations and their storage after the configured period. |
+| `Storage Size` | Persistent storage allocated to each sandbox. |
+| `Ephemeral Storage Size` | Ephemeral-storage reservation for each sandbox. This affects node scheduling capacity. |
+| `Memory Request` | Memory reserved for each sandbox. |
+| `Memory Limit` | Maximum memory available to each sandbox. |
+| `CPU Request` | CPU reserved for each sandbox. |
+| `CPU Limit` | Maximum CPU available to each sandbox. |
+| `Warm Runtime Count` | Number of ready sandboxes kept for faster conversation startup. Set to `0` for cold starts only. |
+| `Additional Host Path Mounts` | Host paths mounted into every sandbox, one per line as `host_path:container_path[:ro\|rw]`. |
+| `Enable /dev/kvm passthrough (QEMU/KVM)` | Makes host KVM acceleration available inside sandboxes. The node must expose `/dev/kvm`. |
+
+Resource requests are scheduling reservations. Multiply per-sandbox requests by the expected concurrent sandbox count and leave capacity for the platform services.
+
+### Custom Sandbox Image
+
+Enable `Use a Custom Sandbox Image` to configure an image repository, tag, and optional private-registry credentials. See [Custom Sandbox Images](/enterprise/custom-sandbox-image).
+
+## Proxy Configuration
+
+Enable the HTTP proxy when outbound traffic must pass through a corporate proxy.
+
+| Field | Description |
+|---|---|
+| `HTTP_PROXY` | Proxy URL for HTTP traffic. |
+| `HTTPS_PROXY` | Proxy URL for HTTPS traffic. |
+| `NO_PROXY` | Additional comma-separated hosts that bypass the proxy. OpenHands adds internal services and configured deployment hostnames automatically. |
+| `SSL Verification` | Verifies outbound TLS certificates. Keep enabled unless a trusted proxy configuration requires otherwise. |
+
+Prefer adding the proxy CA under `Additional Trusted CA Certificates` instead of disabling TLS verification.
+
+## Troubleshooting
+
+`Log Level` defaults to `INFO`. Use `DEBUG` only while investigating a problem because it produces significantly more log output. Return to `INFO` after collecting the necessary diagnostics.
+
+## Experimental
+
+`Enable Plugin Directory` deploys the experimental plugin marketplace at `/plugins`. When enabled, configure a marketplace source beginning with `github://`, `https://`, or `http://`.
+
+See [Plugin Marketplace](/enterprise/plugin-marketplace) for setup and limitations.
+
+## Analytics Configuration
+
+Enable analytics to deploy the bundled Laminar observability services. Optionally provide a Laminar project API key; an ingest-only key is recommended.
+
+See [Analytics](/enterprise/analytics) for the complete setup and verification flow.
+
+## Automations
+
+`Enable Automations` deploys the Automations UI and backend.
+
+If you use external PostgreSQL, create and grant access to the Automations database before enabling this option.
+
+## Advanced Options
+
+| Field | Description |
+|---|---|
+| `OpenHands Resolver Label` | Label and `@mention` that trigger supported issue and pull-request integrations. |
+| `Enable Forwarding Client Headers Through LiteLLM to LLM Providers` | Forwards selected client headers. It does not forward `Authorization` or arbitrary non-`x-*` gateway headers. |
+| `Enable Custom LLM Extra HTTP Headers (JSON)` | Adds static headers to requests sent through a custom LLM gateway. |
+| `Custom LLM Extra HTTP Headers (JSON)` | JSON object containing static string header values. Treat these values as secrets when they contain credentials. |
+| `Login Session Idle Timeout (seconds)` | Maximum inactivity period before a user must sign in again. |
+| `Login Session Max Duration (seconds)` | Maximum total login-session lifetime, regardless of activity. |
+| `Enable OEM User Creation Flow` | Lets OEM deployments provision organizations and users through the supported OEM flow. |
+
+Change advanced options only when the corresponding integration or deployment requirement is understood.
+
+## Installer-Managed Secrets
+
+Replicated generates internal PostgreSQL, Redis, JWT, Keycloak, LiteLLM, sandbox, plugin-directory, and Automations secrets during installation. These values are intentionally hidden from the configuration screen.
+
+<Warning>
+  Do not rotate installer-managed secrets manually unless OpenHands Support provides a component-specific procedure. In particular, changing the LiteLLM salt key makes provider credentials already stored by LiteLLM undecryptable.
+</Warning>
+
+## Related Guides
+
+<CardGroup cols={2}>
+  <Card title="Quick Start" icon="rocket" href="/enterprise/quick-start">
+    Install an OpenHands Enterprise VM deployment.
+  </Card>
+  <Card title="External PostgreSQL" icon="database" href="/enterprise/external-postgres">
+    Prepare and configure an external database.
+  </Card>
+  <Card title="Custom Sandbox Images" icon="box" href="/enterprise/custom-sandbox-image">
+    Build and deploy a custom agent-server image.
+  </Card>
+  <Card title="Analytics" icon="chart-line" href="/enterprise/analytics">
+    Configure Laminar observability.
   </Card>
 </CardGroup>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -49350,21 +49350,48 @@ Some changes restart one or more OpenHands components. Make changes during a mai
 
 ## Domain Configuration
 
-Choose how OpenHands hostnames are defined.
+### Recommended: Derive Hostnames From One Domain
 
-| Field | Description |
+Use the default `Derive hostnames from domain (recommended)` mode unless your organization requires a custom hostname for each service.
+
+1. Leave `Hostname Configuration Mode` set to `Derive hostnames from domain (recommended)`.
+2. Enter your `Base Domain`, such as `openhands.example.com`.
+3. Create DNS records and TLS coverage for the derived hostnames.
+
+For a base domain of `openhands.example.com`, OpenHands uses:
+
+| Service | Derived Hostname |
 |---|---|
-| `Hostname Configuration Mode` | Derive service hostnames from one base domain, or enter every hostname manually. The derived mode is recommended. |
-| `Base Domain` | Base domain used to derive application, authentication, analytics, LLM proxy, runtime API, and sandbox hostnames. |
-| `Application Hostname` | Custom hostname for the OpenHands application. Shown in manual mode. |
-| `Analytics Hostname` | Custom hostname for the analytics service. Shown in manual mode. |
-| `Authentication Hostname` | Custom hostname for Keycloak. Shown in manual mode. |
-| `LLM Proxy Hostname` | Custom hostname for the bundled LiteLLM proxy. Shown in manual mode. |
-| `Runtime API Hostname` | Custom hostname for the Runtime API. Shown in manual mode. |
-| `Runtime Base Hostname` | Base hostname for sandbox routes. Shown in manual mode. |
-| `Additional Permitted CORS Origins` | Optional comma-separated browser origins. Include the scheme and host, with no path or trailing slash. |
+| Admin Console | `openhands.example.com:30000` |
+| OpenHands application | `app.openhands.example.com` |
+| Analytics | `analytics.app.openhands.example.com` |
+| Authentication | `auth.app.openhands.example.com` |
+| LLM proxy | `llm-proxy.openhands.example.com` |
+| Runtime API | `runtime-api.openhands.example.com` |
+| Sandboxes | `*.runtime.openhands.example.com` |
 
-Your DNS records and TLS certificate must cover every configured hostname, including the wildcard runtime hostname.
+<Note>
+  The derived mode keeps DNS, certificates, OAuth callbacks, and webhook URLs consistent with the standard OpenHands deployment. It is the recommended path for most installations.
+</Note>
+
+<Accordion title="Customize every hostname">
+  Select `Enter all hostnames manually` only when your DNS or network requirements do not allow the derived layout.
+
+  | Field | Description |
+  |---|---|
+  | `Application Hostname` | Hostname for the OpenHands application. |
+  | `Analytics Hostname` | Hostname for the analytics service. |
+  | `Authentication Hostname` | Hostname for Keycloak. |
+  | `LLM Proxy Hostname` | Hostname for the bundled LiteLLM proxy. |
+  | `Runtime API Hostname` | Hostname for the Runtime API. |
+  | `Runtime Base Hostname` | Base hostname used to create sandbox routes. |
+
+  You must create DNS records, issue certificates, and configure external OAuth and webhook callbacks for the complete custom hostname set.
+</Accordion>
+
+### Additional CORS Origins
+
+`Additional Permitted CORS Origins` is optional in either hostname mode. Enter a comma-separated list of browser origins, including the scheme and host with no path or trailing slash. The OpenHands application origin is always allowed automatically.
 
 ## Certificate Configuration
 

--- a/llms.txt
+++ b/llms.txt
@@ -236,6 +236,7 @@ from the OpenHands Software Agent SDK.
 
 ## Other
 
+- [Admin Console Configuration](https://docs.openhands.dev/enterprise/vm-install/admin-console-configuration.md): Configure an OpenHands Enterprise VM deployment from the Replicated Admin Console.
 - [Amazon EKS](https://docs.openhands.dev/enterprise/k8s-install/eks.md): Prepare an Amazon EKS cluster to run OpenHands Enterprise
 - [Analytics](https://docs.openhands.dev/enterprise/analytics.md): Deploy Laminar for trace analysis in OpenHands Enterprise.
 - [Azure DevOps](https://docs.openhands.dev/enterprise/integrations/azure-devops.md): Configure Azure DevOps authentication and automation triggers for OpenHands Enterprise.


### PR DESCRIPTION
## Summary

- add a new **VM Install** group to the Enterprise navigation
- add a text-first **Admin Console Configuration** reference covering the user-visible Replicated configuration groups
- link specialized topics to their existing canonical Enterprise guides
- regenerate `llms.txt` and `llms-full.txt`

## Why

The Enterprise Quick Start covers installation and the minimum required configuration, but administrators do not have a durable reference for the rest of the Admin Console. This page documents LLM providers, authentication and integrations, databases, sandbox resources, proxies, analytics, Automations, and advanced settings without adding screenshots that would quickly become stale.

This also creates a natural home for future VM-install administration documentation, including the broader day-2 operations work tracked in [PLTF-2903](https://linear.app/all-hands-ai/issue/PLTF-2903/doc-ohe-admin-day-2-operations-guide).

## Reviewer question

This PR leaves **Quick Start** in the existing **OpenHands Enterprise** group and adds **Admin Console Configuration** under the new **VM Install** group. Would reviewers prefer moving Quick Start into VM Install as part of this PR?

## Validation

- `mintlify broken-links` — no broken links
- `make llms-check`
- `git diff --check`
