### PR TITLE
Update Documentation to address analytics gaps and fix links with repo move

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -261,6 +261,7 @@
           "openhands/usage/agent-canvas/overview",
           "openhands/usage/agent-canvas/setup",
           "openhands/usage/agent-canvas/first-time-setup",
+          "openhands/usage/agent-canvas/llm-profiles",
           "openhands/usage/agent-canvas/conversations",
           "openhands/usage/agent-canvas/agent-profiles",
           "openhands/usage/agent-canvas/plugins",

--- a/openhands/usage/agent-canvas/acp-agents.mdx
+++ b/openhands/usage/agent-canvas/acp-agents.mdx
@@ -1,9 +1,9 @@
 ---
 title: ACP Agents
-description: Drive Agent Canvas conversations with an external coding agent — Claude Code, Codex, or Gemini CLI — over the Agent Client Protocol.
+description: Run Claude Code, Codex, or Gemini CLI in Agent Canvas through the Agent Client Protocol.
 ---
 
-Agent Canvas can drive your conversations with the built-in **OpenHands** agent or with an external **ACP agent** — Claude Code, Codex, or Gemini CLI. This guide explains what ACP agents are, how to onboard one, and how to switch agents or models later.
+Use this guide when you want to bring Claude Code, Codex, or other Agents into Agent Canvas. Agent Canvas can drive conversations with the built-in **OpenHands** agent or with an external **ACP agent**. The selected backend runs the agent CLI and must have access to its subscription login or API key.
 
 ## What is an ACP agent?
 

--- a/openhands/usage/agent-canvas/acp-agents.mdx
+++ b/openhands/usage/agent-canvas/acp-agents.mdx
@@ -3,7 +3,7 @@ title: ACP Agents
 description: Run Claude Code, Codex, or Gemini CLI in Agent Canvas through the Agent Client Protocol.
 ---
 
-Use this guide when you want to bring Claude Code, Codex, or other Agents into Agent Canvas. Agent Canvas can drive conversations with the built-in **OpenHands** agent or with an external **ACP agent**. The selected backend runs the agent CLI and must have access to its subscription login or API key.
+Use this guide when you want to bring Claude Code, Codex, or other agents into Agent Canvas. Agent Canvas can drive conversations with the built-in **OpenHands** agent or with an external **ACP agent**. For an ACP agent, the selected backend launches the provider's CLI and must have access to its subscription login or API key.
 
 ## What is an ACP agent?
 
@@ -90,5 +90,5 @@ Any stdio ACP server works: choose **Custom** in Settings → Agent and enter it
 ## Related Guides
 
 - [Customize and Settings](/openhands/usage/agent-canvas/customize-and-settings)
-- [LLM Profiles and Model Configuration](/openhands/usage/agent-canvas/llm-profiles)
+- [Manage LLM Profiles](/openhands/usage/agent-canvas/llm-profiles)
 - [Connect and Manage Backends](/openhands/usage/agent-canvas/backends)

--- a/openhands/usage/agent-canvas/acp-agents.mdx
+++ b/openhands/usage/agent-canvas/acp-agents.mdx
@@ -3,7 +3,7 @@ title: ACP Agents
 description: Run Claude Code, Codex, or Gemini CLI in Agent Canvas through the Agent Client Protocol.
 ---
 
-Use this guide when you want to bring Claude Code, Codex, or other agents into Agent Canvas. Agent Canvas can drive conversations with the built-in **OpenHands** agent or with an external **ACP agent**. For an ACP agent, the selected backend launches the provider's CLI and must have access to its subscription login or API key.
+Use this guide when you want to bring Claude Code, Codex, or other agent CLIs into Agent Canvas. Agent Canvas can drive conversations with the built-in **OpenHands** agent or with an external **ACP agent**. For an ACP agent, the selected backend launches the provider's CLI and must have access to its subscription login or API key.
 
 ## What is an ACP agent?
 

--- a/openhands/usage/agent-canvas/agent-profiles.mdx
+++ b/openhands/usage/agent-canvas/agent-profiles.mdx
@@ -67,4 +67,4 @@ If you choose OpenHands, the setup flow also configures the LLM profile that the
 
 - [First Time Setup](/openhands/usage/agent-canvas/first-time-setup)
 - [ACP Agents](/openhands/usage/agent-canvas/acp-agents)
-- [LLM Profiles and Model Configuration](/openhands/usage/agent-canvas/llm-profiles)
+- [Manage LLM Profiles](/openhands/usage/agent-canvas/llm-profiles)

--- a/openhands/usage/agent-canvas/backend-setup/docker.mdx
+++ b/openhands/usage/agent-canvas/backend-setup/docker.mdx
@@ -1,9 +1,9 @@
 ---
-title: Docker Backend
-description: Run Agent Canvas in a Docker container as a sandboxed backend.
+title: Use Docker with Agent Canvas
+description: Run Agent Canvas with Docker for a sandboxed backend and mounted project workspace.
 ---
 
-The official Docker image packages the full Agent Canvas stack — backend and frontend — in a single container. The agent runs inside the container rather than directly on your host, giving you a sandboxed environment out of the box.
+Use Docker when you want Agent Canvas and its agent tools to run in a container rather than directly on your host. The official image packages the full Agent Canvas stack — backend and frontend — in a single container, with access only to the project directories you mount.
 
 ## Prerequisites
 

--- a/openhands/usage/agent-canvas/backend-setup/kubernetes.mdx
+++ b/openhands/usage/agent-canvas/backend-setup/kubernetes.mdx
@@ -38,11 +38,11 @@ Use this Helm chart for self-hosted, single-tenant setups; reach for OHE when yo
 
 ## Get the Chart
 
-The chart lives alongside the source in the `OpenHands/agent-canvas` repo. Clone it and install from the local path:
+The chart lives alongside the source in the `OpenHands/OpenHands` repository. Clone it and install from the local path:
 
 ```bash
-git clone https://github.com/OpenHands/agent-canvas.git
-cd agent-canvas
+git clone https://github.com/OpenHands/OpenHands.git
+cd OpenHands
 helm install agent-canvas ./helm/agent-canvas \
   --namespace agent-canvas --create-namespace
 ```
@@ -501,7 +501,7 @@ helm upgrade agent-canvas ./helm/agent-canvas -n agent-canvas -f values.yaml
 
 ### `ErrImagePull` on `ghcr.io/openhands/agent-canvas:<tag>`
 
-Verify the tag exists on GHCR — the chart's `appVersion` pins the default. To pull an image built from a specific commit, use `--set image.tag=sha-<short-sha>`. See [GHCR](https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas) for the tag list.
+Verify the tag exists on GHCR — the chart's `appVersion` pins the default. To pull an image built from a specific commit, use `--set image.tag=sha-<short-sha>`. See the [Agent Canvas package](https://github.com/orgs/OpenHands/packages/container/package/agent-canvas) for the tag list.
 
 ### WebSocket disconnects every minute
 
@@ -523,6 +523,6 @@ Either no `StorageClass` exists on the cluster, or the one you set doesn't provi
 
 ## Related Guides
 
-- [Docker Backend](/openhands/usage/agent-canvas/backend-setup/docker) — single-container equivalent for laptops and single-host VMs.
+- [Use Docker with Agent Canvas](/openhands/usage/agent-canvas/backend-setup/docker) — single-container equivalent for laptops and single-host VMs.
 - [VM / Self-Hosted Installation](/openhands/usage/agent-canvas/backend-setup/vm) — install directly on a Linux VM without Kubernetes.
 - [Connect and Manage Backends](/openhands/usage/agent-canvas/backends) — point a local Agent Canvas UI at a remote backend.

--- a/openhands/usage/agent-canvas/backend-setup/local.mdx
+++ b/openhands/usage/agent-canvas/backend-setup/local.mdx
@@ -49,4 +49,4 @@ Switch between them from the backend selector depending on what you're working o
 
 - [Connect and Manage Backends](/openhands/usage/agent-canvas/backends)
 - [VM / Self-Hosted Installation](/openhands/usage/agent-canvas/backend-setup/vm) — backend-only or full Canvas on a remote machine
-- [Docker Backend](/openhands/usage/agent-canvas/backend-setup/docker) — run in a container
+- [Use Docker with Agent Canvas](/openhands/usage/agent-canvas/backend-setup/docker) — run in a container

--- a/openhands/usage/agent-canvas/backend-setup/modal.mdx
+++ b/openhands/usage/agent-canvas/backend-setup/modal.mdx
@@ -119,7 +119,7 @@ secrets = modal.Secret.from_name("openhands-server-keys")
 # canvas_ui_tool.py is required by the agent-server but ships with agent-canvas,
 # not the standalone server image. Fetch it from GitHub during image build.
 TOOLS_REMOTE_DIR = "/opt/canvas-tools"
-CANVAS_UI_TOOL_URL = "https://raw.githubusercontent.com/OpenHands/agent-canvas/main/tools/canvas_ui_tool.py"
+CANVAS_UI_TOOL_URL = "https://raw.githubusercontent.com/OpenHands/OpenHands/main/tools/canvas_ui_tool.py"
 
 agent_server_image = (
     modal.Image.from_registry(
@@ -344,6 +344,6 @@ modal volume delete openhands-data
 
 - [Connect and Manage Backends](/openhands/usage/agent-canvas/backends)
 - [Local Backend](/openhands/usage/agent-canvas/backend-setup/local)
-- [Docker Backend](/openhands/usage/agent-canvas/backend-setup/docker)
+- [Use Docker with Agent Canvas](/openhands/usage/agent-canvas/backend-setup/docker)
 - [VM / Self-Hosted Backend](/openhands/usage/agent-canvas/backend-setup/vm)
 - [Cloud Backend](/openhands/usage/agent-canvas/backend-setup/cloud)

--- a/openhands/usage/agent-canvas/backend-setup/vm.mdx
+++ b/openhands/usage/agent-canvas/backend-setup/vm.mdx
@@ -335,6 +335,6 @@ Before exposing Agent Canvas beyond an SSH tunnel:
 - [Install](/openhands/usage/agent-canvas/setup)
 - [Connect and Manage Backends](/openhands/usage/agent-canvas/backends)
 - [Local Backend](/openhands/usage/agent-canvas/backend-setup/local)
-- [Docker Backend](/openhands/usage/agent-canvas/backend-setup/docker)
+- [Use Docker with Agent Canvas](/openhands/usage/agent-canvas/backend-setup/docker)
 - [Kubernetes (Helm)](/openhands/usage/agent-canvas/backend-setup/kubernetes)
 - [Cloud Backend](/openhands/usage/agent-canvas/backend-setup/cloud)

--- a/openhands/usage/agent-canvas/backends.mdx
+++ b/openhands/usage/agent-canvas/backends.mdx
@@ -3,7 +3,7 @@ title: Backends
 description: Understand and manage Agent Canvas backends.
 ---
 
-A **backend** is an [agent server](/sdk/guides/agent-server/overview#what-is-a-remote-agent-server) and the workspace it operates in. All conversations, settings, and automations run against whichever backend is currently selected.
+A **backend** is an [agent server](/sdk/guides/agent-server/overview#what-is-a-remote-agent-server) and the workspace it operates in. A workspace is the folder, mounted project directory, container, or cloud sandbox where the agent reads and writes files. All conversations, settings, and automations run against whichever backend is currently selected.
 
 ## Connecting to a Backend
 

--- a/openhands/usage/agent-canvas/critic.mdx
+++ b/openhands/usage/agent-canvas/critic.mdx
@@ -126,7 +126,7 @@ If the critic request fails with an API key or authentication error:
 ## Related Guides
 
 - [Customize and Settings](/openhands/usage/agent-canvas/customize-and-settings)
-- [LLM Profiles and Model Configuration](/openhands/usage/agent-canvas/llm-profiles)
+- [Manage LLM Profiles](/openhands/usage/agent-canvas/llm-profiles)
 - [OpenHands LLMs](/openhands/usage/llms/openhands-llms)
 - [SDK Critic Guide](/sdk/guides/critic)
 - [Critic Model Blog Post](https://openhands.dev/blog/sota-on-swe-bench-verified-with-inference-time-scaling-and-critic-model)

--- a/openhands/usage/agent-canvas/development.mdx
+++ b/openhands/usage/agent-canvas/development.mdx
@@ -7,8 +7,8 @@ Agent Canvas is open source. To work on it from source:
 
 1. Clone the repo and install dependencies:
     ```bash
-    git clone https://github.com/OpenHands/agent-canvas.git
-    cd agent-canvas
+    git clone https://github.com/OpenHands/OpenHands.git
+    cd OpenHands
     npm install
     ```
 
@@ -17,4 +17,4 @@ Agent Canvas is open source. To work on it from source:
     npm run dev
     ```
 
-For development workflows, environment variables, testing, and advanced configuration, see the [Development Guide](https://github.com/OpenHands/agent-canvas/blob/main/docs/DEVELOPMENT.md) in the repository.
+For development workflows, environment variables, testing, and advanced configuration, see the [Development Guide](https://github.com/OpenHands/OpenHands/blob/main/docs/DEVELOPMENT.md) in the repository.

--- a/openhands/usage/agent-canvas/first-time-setup.mdx
+++ b/openhands/usage/agent-canvas/first-time-setup.mdx
@@ -69,3 +69,9 @@ Other available templates include:
 - **Slack Standup Digest** — summarize yesterday's Slack activity into an async standup note.
 
 You can browse all pre-built automations from the `Automate` view at any time. See [Pre-built Automations](/openhands/usage/agent-canvas/prebuilt-automations) for the full list.
+
+## After Your First Session
+
+Keep the terminal or Docker container that runs Agent Canvas active while you use the browser. When you are done, [stop Agent Canvas](/openhands/usage/agent-canvas/setup#stop-agent-canvas). Start it again with the same command when you return.
+
+For routine maintenance, see [update and uninstall](/openhands/usage/agent-canvas/setup#update-agent-canvas). If the UI, backend, or model does not work as expected, start with [Troubleshooting](/openhands/usage/agent-canvas/troubleshooting).

--- a/openhands/usage/agent-canvas/llm-profiles.mdx
+++ b/openhands/usage/agent-canvas/llm-profiles.mdx
@@ -44,6 +44,12 @@ A local server can be LM Studio, Ollama, vLLM, SGLang, or another service that e
 
 The URL must be reachable from the **backend**, not only from your browser. For example, a backend in Docker cannot use `127.0.0.1` to reach a model server running on the host. Use the host address appropriate for that backend and confirm the endpoint's model inventory before saving.
 
+For example, if the model server runs on the host at port `1234` and the Agent Canvas backend runs in Docker, configure:
+
+- **Model**: `openai/<served-model-id>`, replacing `<served-model-id>` with the exact `id` returned by the server's `GET /v1/models` endpoint
+- **Base URL**: `http://host.docker.internal:1234/v1`
+- **API key**: `local-llm` or another placeholder value when the server does not require authentication
+
 See [Local LLMs](/openhands/usage/llms/local-llms) for LM Studio, Ollama, and other local-server examples.
 
 ### LiteLLM Proxy

--- a/openhands/usage/agent-canvas/llm-profiles.mdx
+++ b/openhands/usage/agent-canvas/llm-profiles.mdx
@@ -1,18 +1,56 @@
 ---
-title: LLM Profiles and Model Configuration
+title: Manage LLM Profiles
 description: Configure models in Agent Canvas and use saved LLM profiles during conversations.
 ---
 
 Agent Canvas supports configuring your LLM provider, model, and credentials from the UI. It also supports saved **LLM profiles**, which make it easier to switch models without re-entering provider settings each time.
 
-## Where to Configure Models
+## Configure an LLM Profile
 
-Open `Settings > LLM` to:
+Open `Settings > LLM` to add a reusable LLM profile. Use the **Basic** tab for a provider and model available in the dropdowns. Use the **Advanced** tab when you need to enter a model name and base URL directly. Use the **All** tab to view and customize the full set of model configuration fields.
 
-- choose a provider
-- select or enter a model
-- add the required API key
-- save reusable LLM profiles
+<Note>
+ACP agents such as Claude Code, Codex, and Gemini CLI manage their own model access. See [ACP Agents](/openhands/usage/agent-canvas/acp-agents) instead.
+</Note>
+
+### Choose a Configuration Path
+
+| I have | Profile tab | Configure |
+|---|---|---|
+| An API key from Anthropic, OpenAI, Google, or another provider | **Basic** | Select the provider and model, then add its API key. |
+| An OpenHands LLM API key | **Basic** | Select `OpenHands`, choose a model, and add your OpenHands LLM API key. |
+| A local OpenAI-compatible server | **Advanced** | Enter the provider, exact model ID, base URL, and any required API key. |
+| A LiteLLM proxy | **Advanced** | Use the `litellm_proxy/` model prefix, proxy base URL, and proxy API key. |
+
+### Direct Provider
+
+In the **Basic** tab, select your provider and model, add the API key issued by that provider, and save the profile. Use a new conversation to test the change; an existing conversation continues with the agent and model it started with.
+
+For provider and model recommendations, see [LLM Configuration](/openhands/usage/llms/llms).
+
+### OpenHands Provider
+
+Use an OpenHands LLM API key when you want Agent Canvas to access models through the OpenHands provider:
+
+1. Copy your LLM API key from [OpenHands Cloud](https://app.all-hands.dev/settings/api-keys).
+2. In the **Basic** tab, select `OpenHands`, choose a model, and add the key.
+3. Save the profile and start a new conversation.
+
+For key details and available models, see [OpenHands LLM Provider](/openhands/usage/llms/openhands-llms).
+
+### Local OpenAI-Compatible Endpoint
+
+A local server can be LM Studio, Ollama, vLLM, SGLang, or another service that exposes an OpenAI-compatible API. In the **Advanced** tab, enter the provider, exact model ID, endpoint base URL, and the required API key or a placeholder value when the server does not require one.
+
+The URL must be reachable from the **backend**, not only from your browser. For example, a backend in Docker cannot use `127.0.0.1` to reach a model server running on the host. Use the host address appropriate for that backend and confirm the endpoint's model inventory before saving.
+
+See [Local LLMs](/openhands/usage/llms/local-llms) for LM Studio, Ollama, and other local-server examples.
+
+### LiteLLM Proxy
+
+In the **Advanced** tab, use the model name format `litellm_proxy/<model-name>`, then enter your LiteLLM proxy base URL and API key. The model name after the prefix must match a model configured on the proxy.
+
+See [LiteLLM Proxy](/openhands/usage/llms/litellm-proxy) for the complete configuration.
 
 ## Working with LLM Profiles
 
@@ -24,26 +62,43 @@ LLM profiles are useful when you want different model setups for different tasks
 
 LLM profiles are separate from [Agent Profiles](/openhands/usage/agent-canvas/agent-profiles). Agent Profiles choose which agent runs a new conversation. OpenHands Agent Profiles reference an LLM profile to decide which model configuration that agent uses.
 
+### Manage Saved Profiles
+
+The available profiles list shows each profile's name, configured model, and whether it is active. Use a profile's menu to edit or rename it, set it as the active profile for new conversations, or delete it when you no longer need it.
+
 ## Switching Profiles in a Conversation
 
-You can switch profiles from the chat input with the `/model` command:
+You can switch profiles from the profile selector in the chat input or with the `/model` command:
 
 - `/model` — list the saved profiles available to the conversation
 - `/model <profile-name>` — switch to a specific saved profile
 
-Agent Canvas also shows model-switch events in the conversation timeline so you can see when a profile changed during a task.
+A switch preserves the conversation history, workspace, and task state; it applies to future model requests only. Agent Canvas also shows model-switch events in the conversation timeline so you can see when a profile changed during a task.
 
 <Note>
-  LLM profiles are fully supported in Agent Canvas and are still rolling out in OpenHands Cloud. If you connect Agent Canvas to a cloud backend, profiles you configure in Agent Canvas may be available there before the same profiles appear in the hosted OpenHands Cloud UI for your account.
+Model switching requires saved LLM profiles. If `/model` is not available in the chat input, create a profile in `Settings > LLM` and confirm that the active backend supports profile switching.
 </Note>
+
+## Fix a Failed Configuration
+
+| Symptom | Check first | Next step |
+|---|---|---|
+| Provider is not recognized | Provider selection and model prefix | Use the matching configuration path above. |
+| Model format or identifier error | Exact model ID | Compare it with the provider or proxy model inventory. |
+| Local server cannot be reached | Base URL from the backend | Check host, port, and container or network reachability. |
+| Authentication or permission error | Key type and backend scope | Re-enter the key or follow the provider guide. |
+| Model cannot perform the task | Context and tool support | Choose a compatible model from the provider's recommendations. |
+
+For error-specific steps, see [Troubleshooting](/openhands/usage/agent-canvas/troubleshooting#model-or-api-key-errors).
+
 
 ## Recommended Workflow
 
-1. Configure a default profile in `Settings > LLM`.
-2. Create additional profiles for specific tasks or cost levels.
+1. Configure and save a default profile in `Settings > LLM`.
+2. Create additional profiles for specific tasks or cost levels, using descriptive names that make their purpose clear.
 3. Open `Settings > Agent` and choose which LLM profile an OpenHands Agent Profile should use.
-4. Start a conversation.
-5. Use `/model` when you want to switch profiles without leaving the chat.
+4. Start a new conversation and send a simple message to confirm the selected model responds.
+5. Use the profile selector or `/model` when you want to switch profiles without leaving the chat.
 
 ## Related Guides
 

--- a/openhands/usage/agent-canvas/overview.mdx
+++ b/openhands/usage/agent-canvas/overview.mdx
@@ -14,7 +14,7 @@ Choose the path that matches where and how you want your agents to run:
 | If you want to... | Start here |
 |-------------------|------------|
 | Run OpenHands locally in a browser | [Install Agent Canvas](/openhands/usage/agent-canvas/setup) |
-| Use a sandboxed local environment | [Docker Backend](/openhands/usage/agent-canvas/backend-setup/docker) |
+| Use a sandboxed local environment | [Use Docker with Agent Canvas](/openhands/usage/agent-canvas/backend-setup/docker) |
 | Run agents on an always-on machine | [VM / Self-Hosted Installation](/openhands/usage/agent-canvas/backend-setup/vm) |
 | Connect to managed cloud sandboxes | [Cloud Backend](/openhands/usage/agent-canvas/backend-setup/cloud) |
 | Use Claude Code, Codex, Gemini CLI, or another ACP agent | [ACP Agents](/openhands/usage/agent-canvas/acp-agents) |

--- a/openhands/usage/agent-canvas/overview.mdx
+++ b/openhands/usage/agent-canvas/overview.mdx
@@ -3,13 +3,13 @@ title: Agent Canvas Overview
 description: Understand Agent Canvas, how it runs agents, and which setup path to choose.
 ---
 
-Agent Canvas is an open-source control surface for agentic work. It gives you one browser UI for conversations, files, terminal output, model configuration, backends, and automations.
+Agent Canvas is an open-source control surface for agentic work. From one place, you can manage conversations, files, terminals, model configuration, backends, and automations.
 
-By default, Agent Canvas runs on your own machine. You can also connect the same UI to backends running in Docker, on a VM, on Modal, or in [OpenHands Cloud](/openhands/usage/cloud/openhands-cloud).
+The browser interface connects to one or more backends that run the agent and its tools. By default, that backend runs on your machine, but you can instead use Docker, a VM, Modal, or [OpenHands Cloud](/openhands/usage/cloud/openhands-cloud). The LLM models can run locally, through a provider API or be accessed through an ACP agent.
 
 ## When To Use Agent Canvas
 
-Use Agent Canvas when you want a self-hosted or local browser UI for agents that can work with real files, terminals, tools, and automations.
+Choose the path that matches where and how you want your agents to run:
 
 | If you want to... | Start here |
 |-------------------|------------|
@@ -18,7 +18,6 @@ Use Agent Canvas when you want a self-hosted or local browser UI for agents that
 | Run agents on an always-on machine | [VM / Self-Hosted Installation](/openhands/usage/agent-canvas/backend-setup/vm) |
 | Connect to managed cloud sandboxes | [Cloud Backend](/openhands/usage/agent-canvas/backend-setup/cloud) |
 | Use Claude Code, Codex, Gemini CLI, or another ACP agent | [ACP Agents](/openhands/usage/agent-canvas/acp-agents) |
-| Create scheduled or event-driven workflows | [Pre-built Automations](/openhands/usage/agent-canvas/prebuilt-automations) |
 
 ## How Agent Canvas Works
 
@@ -31,8 +30,25 @@ Agent Canvas has four pieces to understand:
 | **Workspace** | The folder, repository, container mount, or cloud sandbox the agent works in. | This determines which files the agent can read and write. |
 | **Agent and model** | The OpenHands agent or an ACP agent, plus the model credentials it uses. | This determines which LLM or provider receives conversation context and powers the agent. |
 
+```mermaid
+flowchart LR
+    browser["Browser UI"] --> backend["Selected backend"]
+    backend --> conversation["Conversation and agent"]
+    conversation --> model["Model access"]
+    conversation --> workspace["Workspace and tools"]
+
+    classDef primary fill:#f3e8ff,stroke:#7c3aed,stroke-width:2px
+    classDef secondary fill:#e8f3ff,stroke:#2b6cb0,stroke-width:2px
+    classDef tertiary fill:#fff4df,stroke:#b7791f,stroke-width:2px
+    class browser primary
+    class backend,conversation secondary
+    class model,workspace tertiary
+```
+
+The browser UI is a client of the selected backend. Conversations, settings, secrets, LLM profiles, MCP servers, skills, and automations persist on that backend. The workspace and tools run where that backend runs.
+
 <Note>
-  Settings, secrets, LLM configuration, MCP servers, skills, conversations, and automations are scoped to the active backend. Switching backends switches the environment the agent is using.
+  Switching backends switches the environment the agent is using. For details on how conversations and workspaces remain separate, see [Conversations](/openhands/usage/agent-canvas/conversations) and [Backends](/openhands/usage/agent-canvas/backends).
 </Note>
 
 ## Choosing A Trust Boundary
@@ -50,25 +66,39 @@ Before installing, decide where you want the agent to run and what files it shou
   Agent Canvas can run agents that execute shell commands, read files, write files, and use connected tools. Only connect a backend to files, secrets, and networks that you are willing to let the agent use.
 </Warning>
 
+## What Happens When You Close the Terminal?
+
+For a local npm or npx installation, closing the terminal stops the Agent Canvas process, so the browser UI can no longer use its local backend. Start Agent Canvas again with the same command to continue. A Docker container, VM, or cloud backend continues running until that backend is stopped.
+
+See [Install](/openhands/usage/agent-canvas/setup#run-agent-canvas-again) to restart Agent Canvas and [Troubleshooting](/openhands/usage/agent-canvas/troubleshooting) if the browser cannot reconnect.
+
 ## Model Access
 
 Agent Canvas supports several model access patterns:
 
 - **Direct provider key** — enter an API key from Anthropic, OpenAI, Google, or another supported provider.
-- **OpenHands Cloud key** — use an OpenHands Cloud API key for verified hosted models.
+- **OpenHands LLM API key** — use an OpenHands LLM API key for verified hosted models.
 - **ACP agent subscription login** — use a signed-in provider, such as Claude Code, Codex, or Gemini, when the backend runs on the same machine as that login.
 - **Local or OpenAI-compatible provider** — connect providers such as Ollama, LM Studio, LiteLLM, or a compatible gateway through model settings.
 
-See [LLM Profiles and Model Configuration](/openhands/usage/agent-canvas/llm-profiles) and [ACP Agents](/openhands/usage/agent-canvas/acp-agents) for details.
+See [Manage LLM Profiles](/openhands/usage/agent-canvas/llm-profiles) and [ACP Agents](/openhands/usage/agent-canvas/acp-agents) for details.
 
 ## How It Fits With Other OpenHands Products
 
-| Product | Use It When |
-|---------|-------------|
-| **Agent Canvas** | You want a self-hosted browser UI for local, remote, or cloud-backed agents and automations. |
-| **OpenHands Cloud** | You want a fully managed hosted experience with no local installation. |
-| **OpenHands SDK** | You want to build agents or agent-powered applications in Python. |
-| **Local GUI (Legacy)** | You are following older Docker-based Local GUI documentation. New local browser workflows should use Agent Canvas. |
+| Surface | Best for | Where it runs |
+|---------|----------|---------------|
+| **Agent Canvas** | Browser-first agent work, workspace access, and automations | The backend you select: your machine, Docker, a VM, Modal, or Cloud |
+| **OpenHands SDK** | Building agent-powered Python applications | Your application and the workspace you configure |
+| **OpenHands Cloud** | Fully managed hosted execution | Managed OpenHands Cloud infrastructure |
+| **Local GUI (Legacy)** | Following older Docker-based Local GUI documentation | Your local Docker environment |
+
+### Agent Canvas vs "openhands serve"
+
+`agent-canvas` starts the current Agent Canvas UI and backend stack. `openhands serve` starts the legacy OpenHands CLI GUI server and will not run if you have only installed agent-canvas.
+
+### How Conversations and Workspaces Are Isolated
+
+A conversation belongs to one active backend and has its own history, agent configuration, and backend-managed state. Its workspace is the folder, mount, or sandbox attached to that backend. Start a new conversation for a separate task, or [branch a conversation](/openhands/usage/agent-canvas/conversations#branch-from-a-message) to explore another path while preserving the original.
 
 ## Before You Start
 
@@ -86,5 +116,7 @@ For a sandboxed local setup, use Docker instead of the direct npm backend path.
 - [Install Agent Canvas](/openhands/usage/agent-canvas/setup)
 - [First Time Setup](/openhands/usage/agent-canvas/first-time-setup)
 - [Connect and Manage Backends](/openhands/usage/agent-canvas/backends)
-- [LLM Profiles and Model Configuration](/openhands/usage/agent-canvas/llm-profiles)
+- [Manage LLM Profiles](/openhands/usage/agent-canvas/llm-profiles)
+- [Conversations](/openhands/usage/agent-canvas/conversations)
+- [ACP Agents](/openhands/usage/agent-canvas/acp-agents)
 - [Troubleshooting](/openhands/usage/agent-canvas/troubleshooting)

--- a/openhands/usage/agent-canvas/setup.mdx
+++ b/openhands/usage/agent-canvas/setup.mdx
@@ -160,6 +160,30 @@ After startup:
 
 If the page does not load, check the terminal where Agent Canvas is running. Common causes are a missing prerequisite, a busy port, or Docker not running.
 
+## Run Agent Canvas Again
+
+After you close the terminal or restart your computer, start Agent Canvas with the same command you used to install it. Keep that terminal or Docker container running while you use the browser UI.
+
+<Tabs>
+  <Tab title="npm">
+    ```bash
+    agent-canvas
+    ```
+  </Tab>
+
+  <Tab title="npx">
+    ```bash
+    npx @openhands/agent-canvas
+    ```
+  </Tab>
+
+  <Tab title="Docker">
+    Run the same `docker run` command from [Install and Run](#install-and-run). The browser connects to the host port you map, while the backend and model configuration run where the Agent Canvas process or container is running.
+  </Tab>
+</Tabs>
+
+If the UI opens but the backend is disconnected or a model cannot respond, use [Troubleshooting](/openhands/usage/agent-canvas/troubleshooting) to identify the affected part of the stack.
+
 ## Common Startup Options
 
 | Option | Description |
@@ -190,11 +214,12 @@ agent-canvas --port 3000
 ## Stop Agent Canvas
 
 <Tabs>
-  <Tab title="npx">
+
+  <Tab title="npm">
     Return to the terminal running Agent Canvas and press `Ctrl+C`.
   </Tab>
 
-  <Tab title="npm">
+  <Tab title="npx">
     Return to the terminal running Agent Canvas and press `Ctrl+C`.
   </Tab>
 
@@ -213,20 +238,20 @@ agent-canvas --port 3000
 ## Update Agent Canvas
 
 <Tabs>
-  <Tab title="npx">
-    Stop Agent Canvas, then run the latest package:
-
-    ```bash
-    npx @openhands/agent-canvas@latest
-    ```
-  </Tab>
-
   <Tab title="npm">
     Stop Agent Canvas, then reinstall the latest package:
 
     ```bash
     npm install -g @openhands/agent-canvas@latest
     agent-canvas --version
+    ```
+  </Tab>
+
+  <Tab title="npx">
+    Stop Agent Canvas, then run the latest package:
+
+    ```bash
+    npx @openhands/agent-canvas@latest
     ```
   </Tab>
 
@@ -241,19 +266,13 @@ agent-canvas --port 3000
 
 Your settings and conversation data are stored outside the package or image when you use the documented `~/.openhands` mount.
 
+<Note>
+  **Recover or reset:** Use [Troubleshooting](/openhands/usage/agent-canvas/troubleshooting) when the browser is blank, a port is busy, the backend is unreachable, a model or API key fails, or an update or uninstall is stuck. It also explains clean removal and reinstall.
+</Note>
+
 ## Uninstall Agent Canvas
 
 <Tabs>
-  <Tab title="npx">
-    There is no Agent Canvas package to uninstall when you use `npx`. Stop the running process with `Ctrl+C`.
-
-    If you want to clear downloaded package cache entries, use npm's cache commands:
-
-    ```bash
-    npm cache verify
-    ```
-  </Tab>
-
   <Tab title="npm">
     Stop any running Agent Canvas process, then uninstall the package:
 
@@ -262,6 +281,16 @@ Your settings and conversation data are stored outside the package or image when
     ```
 
     If Windows reports that `uv.exe` or another file is in use, close terminals running Agent Canvas, stop related processes, and run the uninstall command again.
+  </Tab>
+
+  <Tab title="npx">
+    There is no Agent Canvas package to uninstall when you use `npx`. Stop the running process with `Ctrl+C`.
+
+    If you want to clear downloaded package cache entries, use npm's cache commands:
+
+    ```bash
+    npm cache verify
+    ```
   </Tab>
 
   <Tab title="Docker">

--- a/openhands/usage/agent-canvas/setup.mdx
+++ b/openhands/usage/agent-canvas/setup.mdx
@@ -1,9 +1,9 @@
 ---
-title: Install
-description: Install, run, update, and uninstall Agent Canvas.
+title: Install Agent Canvas
+description: Install, run, update, or uninstall Agent Canvas.
 ---
 
-Agent Canvas can run directly on your machine or inside Docker. Start with the simplest setup that matches the trust boundary you want.
+Agent Canvas can run directly on your machine or inside Docker. Use the local npm or npx paths for a direct local backend, or Docker for a sandboxed backend with explicit project mounts. Start with the simplest setup that matches the trust boundary you want.
 
 <Warning>
   Agent Canvas starts an agent server that can run shell commands, read files, write files, and use connected tools. Treat the machine or container where the backend runs as trusted infrastructure. Before exposing Agent Canvas to a network you do not control, review [VM / Self-Hosted Installation](/openhands/usage/agent-canvas/backend-setup/vm).

--- a/openhands/usage/agent-canvas/setup.mdx
+++ b/openhands/usage/agent-canvas/setup.mdx
@@ -138,8 +138,8 @@ Agent Canvas can run directly on your machine or inside Docker. Use the local np
     Use the source workflow only when you want to modify Agent Canvas itself:
 
     ```bash
-    git clone https://github.com/OpenHands/agent-canvas.git
-    cd agent-canvas
+    git clone https://github.com/OpenHands/OpenHands.git
+    cd OpenHands
     npm install
     npm run dev
     ```
@@ -310,6 +310,6 @@ Uninstalling the package or image does not automatically remove your persisted d
 
 - [First Time Setup](/openhands/usage/agent-canvas/first-time-setup)
 - [Connect and Manage Backends](/openhands/usage/agent-canvas/backends)
-- [LLM Profiles and Model Configuration](/openhands/usage/agent-canvas/llm-profiles)
-- [Docker Backend](/openhands/usage/agent-canvas/backend-setup/docker)
+- [Manage LLM Profiles](/openhands/usage/agent-canvas/llm-profiles)
+- [Use Docker with Agent Canvas](/openhands/usage/agent-canvas/backend-setup/docker)
 - [Troubleshooting](/openhands/usage/agent-canvas/troubleshooting)

--- a/openhands/usage/agent-canvas/troubleshooting.mdx
+++ b/openhands/usage/agent-canvas/troubleshooting.mdx
@@ -248,7 +248,6 @@ Common causes:
 For model setup details, see:
 
 - [LLM Profiles and Model Configuration](/openhands/usage/agent-canvas/llm-profiles)
-- [LLM Settings](/openhands/usage/settings/llm-settings)
 - [Local LLMs](/openhands/usage/llms/local-llms)
 - [LiteLLM Proxy](/openhands/usage/llms/litellm-proxy)
 

--- a/openhands/usage/agent-canvas/troubleshooting.mdx
+++ b/openhands/usage/agent-canvas/troubleshooting.mdx
@@ -5,6 +5,28 @@ description: Fix common Agent Canvas install, startup, backend, model, workspace
 
 Use this page when Agent Canvas does not start, the browser cannot reach it, the backend is disconnected, model setup fails, or uninstall/update commands get stuck.
 
+## Choose Your Situation
+
+**Agent Canvas cannot start**
+
+- ["agent-canvas" Command Not Found](#agent-canvas-command-not-found),
+- [Missing `uv` or `uvx`](#missing-uv-or-uvx)
+- [Port Already In Use](#port-already-in-use)
+- [Docker Daemon Not Running](#docker-daemon-not-running).
+
+**The browser works but Canvas cannot reach its backend**
+- [Backend Is Unreachable](#backend-is-unreachable)
+- [Wrong Backend URL Or API Key](#wrong-backend-url-or-api-key).
+
+**The backend works but the model fails**
+- [Model Or API Key Errors](#model-or-api-key-errors)
+- [`LLM Provider NOT provided`](#llm-provider-not-provided)
+- [ACP Agent Credentials Are Not Used](#acp-agent-credentials-are-not-used).
+
+**You need to remove or reset Canvas**
+- [Update Or Uninstall Is Stuck](#update-or-uninstall-is-stuck)
+- [Uninstall Agent Canvas](/openhands/usage/agent-canvas/setup#uninstall-agent-canvas) for clean removal and reinstall.
+
 ## Start With These Checks
 
 Run the checks for the install method you used:

--- a/openhands/usage/agent-canvas/troubleshooting.mdx
+++ b/openhands/usage/agent-canvas/troubleshooting.mdx
@@ -247,7 +247,7 @@ Common causes:
 
 For model setup details, see:
 
-- [LLM Profiles and Model Configuration](/openhands/usage/agent-canvas/llm-profiles)
+- [Manage LLM Profiles](/openhands/usage/agent-canvas/llm-profiles)
 - [Local LLMs](/openhands/usage/llms/local-llms)
 - [LiteLLM Proxy](/openhands/usage/llms/litellm-proxy)
 
@@ -361,5 +361,5 @@ Uninstalling the package or image does not automatically delete persisted settin
 If you are still stuck:
 
 - [Join the OpenHands Slack community](https://openhands.dev/joinslack)
-- [Open an issue in the Agent Canvas repository](https://github.com/OpenHands/agent-canvas/issues)
-- [Browse the Agent Canvas source](https://github.com/OpenHands/agent-canvas)
+- [Open an issue in the OpenHands repository](https://github.com/OpenHands/OpenHands/issues)
+- [Browse the Agent Canvas source](https://github.com/OpenHands/OpenHands)

--- a/openhands/usage/llms/local-llms.mdx
+++ b/openhands/usage/llms/local-llms.mdx
@@ -1,7 +1,9 @@
 ---
-title: Local LLMs
-description: When using a Local LLM, OpenHands may have limited functionality. It is highly recommended that you use GPUs to serve local models for optimal experience.
+title: Run Local LLMs with OpenHands
+description: Connect OpenHands to local LLM servers such as LM Studio, Ollama, vLLM, and SGLang.
 ---
+
+Use this guide when you want a local model, rather than a local Agent Canvas backend or local project files. Local LLMs can have limited functionality; use a capable model and GPU-backed server for the best experience.
 
 ## News
 

--- a/overview/introduction.mdx
+++ b/overview/introduction.mdx
@@ -10,7 +10,7 @@ There are a few ways to work with OpenHands:
 ## Agent Canvas
 Agent Canvas is a browser-based UI and backend server for running agents and automations. A single `agent-canvas` command starts the full stack locally. Self-host on a VM, or connect to OpenHands Cloud.
 
-[Get started with Agent Canvas](/openhands/usage/agent-canvas/overview) or [view the source](https://github.com/OpenHands/agent-canvas)
+[Get started with Agent Canvas](/openhands/usage/agent-canvas/overview) or [view the source](https://github.com/OpenHands/OpenHands)
 
 ## OpenHands Cloud
 A fully managed version of OpenHands with source-available features and integrations:

--- a/overview/skills.mdx
+++ b/overview/skills.mdx
@@ -1,148 +1,137 @@
 ---
-title: Overview
-description: Skills are specialized prompts that enhance OpenHands with domain-specific knowledge, expert guidance, and automated task handling.
+title: Skills Overview
+description: Give OpenHands reusable instructions, domain knowledge, workflows, and supporting resources.
 ---
 
-Skills are specialized prompts that enhance OpenHands with domain-specific knowledge, expert guidance, and automated task handling. They provide consistent practices across projects and can be triggered automatically based on keywords or context.
+Skills give OpenHands reusable instructions for specialized tasks. A skill can capture domain knowledge, define a repeatable workflow, and include supporting scripts, references, or templates.
+
+Skills guide the agent's behavior; they do not grant permissions or install dependencies by themselves. The agent can only use the files, tools, secrets, and network access available in its environment.
 
 <Info>
-OpenHands supports an **extended version** of the [AgentSkills standard](https://agentskills.io/specification) with optional keyword triggers for automatic activation. See the [SDK Skills Guide](/sdk/guides/skill) for details on the SKILL.md format.
+OpenHands supports the [Agent Skills specification](https://agentskills.io/specification) and adds optional features such as keyword triggers and path-triggered rules. Other Agent Skills clients may ignore these OpenHands extensions.
 </Info>
+
+## Choose the Right Mechanism
+
+| Need | Use | Recommended Location | Loading Behavior |
+|---|---|---|---|
+| Instructions for every task in a repository | `AGENTS.md` | Repository root | Full content is included in the initial system prompt |
+| Reusable expertise or a workflow for a specific task | Agent Skills `SKILL.md` | `.agents/skills/<skill-name>/SKILL.md` | Name and description are advertised first; the agent invokes the full skill when relevant |
+| Automatic activation for specific words or commands | `SKILL.md` with `triggers` | `.agents/skills/<skill-name>/SKILL.md` | The skill remains available for model invocation and its content is also injected when a trigger matches |
+| Deterministic guidance for specific files | A skill with `paths` | `.agents/skills/<skill-name>/SKILL.md` or `.agents/skills/<rule-name>.md` | Content is injected when the agent first touches a matching file |
+
+Use `AGENTS.md` for short, repository-wide conventions. Use `SKILL.md` for focused knowledge that is needed only for some tasks. A legacy `.md` skill without a trigger is always loaded in full; prefer `AGENTS.md` for that use case so its purpose is clear.
+
+OpenHands also recognizes `CLAUDE.md` and `GEMINI.md` as model-specific repository context.
+
+## How Progressive Disclosure Works
+
+Agent Skills use three levels of context:
+
+1. **Discovery**: OpenHands loads each skill's `name` and `description` into the available-skills catalog.
+2. **Invocation**: When a task matches the description, the agent invokes the skill by name and receives the full `SKILL.md` instructions.
+3. **Resources**: The agent reads referenced files from `scripts/`, `references/`, or `assets/` only when needed.
+
+This keeps the initial prompt smaller than loading every skill in full. Write the description to explain both what the skill does and when it applies; the agent uses that metadata to decide whether to invoke it.
+
+OpenHands supports two deterministic activation paths:
+
+- `triggers` injects the skill when a keyword or command appears in a user message. The skill is still available for model invocation.
+- `paths` turns the file into a path-triggered rule. The rule is not advertised to the model and is injected once per conversation when a matching file is read, edited, or created. If a file declares both `paths` and `triggers`, `paths` takes precedence.
+
+<Note>
+Always-on content occupies the conversation context from the beginning. Keep `AGENTS.md` concise and move lengthy or specialized instructions into on-demand skills and references.
+</Note>
 
 ## Official Skill Registry
 
 The official global skill registry is maintained at [github.com/OpenHands/extensions](https://github.com/OpenHands/extensions). This repository contains community-shared skills that can be used by all OpenHands agents. You can browse available skills, contribute your own, and learn from examples created by the community.
 
-## How Skills Work
 
-Skills inject additional context and rules into the agent's behavior.
+## Five-Minute Setup
 
-At a high level, OpenHands supports three loading models:
+Add concise repository guidance and one on-demand skill:
 
-- **Always-on context** (e.g., `AGENTS.md`) that is injected into the system prompt at conversation start.
-- **On-demand skills** that are either:
-  - **triggered by the user** (keyword matches), or
-  - **invoked by the agent** (the agent decides to look up the full skill content).
-- **Path-triggered rules** that are injected deterministically when the agent reads, edits, or creates a file whose path matches a glob pattern.
-
-## Permanent agent context (recommended)
-
-For repository-wide, always-on instructions, prefer a root-level `AGENTS.md` file.
-
-We also support model-specific variants:
-- `GEMINI.md` for Gemini
-- `CLAUDE.md` for Claude
-
-## Triggered and optional skills
-
-To add optional skills that are loaded on demand:
-
-- **AgentSkills standard (recommended for progressive disclosure)**: create one directory per skill and add a `SKILL.md` file.
-- **Legacy/OpenHands format (simple)**: put markdown files in `.agents/skills/*.md` at the repository root.
-
-<Note>
-Loaded skills take up space in the context window. On-demand skills help keep the system prompt smaller because the agent sees a summary first and reads the full content only when needed.
-</Note>
-
-### Example Repository Structure
-
-```
-some-repository/
-├── AGENTS.md                       # Permanent repository guidelines (recommended)
+```text
+my-repository/
+├── AGENTS.md
 └── .agents/
     └── skills/
-        ├── rot13-encryption/       # AgentSkills standard (progressive disclosure)
-        │   ├── SKILL.md
-        │   ├── scripts/
-        │   │   └── rot13.sh
-        │   └── references/
-        │       └── README.md
-        ├── another-agentskill/     # AgentSkills standard (progressive disclosure)
-        │   ├── SKILL.md
-        │   └── scripts/
-        │       └── placeholder.sh
-        └── legacy_trigger_this.md  # Legacy/OpenHands format (keyword-triggered)
+        └── release-checklist/
+            └── SKILL.md
 ```
 
-## Skill Loading Precedence
+```markdown title="AGENTS.md"
+# Repository Guidance
 
-For project location, paths are relative to the repository root; `.agents/skills/` is a subdirectory of the project directory.
-For user home location, paths are relative to the user home: `~/`
+Run the test suite before committing. Keep changes focused and follow the existing project conventions.
+```
 
-When multiple skills share the same name, OpenHands keeps the first match in this order:
+```markdown title=".agents/skills/release-checklist/SKILL.md"
+---
+name: release-checklist
+description: Prepare and verify a release checklist. Use when creating release notes or publishing a release.
+---
 
-1. `.agents/skills/` (recommended)
-2. `.openhands/skills/` (deprecated)
-3. `.openhands/microagents/` (deprecated)
+Check the version, changelog, validation commands, and release notes before publishing.
+```
 
-Project-specific skills take precedence over user skills.
+For a portable Agent Skills package, `name` and `description` are required. The `name` must match the parent directory and use lowercase letters, numbers, and hyphens. See [Creating Skills](/overview/skills/creating) for the complete format and authoring guidance.
 
-## Skill Types
+Start a new conversation after changing skill files so OpenHands rebuilds the available-skills catalog.
 
-Currently supported skill types:
+## Skill Locations and Precedence
 
-- **[Permanent Context](/overview/skills/repo)**: Repository-wide guidelines and best practices. We recommend `AGENTS.md` (and optionally `GEMINI.md` / `CLAUDE.md`).
-- **[Keyword-Triggered Skills](/overview/skills/keyword)**: Guidelines activated by specific keywords in user prompts.
-- **[Path-Triggered Rules](/overview/skills/path)**: Guidelines injected automatically when the agent touches files matching a glob pattern.
-- **[Organization Skills](/overview/skills/org)**: Team or organization-wide standards.
-- **[Global Skills](/overview/skills/public)**: Community-shared skills and templates.
+OpenHands can combine skills from several scopes:
 
-### Skills Frontmatter Requirements
+| Scope | Recommended Location | Applies To |
+|---|---|---|
+| Repository context | `<repository>/AGENTS.md` | Conversations in that repository |
+| Project skills | `<project>/.agents/skills/` | Conversations using that project workspace |
+| User skills | `~/.agents/skills/` | Conversations for that user |
+| Public skills | [OpenHands extensions registry](https://github.com/OpenHands/extensions/tree/main/skills) | Conversations configured to load the public registry |
 
-Each skill file may include frontmatter that provides additional information. In some cases, this frontmatter is required:
+Both `.openhands/skills/` and the legacy `.openhands/microagents/` directories remain supported, but use `.agents/skills/` for new skills which supports multi agent workflows.
 
-| Skill Type  | Required |
-|-------------|----------|
-| General Skills                           | No       |
-| Keyword-Triggered Skills                 | Yes      |
-| Path-Triggered Rules                     | Yes      |
+Name conflicts are resolved by precedence rather than by merging skill bodies. For automatically loaded sources, project skills override user skills, and user skills override public skills. Within a project or user scope, `.agents/skills/` takes precedence over the legacy directories.
 
-## Skills Support Matrix
+<Note>
+In the SDK, explicitly supplied skills override automatically loaded user and public skills. Project skills are resolved from the conversation workspace and override a same-named skill from another source. See the [SDK Skills Guide](/sdk/guides/skill) for loader configuration.
+</Note>
 
-| Platform | Support Level | Configuration Method | Implementation | Documentation |
-|----------|---------------|---------------------|----------------|---------------|
-| **CLI** | ✅ Full Support | `~/.agents/skills/` (user-level) and `.agents/skills/` (repo-level) | File-based markdown | [Skills Overview](/overview/skills) |
-| **SDK** | ✅ Full Support | Programmatic `Skill` objects | Code-based configuration | [SDK Skills Guide](/sdk/guides/skill) |
-| **Local GUI** | ✅ Full Support | `.agents/skills/` + UI | File-based with UI management | [Local Setup](/openhands/usage/run-openhands/local-setup) |
-| **OpenHands Cloud** | ✅ Full Support | Cloud UI + repository integration | Managed skill library | [Cloud UI](/openhands/usage/cloud/cloud-ui) |
+## OpenHands-Specific Skill Types
 
-## Platform-Specific Differences
+- [Repository Context](/overview/skills/repo) provides always-on project instructions.
+- [Keyword-Triggered Skills](/overview/skills/keyword) activate when a user message contains configured terms.
+- [Path-Triggered Rules](/overview/skills/path) apply deterministic instructions to matching files.
+- [Organization and User Skills](/overview/skills/org) share guidance across repositories.
+- [Global Skills](/overview/skills/public) are reusable skills published through the OpenHands extensions registry.
 
-<Tabs>
-  <Tab title="CLI">
-    - File-based configuration in two locations:
-      - `~/.agents/skills/` - User-level skills (all conversations).
-      - `.agents/skills/` - Repository-level skills (current directory)
-    - Markdown format for skill definitions
-    - Manual file management required
-    - Supports both general and keyword-triggered skills
-  </Tab>
-  <Tab title="SDK">
-    - Programmatic `Skill` objects in code
-    - Dynamic skill creation and management
-    - Integration with custom workflows
-    - Full control over skill lifecycle
-  </Tab>
-  <Tab title="Local GUI">
-    - Visual skill management through UI
-    - File-based storage with GUI editing
-    - Real-time skill status display
-    - Drag-and-drop skill organization
-  </Tab>
-  <Tab title="OpenHands Cloud">
-    - Cloud-based skill library management
-    - Team-wide skill sharing and templates
-    - Organization-level skill policies
-    - Integrated skill marketplace
-  </Tab>
-</Tabs>
+## Using Skills Across OpenHands
+
+| Surface | How Skills Are Loaded |
+|---|---|
+| **Agent Canvas** | Manage installed skills under `Customize > Skills`; configuration is scoped to the active backend |
+| **SDK and agent server** | Pass `Skill` objects directly or enable the user, project, and public file-based loaders in `AgentContext` |
+| **OpenHands Cloud** | Select or import skills for a conversation, including skills stored in Git repositories |
+
+See [Customize and Settings](/openhands/usage/agent-canvas/customize-and-settings) for Agent Canvas and [Plugin Launcher](/openhands/usage/cloud/plugin-launcher) for loading a Git-hosted skill into an OpenHands Cloud conversation.
+
+<Warning>
+Review a skill and its bundled resources before installing it. A skill can instruct the agent to run scripts, read files, use secrets, or call connected tools. Only install skills from sources you trust.
+</Warning>
+
+## Next Steps
+
+- [Add an Existing Skill](/overview/skills/adding)
+- [Create a Skill](/overview/skills/creating)
+- [Browse the OpenHands Skills Registry](https://github.com/OpenHands/extensions/tree/main/skills)
+- [Use Skills in the SDK](/sdk/guides/skill)
+- [Bundle Skills in a Plugin](/overview/plugins)
+- [Monitor and Improve Skills](/overview/skills/monitoring)
 
 ## Learn More
 
-- **To add existing skills**: See [Adding New Skills](/overview/skills/adding)
-- **To create your own skills**: See [Creating New Skills](/overview/skills/creating)
-- **To monitor skill performance**: See [Monitoring and Improving Skills](/overview/skills/monitoring)
-- **For bundling multiple components**: See [Plugins](/overview/plugins)
-- **For SDK integration**: See [SDK Skills Guide](/sdk/guides/skill)
-- **For architecture details**: See [Skills Architecture](/sdk/arch/skill)
-- **For specific skill types**: See [Repository Skills](/overview/skills/repo), [Keyword Skills](/overview/skills/keyword), [Path-Triggered Rules](/overview/skills/path), [Organization Skills](/overview/skills/org), and [Global Skills](/overview/skills/public)
+- **For SDK integration**: See [**SDK Skills Guide**](/sdk/guides/skill)
+- **For architecture details**: See [**Skills Architecture**](/sdk/arch/skill)
+- **For specific skill types**: See [**Repository Skills**](/overview/skills/repo), [**Keyword Skills**](/overview/skills/keyword), [**Path-Triggered Rules**](/overview/skills/path), [**Organization Skills**](/overview/skills/org), and [**Global Skills**](/overview/skills/public)

--- a/overview/skills.mdx
+++ b/overview/skills.mdx
@@ -91,7 +91,7 @@ OpenHands can combine skills from several scopes:
 | User skills | `~/.agents/skills/` | Conversations for that user |
 | Public skills | [OpenHands extensions registry](https://github.com/OpenHands/extensions/tree/main/skills) | Conversations configured to load the public registry |
 
-Both `.openhands/skills/` and the legacy `.openhands/microagents/` directories remain supported, but use `.agents/skills/` for new skills which supports multi agent workflows.
+Both `.openhands/skills/` and the legacy `.openhands/microagents/` directories remain supported, but use `.agents/skills/` for new skills. This location follows the Agent Skills standard and makes skills portable across compatible agent tools.
 
 Name conflicts are resolved by precedence rather than by merging skill bodies. For automatically loaded sources, project skills override user skills, and user skills override public skills. Within a project or user scope, `.agents/skills/` takes precedence over the legacy directories.
 
@@ -126,7 +126,6 @@ Review a skill and its bundled resources before installing it. A skill can instr
 - [Add an Existing Skill](/overview/skills/adding)
 - [Create a Skill](/overview/skills/creating)
 - [Browse the OpenHands Skills Registry](https://github.com/OpenHands/extensions/tree/main/skills)
-- [Use Skills in the SDK](/sdk/guides/skill)
 - [Bundle Skills in a Plugin](/overview/plugins)
 - [Monitor and Improve Skills](/overview/skills/monitoring)
 

--- a/overview/skills.mdx
+++ b/overview/skills.mdx
@@ -91,7 +91,7 @@ OpenHands can combine skills from several scopes:
 | User skills | `~/.agents/skills/` | Conversations for that user |
 | Public skills | [OpenHands extensions registry](https://github.com/OpenHands/extensions/tree/main/skills) | Conversations configured to load the public registry |
 
-Both `.openhands/skills/` and the legacy `.openhands/microagents/` directories remain supported, but use `.agents/skills/` for new skills. This location follows the Agent Skills standard and makes skills portable across compatible agent tools.
+Both the legacy `.openhands/skills/` and `.openhands/microagents/` directories remain supported, but use `.agents/skills/` for new skills. This location follows the Agent Skills standard and makes skills portable across compatible agent tools.
 
 Name conflicts are resolved by precedence rather than by merging skill bodies. For automatically loaded sources, project skills override user skills, and user skills override public skills. Within a project or user scope, `.agents/skills/` takes precedence over the legacy directories.
 


### PR DESCRIPTION
## Summary

Improves high-demand documentation journeys identified in issue #663.

- Clarifies the Agent Canvas install, restart, recovery, and uninstall lifecycle.
- Adds a discoverable Agent Canvas LLM profile guide with configuration, switching, and recovery guidance.
- Explains where Agent Canvas runs, how its backend and workspace model works, and how it compares with other OpenHands surfaces.
- Modernizes the Skills overview with loading behavior, progressive disclosure, setup, precedence, and safety guidance.
- Tunes high-intent landing pages for Docker, local LLMs, ACP agents, installation, and workspaces.

## Validation

- `mint broken-links` ✅
- `uv run --with pytest --with requests --with pyyaml pytest -q tests/` ⚠️ 34 passed; 2 pricing tests error because they fetch a stale upstream URL returning HTTP 404 (`OpenHands/OpenHands/main/openhands/utils/llm.py`).

_This pull request was created by an AI agent (OpenHands) on behalf of the user._