### PR TITLE
Document Agent Canvas 1.6 features

### DIFF
--- a/openhands/usage/agent-canvas/backend-setup/cloud.mdx
+++ b/openhands/usage/agent-canvas/backend-setup/cloud.mdx
@@ -35,6 +35,8 @@ If your organization runs OpenHands Enterprise, click **Advanced** in the Add Ba
 - **Sandboxed execution** — each conversation runs in an isolated cloud sandbox rather than on your host filesystem.
 - **Cloud integrations** — GitHub, GitLab, Bitbucket, Slack, and other integrations configured in OpenHands Cloud are available.
 - **Settings are per-backend** — LLM configuration, secrets, and MCP servers saved against the Cloud backend are independent from your local backend settings.
+- **Cloud-managed customization** — `Customize > Skills` becomes **Skills and Plugins** and opens the Cloud skills settings in a new tab. The local `Plugins` page is hidden; `MCP Servers` remains in Agent Canvas.
+- **Cloud settings links** — the `Cloud` link becomes **All Cloud Settings**, and `Integrations` opens the Cloud integrations settings in a new tab.
 
 ## Related Guides
 

--- a/openhands/usage/agent-canvas/backend-setup/cloud.mdx
+++ b/openhands/usage/agent-canvas/backend-setup/cloud.mdx
@@ -35,7 +35,7 @@ If your organization runs OpenHands Enterprise, click **Advanced** in the Add Ba
 - **Sandboxed execution** — each conversation runs in an isolated cloud sandbox rather than on your host filesystem.
 - **Cloud integrations** — GitHub, GitLab, Bitbucket, Slack, and other integrations configured in OpenHands Cloud are available.
 - **Settings are per-backend** — LLM configuration, secrets, and MCP servers saved against the Cloud backend are independent from your local backend settings.
-- **Cloud-managed customization** — `Customize > Skills` becomes **Skills and Plugins** and opens the Cloud skills settings in a new tab. The local `Plugins` page is hidden; `MCP Servers` remains in Agent Canvas.
+- **Cloud-managed customization** — `Customize > Skills` becomes **Skills and Plugins** and opens the Cloud skills settings in a new tab. The local `Plugins` page is hidden; MCP Servers are still fully managed through the Canvas UI but installed on Cloud.
 - **Cloud settings links** — the `Cloud` link becomes **All Cloud Settings**, and `Integrations` opens the Cloud integrations settings in a new tab.
 
 ## Related Guides

--- a/openhands/usage/agent-canvas/customize-and-settings.mdx
+++ b/openhands/usage/agent-canvas/customize-and-settings.mdx
@@ -58,7 +58,7 @@ The `Settings` area currently includes the following sections:
 
 On local backends, the `LLM` page also includes an `Available Profiles` area for saved profiles.
 
-In `Settings > Application`, the **Conversation titles** setting selects the LLM profile used to generate conversation titles. **Automatic** uses the active local LLM profile; choose another saved profile when you want titles generated independently from the model selected for agent work. The same page shows the installed Agent Canvas version, update availability, and a **Check for updates** button.
+In `Settings > Application`, the **Conversation titles** setting selects the LLM profile used to generate conversation titles. **Automatic** uses the active local LLM profile; you can choose another saved profile, like a small, cheap LLM, when you want titles generated independently from the model selected for agent work. The same page shows the installed Agent Canvas version, update availability, and a **Check for updates** button.
 
 Use `Settings > Agent` to choose the active Agent Profile for new conversations. OpenHands profiles reference LLM profiles from `Settings > LLM`; ACP profiles use the external agent's own model configuration.
 

--- a/openhands/usage/agent-canvas/customize-and-settings.mdx
+++ b/openhands/usage/agent-canvas/customize-and-settings.mdx
@@ -14,12 +14,34 @@ Open the top-level `Customize` area to manage:
 
 - [Skills](/overview/skills)
 - [MCP Servers](/openhands/usage/settings/mcp-settings)
+- [Plugins](/openhands/usage/agent-canvas/plugins)
 
-Use the section navigation inside `Customize` to switch between those pages.
+Use the section navigation inside `Customize` to switch between these pages.
 
 <Note>
-  MCP configuration lives under `Customize > MCP Servers`, not under `Settings`.
+  MCP Server configuration lives under `Customize > MCP Servers`, not under `Settings`.
 </Note>
+
+When using an OpenHands Cloud backend, **Skills** becomes **Skills and Plugins** and opens the Cloud settings in a new tab. The local `Plugins` page is hidden, while `MCP Servers` remains in Agent Canvas. In Settings, **Cloud** becomes **All Cloud Settings** and an **Integrations** link opens the Cloud integrations page. Switching back to a local backend restores the local navigation.
+
+### Install Skills From Chat
+
+You can install a skill from a conversation with `/add-skill <github-url>`. Because skills load when a conversation starts, Agent Canvas shows a banner after installation with **Start new conversation with this skill**. You will need to select it to start a conversation that includes the new skill.
+
+You can dismiss the banner. It appears again when you install another skill in the same session.
+
+### Check MCP Server Health
+
+Installed MCP server cards check their connection and retain the resulting status:
+
+| Status | Meaning | Available action |
+|--------|---------|------------------|
+| `Checking` | Agent Canvas is testing the server connection. | Wait for the check to finish. |
+| `Reachable` | The server responded. For a public or no-auth server, this means credentials were not verified. | Retry the check or view the server documentation. |
+| `Credential check failed` | The server responded but rejected its credentials. | Update credentials, then retry. |
+| `Connection failure` | Agent Canvas could not connect to the server. | Retry, check the configuration, or view its documentation. |
+
+Server URLs and errors redact embedded secrets. Select **Update credentials** to edit a server; saving a corrected configuration refreshes its health status without reloading the page.
 
 ## Settings
 
@@ -35,6 +57,8 @@ The `Settings` area currently includes the following sections:
 | `Secrets` | Stored secrets used by the active backend |
 
 On local backends, the `LLM` page also includes an `Available Profiles` area for saved profiles.
+
+In `Settings > Application`, the **Conversation titles** setting selects the LLM profile used to generate conversation titles. **Automatic** uses the active local LLM profile; choose another saved profile when you want titles generated independently from the model selected for agent work. The same page shows the installed Agent Canvas version, update availability, and a **Check for updates** button.
 
 Use `Settings > Agent` to choose the active Agent Profile for new conversations. OpenHands profiles reference LLM profiles from `Settings > LLM`; ACP profiles use the external agent's own model configuration.
 

--- a/openhands/usage/agent-canvas/llm-profiles.mdx
+++ b/openhands/usage/agent-canvas/llm-profiles.mdx
@@ -5,6 +5,8 @@ description: Configure models in Agent Canvas and use saved LLM profiles during 
 
 Agent Canvas supports configuring your LLM provider, model, and credentials from the UI. It also supports saved **LLM profiles**, which make it easier to switch models without re-entering provider settings each time.
 
+LLM profiles can also generate conversation titles. In `Settings > Application > Conversation titles`, leave the selection on **Automatic** to use the active local profile, or select a saved profile dedicated to title generation.
+
 ## Configure an LLM Profile
 
 Open `Settings > LLM` to add a reusable LLM profile. Use the **Basic** tab for a provider and model available in the dropdowns. Use the **Advanced** tab when you need to enter a model name and base URL directly. Use the **All** tab to view and customize the full set of model configuration fields.

--- a/openhands/usage/agent-canvas/overview.mdx
+++ b/openhands/usage/agent-canvas/overview.mdx
@@ -19,6 +19,8 @@ Choose the path that matches where and how you want your agents to run:
 | Connect to managed cloud sandboxes | [Cloud Backend](/openhands/usage/agent-canvas/backend-setup/cloud) |
 | Use Claude Code, Codex, Gemini CLI, or another ACP agent | [ACP Agents](/openhands/usage/agent-canvas/acp-agents) |
 
+You can also test a preview build of the native desktop app. [Try the desktop preview](/openhands/usage/agent-canvas/setup#desktop-app-preview-build).
+
 ## How Agent Canvas Works
 
 Agent Canvas has four pieces to understand:

--- a/openhands/usage/agent-canvas/plugins.mdx
+++ b/openhands/usage/agent-canvas/plugins.mdx
@@ -40,6 +40,15 @@ Local plugins are discovered from user-level plugin directories such as `~/.agen
   Local plugins are read-only in the Plugins page. To change or remove a local plugin, edit the files in the local plugin directory.
 </Note>
 
+## Inspect Plugin Contents
+
+Select a plugin to open its details. Alongside its metadata, the detail view can show:
+
+- **Skills in this plugin bundle** — cards for bundled skills, including command-derived skills, with their icons, names, and descriptions.
+- **Files** — an expandable directory tree. Select a file to view it inline with syntax highlighting; select it again to close the viewer.
+
+Plugin content is provided by the active backend. A backend that does not provide this data shows plugin metadata only.
+
 ## Enable or Disable Installed Plugins
 
 Enabled installed plugins are automatically available to new conversations on that backend. Disabled plugins remain installed, but they are not loaded into new conversations.

--- a/openhands/usage/agent-canvas/setup.mdx
+++ b/openhands/usage/agent-canvas/setup.mdx
@@ -306,6 +306,46 @@ Your settings and conversation data are stored outside the package or image when
 
 Uninstalling the package or image does not automatically remove your persisted data. If you want to delete local settings, secrets, and conversation history, remove the persistence directory you mounted or used, such as `~/.openhands`.
 
+## Desktop App (Preview Build)
+
+The Agent Canvas desktop app for macOS and Windows is an early preview build ready for user testing. It bundles the Node.js and `uv` runtimes, so you do not need to install prerequisites or keep a terminal open.
+
+<Note>
+  Please [join the OpenHands Slack community](https://openhands.dev/joinslack) to share feedback and [open an issue](https://github.com/OpenHands/OpenHands/issues) for problems you find while testing the preview.
+</Note>
+
+### Install and Run
+
+Download the installer for your operating system from the [OpenHands releases page](https://github.com/OpenHands/OpenHands/releases).
+
+**macOS (Apple silicon)**
+
+1. Download the `Agent-Canvas-<version>-arm64.dmg` file.
+2. Open the disk image and drag **Agent Canvas** to **Applications**.
+3. Launch Agent Canvas from Applications.
+
+Pre-built desktop releases support Apple silicon Macs. On an Intel Mac, use the npm or [from-source](#install-and-run) installation method.
+
+**Windows**
+
+1. Download the `Agent-Canvas-Setup-<version>.exe` installer.
+2. Run the installer. If Windows SmartScreen prompts you, confirm that you want to continue.
+3. Launch Agent Canvas from the Start menu.
+
+The desktop app starts its local backend automatically. During startup, select **Show details** to view and copy the live startup log. This is useful if startup takes longer than expected or fails.
+
+### Troubleshooting and Lifecycle
+
+On macOS, the app is ad-hoc signed. If macOS reports that Agent Canvas is damaged or cannot be opened, clear its quarantine attribute in Terminal, then launch it again:
+
+```bash
+xattr -d com.apple.quarantine /Applications/Agent\ Canvas.app
+```
+
+Do not use `xattr -cr`; that command does not clear this issue on macOS Sequoia.
+
+To stop the app, quit **Agent Canvas** from its application menu or window controls. To update it, download and install the latest desktop release; `Settings > Application` also shows the installed version and can check for updates. To uninstall, quit the app and move it to the Trash on macOS or uninstall it from **Installed apps** on Windows.
+
 ## Next Steps
 
 - [First Time Setup](/openhands/usage/agent-canvas/first-time-setup)


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [x] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**
Fixes https://github.com/OpenHands/docs/issues/646

### Desktop app preview

- Adds a consolidated **Desktop App (Preview Build)** section to the Agent Canvas setup guide.
- Covers macOS Apple silicon and Windows installation, bundled runtimes, startup logs, macOS quarantine recovery, updates, and uninstalling.
- Directs preview testers to join the OpenHands Slack community for feedback and file issues in the OpenHands repository.
- Links to the preview section from the Agent Canvas overview.

### Customize, settings, and Cloud behavior

- Adds Plugins to the Customize area overview.
- Documents plugin content inspection, including bundled skills and the file viewer.
- Documents the `/add-skill` restart banner and MCP server connection-health states/actions.
- Documents Cloud-specific Customize and Settings navigation.
- Documents the conversation-title LLM profile and update-availability settings.