### PR TITLE
docs: document the simple single-wildcard hostname layout

### DIFF
--- a/enterprise/analytics.mdx
+++ b/enterprise/analytics.mdx
@@ -53,7 +53,7 @@ Before you begin, complete the [Quick Start guide](/enterprise/quick-start).
       frontend:
         ingress:
           enabled: true
-          hostname: "analytics.app.<your-base-domain>"
+          hostname: "analytics.<your-base-domain>"
           tls:
             enabled: true
             secretName: "laminar-frontend-tls"
@@ -106,7 +106,7 @@ Before you begin, complete the [Quick Start guide](/enterprise/quick-start).
 
 Once the deployment status shows **Ready**, navigate to the Laminar frontend URL:
 
-- VM install: `https://analytics.app.<your-base-domain>`
+- VM install: `https://analytics.<your-base-domain>`
 - Kubernetes install: the hostname configured in `laminar.frontend.ingress.hostname`
 
 Click the **Continue with Keycloak** button:

--- a/enterprise/custom-sandbox-image.mdx
+++ b/enterprise/custom-sandbox-image.mdx
@@ -89,7 +89,7 @@ so the agent can refresh only the parts that need updating without a full rebuil
 
 Once your image is built and pushed to a registry, point the Replicated Admin Console at it.
 
-1. Open the **Admin Console** at `https://<your-base-domain>:30000`.
+1. Open the **Admin Console** at `https://admin.<your-base-domain>:30000`.
 2. Navigate to **Config** and find the **Sandbox Image** section.
 3. Set the following fields:
 

--- a/enterprise/integrations/azure-devops.mdx
+++ b/enterprise/integrations/azure-devops.mdx
@@ -39,12 +39,12 @@ In the Azure portal, create a Microsoft Entra app registration for OpenHands.
 5. Add a **Web** redirect URI:
 
    ```text
-   https://auth.app.<your-openhands-domain>/realms/allhands/broker/azure_devops/endpoint
+   https://<your-auth-hostname>/realms/allhands/broker/azure_devops/endpoint
    ```
 
-   Replace `<your-openhands-domain>` with the domain for your OpenHands
-   Enterprise installation. If you configured a custom authentication hostname,
-   use that hostname instead of `auth.app.<your-openhands-domain>`.
+   Replace `<your-auth-hostname>` with your installation's Authentication
+   hostname (`auth.<your-openhands-domain>` by default), for example
+   `https://auth.openhands.example.com/realms/allhands/broker/azure_devops/endpoint`.
 
 6. Click **Register**.
 7. Copy the **Directory (tenant) ID** and **Application (client) ID**.
@@ -200,7 +200,7 @@ To configure this pattern:
 | Symptom | Check |
 | --- | --- |
 | The Azure DevOps login option is not visible | Confirm **Azure DevOps Authentication** is enabled in the Admin Console or Helm values and the deployment has been applied. |
-| OAuth redirects fail | Confirm the Entra redirect URI exactly matches `https://auth.app.<your-openhands-domain>/realms/allhands/broker/azure_devops/endpoint`. |
+| OAuth redirects fail | Confirm the Entra redirect URI exactly matches `https://<your-auth-hostname>/realms/allhands/broker/azure_devops/endpoint`. |
 | Microsoft sign-in shows an invalid client or secret error | Confirm the Azure DevOps Client ID and Client Secret match the Microsoft Entra app registration. If the secret expired, create a new one and redeploy. |
 | Microsoft sign-in succeeds but no repositories are listed | Confirm the user has access to the Azure DevOps organization, project, and repositories. Also confirm the default organization value is the organization name only. |
 | Consent fails or Azure DevOps API calls are denied | Confirm the Entra application has the required Azure DevOps delegated permission and that admin consent has been granted if your tenant requires it. |

--- a/enterprise/integrations/bitbucket-data-center.mdx
+++ b/enterprise/integrations/bitbucket-data-center.mdx
@@ -33,19 +33,17 @@ The exact menu labels can vary by Bitbucket version, but this is usually under
 
 ![Bitbucket Data Center Application Links settings](../images/bitbucket-data-center-application-links.png)
 
-Use this callback URL:
+Use this callback URL, where `<your-auth-hostname>` is your installation's
+Authentication hostname (`auth.<your-openhands-domain>` by default):
 
 ```text
-https://auth.app.<your-openhands-domain>/realms/allhands/broker/bitbucket_data_center/endpoint
+https://<your-auth-hostname>/realms/allhands/broker/bitbucket_data_center/endpoint
 ```
 
-Replace only `<your-openhands-domain>` in the callback URL. Leave the rest of
-the path unchanged.
-
-Use your actual auth hostname, for example:
+Replace only the hostname. Leave the rest of the path unchanged, for example:
 
 ```text
-https://auth.app.openhands.example.com/realms/allhands/broker/bitbucket_data_center/endpoint
+https://auth.openhands.example.com/realms/allhands/broker/bitbucket_data_center/endpoint
 ```
 
 OpenHands requests the `REPO_ADMIN` OAuth scope so it can list repositories and
@@ -146,7 +144,7 @@ when the job starts and when it completes.
 | Symptom | Check |
 | --- | --- |
 | The Bitbucket Data Center login option is not visible | Confirm Bitbucket Data Center Authentication is enabled in the Admin Console and the deployment has been applied. |
-| OAuth redirects fail | Confirm the callback URL exactly matches `https://auth.app.<your-openhands-domain>/realms/allhands/broker/bitbucket_data_center/endpoint`. |
+| OAuth redirects fail | Confirm the callback URL exactly matches `https://<your-auth-hostname>/realms/allhands/broker/bitbucket_data_center/endpoint`. |
 | Login tries to reach an invalid `https://https://...` URL | Remove `https://` from the Bitbucket Data Center Domain field in the Admin Console. |
 | Repository webhook install fails | Confirm the user has repository admin access and the OAuth app grants `REPO_ADMIN`. |
 | Webhook delivery reaches OpenHands but no job starts | Confirm the comment contains `@openhands`, the webhook is installed for that repository, and the mentioning Bitbucket user has signed in to OpenHands. |

--- a/enterprise/k8s-install/dns-and-tls.mdx
+++ b/enterprise/k8s-install/dns-and-tls.mdx
@@ -17,12 +17,13 @@ OpenHands serves these hostnames, using `openhands.example.com` as the base doma
 | Hostname | Purpose |
 |---|---|
 | `app.openhands.example.com` | Application |
-| `auth.app.openhands.example.com` | Login (Keycloak) |
+| `auth.openhands.example.com` | Login (Keycloak) |
 | `runtime-api.openhands.example.com` | Runtime API |
-| `*.runtime.openhands.example.com` | Per-session sandboxes |
+| `<id>-runtime.openhands.example.com` | Per-session sandboxes |
 
-All of these must resolve to your ingress load balancer. The sandbox entry must be a **wildcard**
-because each session gets its own subdomain.
+All of these must resolve to your ingress load balancer. Every hostname sits one label under the
+base domain, so a single **wildcard** DNS record and certificate for `*.openhands.example.com`
+cover everything, including the dynamically named sandboxes.
 
 ## external-dns
 
@@ -48,7 +49,7 @@ With `upsert-only` and a TXT registry, external-dns only ever touches records it
 ## cert-manager
 
 cert-manager issues and renews certificates from Let's Encrypt. Use the **DNS-01** challenge, the
-only one that can issue the **wildcard** certificate the sandbox hostnames need.
+only one that can issue **wildcard** certificates.
 
 <Steps>
   <Step title="Install cert-manager">
@@ -81,25 +82,23 @@ only one that can issue the **wildcard** certificate the sandbox hostnames need.
     </Tip>
   </Step>
   <Step title="Request a wildcard certificate">
-    A single wildcard covers every sandbox host. With Traefik, serve it as the default `TLSStore` so
+    A single wildcard covers every hostname. With Traefik, serve it as the default `TLSStore` so
     no per-ingress TLS config is needed.
 
     ```yaml
     apiVersion: cert-manager.io/v1
     kind: Certificate
     metadata:
-      name: runtime-wildcard
+      name: openhands-wildcard
       namespace: openhands
     spec:
-      secretName: runtime-wildcard-tls
+      secretName: openhands-wildcard-tls
       issuerRef:
         name: letsencrypt-prod
         kind: ClusterIssuer
       dnsNames:
-        - "*.runtime.openhands.example.com"
+        - "*.openhands.example.com"
     ```
-
-    Issue certificates for the `app`, `auth`, and `runtime-api` hosts the same way.
   </Step>
 </Steps>
 
@@ -108,18 +107,16 @@ only one that can issue the **wildcard** certificate the sandbox hostnames need.
 If you don't run external-dns and cert-manager, provision these by hand and point the ingress
 controller at them.
 
-**DNS**: create a record for each hostname in the table above, all pointing to your ingress load
-balancer (typically a CNAME to the load balancer's hostname, or a cloud DNS alias). The sandbox
-record must be the wildcard `*.runtime.openhands.example.com`.
+**DNS**: create a single wildcard record `*.openhands.example.com` pointing to your ingress load
+balancer (typically a CNAME to the load balancer's hostname, or a cloud DNS alias).
 
-**TLS**: obtain certificates covering those hostnames and load them into the ingress controller as
-Kubernetes TLS secrets. A single wildcard isn't enough, because the hostnames sit at different
-depths. You need:
+**TLS**: obtain a certificate with a `*.openhands.example.com` SAN and load it into the ingress
+controller as a Kubernetes TLS secret.
 
-- `*.runtime.openhands.example.com` for the sandboxes, and
-- certificates for `app.openhands.example.com`, `auth.app.openhands.example.com`, and
-  `runtime-api.openhands.example.com` (for example a `*.openhands.example.com` wildcard, which covers
-  `app` and `runtime-api`, plus a certificate for `auth.app.openhands.example.com`).
+If you can't use a wildcard certificate, obtain one with SANs for the `app`, `auth`, and
+`runtime-api` hostnames plus `runtime.openhands.example.com`, and set
+`runtime-api.env.RUNTIME_ROUTING_MODE: "path"` in your Helm values so sandboxes are served under
+`runtime.openhands.example.com/<id>` instead of their own hostnames.
 
 ## Next Steps
 

--- a/enterprise/k8s-install/installation.mdx
+++ b/enterprise/k8s-install/installation.mdx
@@ -24,14 +24,15 @@ license automatically at install time.
   (both provided by our team)
 - **LLM credentials** from your chosen provider, for example an Anthropic API key
   from the [Anthropic Console](https://console.anthropic.com/)
-- DNS records you control, following the `app.<base-domain>` layout used
-  throughout this guide (with `openhands.example.com` as the base):
-  `app.openhands.example.com` (application), `auth.app.openhands.example.com`
-  (login), `runtime-api.openhands.example.com`, and a **wildcard**
-  `*.runtime.openhands.example.com` for runtime sandboxes. These point at your
-  cluster's ingress; see the Quick Start's
-  [DNS checks](/enterprise/quick-start#dns-checks) for the full hostname list.
-- **TLS certificates covering all of the hostnames above**, which you provide.
+- DNS records you control, following the layout used throughout this guide
+  (with `openhands.example.com` as the base domain):
+  `app.openhands.example.com` (application), `auth.openhands.example.com`
+  (login), `runtime-api.openhands.example.com`, and
+  `<id>-runtime.openhands.example.com` for the per-session sandboxes. Every
+  hostname sits one label under the base domain, so a single **wildcard**
+  record `*.openhands.example.com` pointing at your cluster's ingress covers
+  all of them; see [DNS and TLS](/enterprise/k8s-install/dns-and-tls).
+- A **wildcard TLS certificate** for `*.openhands.example.com`, which you provide.
 - An **authentication method** for user login — GitLab, Bitbucket Data Center,
   and more are supported; this guide uses a **GitHub App**. See
   [Creating a GitHub App](/enterprise/quick-start#create-a-github-app).
@@ -169,22 +170,22 @@ postgresql:
 databaseMigrations:
   createDatabases: true
 
-# Login is served by the bundled Keycloak at auth.<ingress.host> — both the
-# component and its ingress must be enabled for users to be able to log in
+# Login is served by the bundled Keycloak — both the component and its
+# ingress must be enabled for users to be able to log in
 keycloak:
   enabled: true
   ingress:
     enabled: true
-    hostname: auth.app.openhands.example.com
+    hostname: auth.openhands.example.com
     tls: false
 
 # Where agent sandboxes run. The runtime API needs its own hostname, and each
-# sandbox gets a subdomain under your wildcard DNS record.
+# sandbox gets its own hostname under your wildcard DNS record.
 sandbox:
   apiHostname: https://runtime-api.openhands.example.com
 
 env:
-  RUNTIME_URL_PATTERN: "https://{runtime_id}.runtime.openhands.example.com"
+  RUNTIME_URL_PATTERN: "https://{runtime_id}-runtime.openhands.example.com"
   LITELLM_DEFAULT_MODEL: litellm_proxy/claude-sonnet-4-5
 
 runtime-api:
@@ -198,10 +199,11 @@ runtime-api:
   databaseMigrations:
     createDatabases: true
   env:
-    # Base domain for the per-sandbox ingresses ({runtime_id}.<RUNTIME_BASE_URL>);
-    # must match RUNTIME_URL_PATTERN above. RUNTIME_DISABLE_SSL defaults to
-    # "true" — it must be "false" so sandbox URLs are served over https.
+    # Sandbox hostnames are built as {runtime_id}<separator><RUNTIME_BASE_URL>;
+    # together these must match RUNTIME_URL_PATTERN above. RUNTIME_DISABLE_SSL
+    # defaults to "true"; it must be "false" so sandbox URLs are served over https.
     RUNTIME_BASE_URL: runtime.openhands.example.com
+    RUNTIME_URL_SEPARATOR: "-"
     RUNTIME_DISABLE_SSL: "false"
     # Storage class for sandbox volumes. The chart default (standard-rwo) only
     # exists on GKE — set a storage class from `kubectl get storageclass` or

--- a/enterprise/plugin-marketplace.mdx
+++ b/enterprise/plugin-marketplace.mdx
@@ -36,7 +36,7 @@ plugins directly at `/plugins` on your application hostname.
 
     ### 1. Open the Admin Console
 
-    Navigate to `https://<your-base-domain>:30000` and log in.
+    Navigate to `https://admin.<your-base-domain>:30000` and log in.
 
     ### 2. Open the configuration page
 
@@ -110,7 +110,7 @@ plugins directly at `/plugins` on your application hostname.
 
       oidc:
         # Keycloak issuer URL — must match your Keycloak realm
-        issuerUrl: "https://auth.app.<your-base-domain>"
+        issuerUrl: "https://auth.<your-base-domain>"
         realmSecretName: "keycloak-realm"
     ```
 

--- a/enterprise/quick-start.mdx
+++ b/enterprise/quick-start.mdx
@@ -127,22 +127,32 @@ You will need a VM to host OpenHands Enterprise. Choose one of the options below
 
     Once your VM is running, configure DNS and TLS before starting the installer.
 
-    **Create DNS A records** pointing to your VM's public IP address:
+    **Create a wildcard DNS A record** pointing to your VM's public IP address:
 
     | Record | Example |
     |--------|---------|
-    | `<your-domain>` | `openhands.example.com` |
-    | `app.<your-domain>` | `app.openhands.example.com` |
-    | `analytics.app.<your-domain>` | `analytics.app.openhands.example.com` |
-    | `auth.app.<your-domain>` | `auth.app.openhands.example.com` |
-    | `llm-proxy.<your-domain>` | `llm-proxy.openhands.example.com` |
-    | `runtime-api.<your-domain>` | `runtime-api.openhands.example.com` |
-    | `*.runtime.<your-domain>` | `*.runtime.openhands.example.com` |
+    | `*.<your-domain>` | `*.openhands.example.com` |
 
-    **Obtain a TLS certificate signed by a well-known certificate authority (CA) such as Let's Encrypt**, with SANs
-    (Subject Alternative Names) for all of the above domains, then copy the certificate
+    **Obtain a wildcard TLS certificate signed by a well-known certificate authority (CA) such as Let's Encrypt**
+    for `*.<your-domain>`, then copy the certificate
     (`.pem` or `.crt`) and private key (`.pem` or `.key`) to the VM. Self-signed certificates
     are not supported for the OpenHands application.
+
+    <Accordion title="Can't use wildcard certificates?">
+      Obtain a certificate with SANs (Subject Alternative Names) for each of these hostnames:
+
+      - `admin.<your-domain>`
+      - `app.<your-domain>`
+      - `auth.<your-domain>`
+      - `analytics.<your-domain>`
+      - `llm-proxy.<your-domain>`
+      - `runtime-api.<your-domain>`
+      - `runtime.<your-domain>`
+
+      By default, each sandbox runtime gets its own dynamic hostname, which only a wildcard
+      certificate can cover. When you configure OpenHands, set **Sandbox Routing Mode** to
+      **Path-based** so all sandboxes are served under `runtime.<your-domain>` instead.
+    </Accordion>
 
     <Warning>
       If you don't provide TLS certificates during installation, the Admin Console will use a
@@ -178,27 +188,14 @@ export BASE_DOMAIN="openhands.example.com"
 ```
 Test DNS:
 ```bash
-for h in \
-  "${BASE_DOMAIN}" \
-  "app.${BASE_DOMAIN}" \
-  "analytics.app.${BASE_DOMAIN}" \
-  "auth.app.${BASE_DOMAIN}" \
-  "llm-proxy.${BASE_DOMAIN}" \
-  "runtime-api.${BASE_DOMAIN}"; do
+for h in "admin.${BASE_DOMAIN}" "app.${BASE_DOMAIN}" "test-runtime.${BASE_DOMAIN}"; do
   echo "[DNS] $h"
   getent hosts "$h" || nslookup "$h"
 done
 ```
 
-Expected: each hostname above resolves to your VM's public IP address.
-
-Test that a runtime wildcard hostname resolves:
-
-```bash
-getent hosts "test.runtime.${BASE_DOMAIN}" || nslookup "test.runtime.${BASE_DOMAIN}"
-```
-
-Expected: `test.runtime.${BASE_DOMAIN}` resolves to the same target as `${BASE_DOMAIN}`.
+Expected: each hostname resolves to your VM's public IP address through the
+wildcard record.
 
 ### Outbound connectivity checks
 
@@ -241,7 +238,7 @@ If any check fails, stop and resolve before continuing:
 | `443/TCP` inbound | Primary HTTPS entrypoint for users and service hostnames |
 | `30000/TCP` inbound | Replicated/KOTS Admin Console for install and configuration |
 | `80/TCP` inbound | HTTP entrypoint used for ingress/redirect behavior |
-| `*.runtime.<domain>` DNS + cert SAN | Runtime sandboxes are addressed by dynamic runtime-specific hostnames |
+| `*.<domain>` DNS + cert SAN | Application services and sandboxes are addressed by hostnames under the base domain |
 | `replicated.app`, `proxy.replicated.com` | Replicated control-plane/license/install paths |
 | `images.r9...`, `charts.r9...`, `updates.r9...`, `install.r9...` | Vendor distribution image/chart/update/install endpoints |
 | `traefik.github.io` | Embedded cluster ingress chart repository |
@@ -301,7 +298,7 @@ If the install command fails after preflight checks pass, run `sudo ./openhands 
 ### 4. Access the Admin Console
 
 Once the install command completes, the Admin Console is available at:
-- `https://<your-base-domain>:30000` (if you provided TLS certificates)
+- `https://admin.<your-base-domain>:30000` (if you provided TLS certificates)
 - `http://<your-vm-ip>:30000` (if you did not use the `--tls-cert` and `--tls-key` flags on the `install` command)
 
 If you did not provide TLS certificates with the `install` command, your browser will display a security warning.
@@ -312,7 +309,7 @@ Click **Advanced**, then **Proceed** to continue to the Admin Console.
 ### 5. Upload TLS certificate (if not provided with the install command)
 
 If you did not provide certificates with the `install` command, select **"Upload your own"**,
-enter your base domain under **Hostname**, upload your private key and SSL certificate, then click **Continue**.
+enter `admin.<your-base-domain>` under **Hostname**, upload your private key and SSL certificate, then click **Continue**.
 
 If you upload a private CA certificate, make sure any external webhook or OAuth provider that
 calls OpenHands also trusts that CA.
@@ -340,7 +337,7 @@ You should now see the application configuration page.
 
 ### Domain Configuration
 
-- Select **"Derive hostnames from domain (recommended)"**
+- Keep the Hostname Configuration Mode set to **"Simple (default)"**
 - Enter your base domain (e.g., `openhands.example.com`)
 
 ### Certificate Configuration

--- a/enterprise/vm-install/admin-console-configuration.mdx
+++ b/enterprise/vm-install/admin-console-configuration.mdx
@@ -12,7 +12,7 @@ Use the Replicated Admin Console to configure an OpenHands Enterprise deployment
 
 ## Open the Configuration Screen
 
-1. Open `https://<your-base-domain>:30000`.
+1. Open `https://admin.<your-base-domain>:30000`.
 2. Log in with the Admin Console password created during installation.
 3. Select `Config`.
 
@@ -34,32 +34,31 @@ Some changes restart one or more OpenHands components. Make changes during a mai
 
 ## Domain Configuration
 
-### Recommended: Derive Hostnames From One Domain
+### Recommended: Simple
 
-Use the default `Derive hostnames from domain (recommended)` mode unless your organization requires a custom hostname for each service.
+Use the default `Simple` mode unless your organization requires a custom hostname for each service.
 
-1. Leave `Hostname Configuration Mode` set to `Derive hostnames from domain (recommended)`.
+1. Leave `Hostname Configuration Mode` set to `Simple (default)`.
 2. Enter your `Base Domain`, such as `openhands.example.com`.
-3. Create DNS records and TLS coverage for the derived hostnames.
 
-For a base domain of `openhands.example.com`, OpenHands uses:
+Every hostname sits one subdomain under the base domain, so a single wildcard DNS record and TLS certificate for `*.openhands.example.com` cover all of them:
 
-| Service | Derived Hostname |
+| Service | Hostname |
 |---|---|
-| Admin Console | `openhands.example.com:30000` |
+| Admin Console | `admin.openhands.example.com:30000` |
 | OpenHands application | `app.openhands.example.com` |
-| Analytics | `analytics.app.openhands.example.com` |
-| Authentication | `auth.app.openhands.example.com` |
+| Analytics | `analytics.openhands.example.com` |
+| Authentication | `auth.openhands.example.com` |
 | LLM proxy | `llm-proxy.openhands.example.com` |
 | Runtime API | `runtime-api.openhands.example.com` |
-| Sandboxes | `*.runtime.openhands.example.com` |
+| Sandboxes | `<id>-runtime.openhands.example.com` |
 
 <Note>
-  The derived mode keeps DNS, certificates, OAuth callbacks, and webhook URLs consistent with the standard OpenHands deployment. It is the recommended path for most installations.
+  Installations created before the Simple layout run in `Legacy` mode, which nests some hostnames deeper (`auth.app.<base>`, `*.runtime.<base>`). Keep existing installs on Legacy; their certificates and OAuth callbacks were issued for those hostnames.
 </Note>
 
 <Accordion title="Customize every hostname">
-  Select `Enter all hostnames manually` only when your DNS or network requirements do not allow the derived layout.
+  Select `Manual` only when your DNS or network requirements do not allow the Simple layout.
 
   | Field | Description |
   |---|---|

--- a/sdk/guides/observability.mdx
+++ b/sdk/guides/observability.mdx
@@ -210,7 +210,7 @@ If you are running OpenHands Enterprise (OHE), you can use the same Laminar inte
 1. Complete the [OpenHands Enterprise quick start](/enterprise/quick-start).
 2. Enable analytics in the Admin Console.
 3. Deploy OHE and wait for the analytics service to become ready.
-4. Open the Laminar UI at `https://analytics.app.<your-base-domain>`.
+4. Open the Laminar UI at `https://analytics.<your-base-domain>`.
 5. Create a Laminar project and an ingest-only API key.
 6. Save that key as the **Laminar Project API Key** in the Admin Console.
 7. Redeploy, then start a conversation in OpenHands.


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [ ] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

OpenHands/OpenHands-Cloud#985 makes the Simple hostname layout the default for new installs: every hostname sits one label under the base domain, so a single `*.<base>` DNS record and wildcard certificate cover the whole install, admin console included.

This updates the install docs to match:

- The quick start and helm install guides now ask for one wildcard record and certificate instead of the per-host list, with a short "can't use wildcard certificates?" fallback (enumerated SANs plus path-based sandbox routing).
- Admin console URLs move from `<base>:30000` to `admin.<base>:30000`, since nothing answers at the apex anymore.
- The admin console configuration page documents the renamed Simple/Manual/Legacy modes and the flat hostname table.
- The keycloak callback URLs in the bitbucket and azure devops integration guides are written against the Authentication hostname (`auth.<base>` by default) instead of hardcoding the nested `auth.app.<base>`.