### PR TITLE
Document app conversation observability fields

### DIFF
--- a/enterprise/conversations-and-sandboxes.mdx
+++ b/enterprise/conversations-and-sandboxes.mdx
@@ -136,6 +136,39 @@ Conversation startup is asynchronous. The response is a start task. Poll the
 start task until it reaches `READY` and returns `app_conversation_id` and
 `sandbox_id`.
 
+### Add Observability Context
+
+Conversation start requests can include optional observability fields:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `observability_span_name` | string | Creates a named child span under the root `conversation` span. Use stable, low-cardinality names for grouping and signal routing. |
+| `observability_tags` | string array | Adds tags to the conversation root observability span. |
+| `observability_metadata` | object | Adds trace-level metadata. Values must be scalars or homogeneous scalar arrays, such as strings, numbers, booleans, `string[]`, `number[]`, or `boolean[]`. |
+
+```json
+{
+  "initial_message": {
+    "role": "user",
+    "content": [
+      {
+        "type": "text",
+        "text": "Evaluate this repository against the WB rubric."
+      }
+    ],
+    "run": true
+  },
+  "selected_repository": "yourorganization/yourrepository",
+  "observability_span_name": "wb_rubric_eval",
+  "observability_tags": ["wb-rubric", "evaluation"],
+  "observability_metadata": {
+    "evaluation": "wb",
+    "attempt": 1,
+    "replay": false
+  }
+}
+```
+
 ### Pass Secrets At Conversation Start
 
 For credentials needed by only one conversation, include a `secrets` map in

--- a/openhands/usage/cloud/cloud-api.mdx
+++ b/openhands/usage/cloud/cloud-api.mdx
@@ -109,6 +109,39 @@ make a POST request to the V1 app-conversations endpoint.
   </Tab>
 </Tabs>
 
+#### Optional observability fields
+
+When starting a conversation, you can attach observability context to the trace:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `observability_span_name` | string | Creates a named child span under the root `conversation` span. Use stable, low-cardinality names for grouping and signal routing. |
+| `observability_tags` | string array | Adds tags to the conversation root observability span. |
+| `observability_metadata` | object | Adds trace-level metadata. Values must be scalars or homogeneous scalar arrays, such as strings, numbers, booleans, `string[]`, `number[]`, or `boolean[]`. |
+
+Example:
+
+```json
+{
+  "initial_message": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Evaluate this repository against the WB rubric."
+      }
+    ]
+  },
+  "selected_repository": "yourusername/your-repo",
+  "observability_span_name": "wb_rubric_eval",
+  "observability_tags": ["wb-rubric", "evaluation"],
+  "observability_metadata": {
+    "evaluation": "wb",
+    "attempt": 1,
+    "replay": false
+  }
+}
+```
+
 #### Response
 
 The API will return a JSON object with details about the conversation start task:


### PR DESCRIPTION
## Summary
- document observability_span_name, observability_tags, and observability_metadata on POST /api/v1/app-conversations
- add JSON examples to the Cloud API and Enterprise conversations guides

## Context
Docs companion for OpenHands/sandbox-server#3 and OpenHands/typescript-client#314.

## Testing
- inspected the changed MDX and verified the new field references with ripgrep