### PR TITLE
docs(sdk): document structured output

### DIFF
--- a/sdk/guides/custom-tools.mdx
+++ b/sdk/guides/custom-tools.mdx
@@ -225,6 +225,132 @@ grep_tool = ToolDefinition(
 )
 ```
 
+### Structured Agent Output
+
+Attach a Pydantic model to one tool when the agent's response must follow a typed
+schema. The SDK adds the model fields to that tool's LLM-facing schema and validates
+them before creating the action.
+
+```python icon="python" wrap
+from pydantic import BaseModel, Field
+
+from openhands.sdk import Agent, LLM, Tool
+
+
+class ProjectFacts(BaseModel):
+    description: str
+    key_points: list[str] = Field(min_length=1, max_length=5)
+
+
+finish = Tool(
+    name="FinishTool",
+    params={"response_schema": ProjectFacts},
+)
+agent = Agent(llm=LLM(model="anthropic/claude-sonnet-4-5"), tools=[finish])
+```
+
+After the conversation completes, resolve the configured tool and parse its latest
+response:
+
+```python icon="python" wrap
+from typing import cast
+
+finish_tool = agent.tools_map["finish"]
+result = cast(ProjectFacts | None, finish_tool.parse_last_response(events))
+```
+
+`response_schema` accepts a Pydantic model or a JSON Schema object. It can only be
+attached to a specification that resolves to one tool. Response field names must not
+overlap the tool's existing fields or the reserved `kind`, `security_risk`, `summary`,
+and `structured_output` names.
+
+<Note>
+See the [complete structured output example](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/01_standalone_sdk/56_structured_output.py).
+</Note>
+
+```python icon="python" expandable examples/01_standalone_sdk/56_structured_output.py
+"""Attach structured output schemas to existing tools."""
+
+import os
+from typing import cast
+
+from pydantic import BaseModel, Field
+
+from openhands.sdk import LLM, Agent, Conversation
+from openhands.sdk.event import ActionEvent
+from openhands.sdk.tool import Tool, register_tool
+from openhands.sdk.tool.builtins.finish import FinishTool
+from openhands.tools.file_editor import FileEditorTool
+from openhands.tools.terminal import TerminalAction, TerminalTool
+
+
+class CommandRationale(BaseModel):
+    purpose: str = Field(description="Why this command is being run, in one line.")
+    expected_outcome: str = Field(
+        description="What the assistant expects to observe from running it."
+    )
+
+
+class ProjectFacts(BaseModel):
+    description: str = Field(description="One-paragraph description of the project.")
+    facts: list[str] = Field(description="Three concise, distinct facts.")
+
+
+register_tool("FinishTool", FinishTool)
+
+
+llm = LLM(
+    model=os.getenv("LLM_MODEL", "anthropic/claude-sonnet-4-5-20250929"),
+    api_key=os.getenv("LLM_API_KEY"),
+    base_url=os.getenv("LLM_BASE_URL", None),
+)
+
+agent = Agent(
+    llm=llm,
+    tools=[
+        Tool(name=TerminalTool.name, params={"response_schema": CommandRationale}),
+        Tool(name=FileEditorTool.name),
+        Tool(name="FinishTool", params={"response_schema": ProjectFacts}),
+    ],
+    include_default_tools=["ThinkTool"],
+)
+
+conversation = Conversation(agent=agent, workspace=os.getcwd())
+conversation.send_message(
+    "Inspect the repo using terminal commands, then finish with three facts "
+    "about the project."
+)
+conversation.run()
+
+events = conversation.state.events
+terminal_tool = agent.tools_map[TerminalTool.name]
+finish_tool = agent.tools_map["finish"]
+
+print("\n[Terminal commands with rationale]")
+
+for event in events:
+    if (
+        isinstance(event, ActionEvent)
+        and event.tool_name == TerminalTool.name
+        and event.action is not None
+    ):
+        assert isinstance(event.action, TerminalAction)
+        rationale = cast(CommandRationale, terminal_tool.parse_response(event.action))
+        print(f"  $ {event.action.command}")
+        print(f"    purpose:          {rationale.purpose}")
+        print(f"    expected_outcome: {rationale.expected_outcome}")
+
+facts = cast(ProjectFacts | None, finish_tool.parse_last_response(events))
+if facts:
+    print("\n[Finish]")
+    print(f"  description: {facts.description}")
+    for fact in facts.facts:
+        print(f"  - {fact}")
+
+cost = conversation.conversation_stats.get_combined_metrics().accumulated_cost
+print(f"\nEXAMPLE_COST: {cost}")
+```
+
 ## When to Create Custom Tools
 
 Create custom tools when you need to:

--- a/sdk/guides/custom-tools.mdx
+++ b/sdk/guides/custom-tools.mdx
@@ -265,10 +265,10 @@ overlap the tool's existing fields or the reserved `kind`, `security_risk`, `sum
 and `structured_output` names.
 
 <Note>
-See the [complete structured output example](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/01_standalone_sdk/56_structured_output.py).
+The complete structured output example is included below.
 </Note>
 
-```python icon="python" expandable examples/01_standalone_sdk/56_structured_output.py
+```python icon="python" expandable
 """Attach structured output schemas to existing tools."""
 
 import os


### PR DESCRIPTION
Documents the structured-output API introduced by OpenHands/software-agent-sdk#4207.

- Shows how to attach a Pydantic response schema to a tool
- Shows how to retrieve the typed result
- Includes the synchronized runnable example

Companion to OpenHands/software-agent-sdk#4207.