### PR TITLE
docs: update documentation for OpenHands v1.8.0

### DIFF
--- a/openhands/usage/settings/mcp-settings.mdx
+++ b/openhands/usage/settings/mcp-settings.mdx
@@ -193,6 +193,12 @@ Other options include:
 - **Docker-based proxies**: Containerized solutions for better isolation.
 - **Cloud-hosted MCP services**: Third-party services that provide MCP endpoints.
 
+## Manage Installed Servers
+
+In Agent Canvas, open `Customize > MCP Servers` to manage installed MCP servers. Use the control on an installed server card to disable it without deleting its configuration or saved credentials. Disabled servers are unavailable to new conversations until you enable them again.
+
+Use the editor's delete action only when you want to remove the server configuration. Editing a disabled server does not enable it.
+
 ## OAuth Authentication
 
 Some MCP servers (like Notion MCP) require OAuth authentication instead of API keys. OpenHands supports OAuth-based MCP servers through the [FastMCP](https://gofastmcp.com/) library.

--- a/overview/skills.mdx
+++ b/overview/skills.mdx
@@ -115,6 +115,8 @@ In the SDK, explicitly supplied skills override automatically loaded user and pu
 | **SDK and agent server** | Pass `Skill` objects directly or enable the user, project, and public file-based loaders in `AgentContext` |
 | **OpenHands Cloud** | Select or import skills for a conversation, including skills stored in Git repositories |
 
+In Agent Canvas, disabling a bundled or custom skill prevents it from being included in the agent context for new OpenHands and ACP conversations. Enabled skills remain available to new conversations.
+
 See [Customize and Settings](/openhands/usage/agent-canvas/customize-and-settings) for Agent Canvas and [Plugin Launcher](/openhands/usage/cloud/plugin-launcher) for loading a Git-hosted skill into an OpenHands Cloud conversation.
 
 <Warning>


### PR DESCRIPTION
Closes #672

## Documentation changes
- Document how to disable and re-enable installed MCP servers without deleting their configuration or credentials.
- Document that disabled bundled and custom skills are omitted from new OpenHands and ACP agent contexts.

## Validation
- `git diff --check`
- Verified edited MDX frontmatter

This pull request was created by an AI agent (OpenHands) on behalf of the user.