### PR TITLE
Add Enterprise 0.36.0 release notes

### DIFF
--- a/.agents/skills/ohe-release-notes.md
+++ b/.agents/skills/ohe-release-notes.md
@@ -36,7 +36,7 @@ the user to add it** before proceeding:
 ## When to use
 
 Use this skill when asked to create or update Enterprise release notes. You derive every component
-version yourself from Replicated — you do **not** ask the user for version ranges.
+version yourself from Replicated.
 
 ## What you need to determine
 
@@ -48,8 +48,6 @@ plus the derived software-agent-sdk range — is derived from the Replicated rel
 By default:
 - **new** = the latest release on the Replicated `Stable` channel
 - **previous** = the most recent release already documented at the top of `enterprise/release-notes.mdx`
-
-Confirm these two with the user before generating the page.
 
 ## Step-by-step procedure
 
@@ -95,13 +93,13 @@ The `openhands` chart version equals the Enterprise release version and lives in
 `OpenHands/OpenHands-Cloud` repo under the tag `openhands/{version}`. Read the pinned tags at both
 the **previous** and **new** versions to get each component's version range.
 
-| Component | Where the tag is pinned (in `OpenHands/OpenHands-Cloud` at `openhands/{version}`) | Notes |
-|-----------|-----------------------------------------------------------------------------------|-------|
-| **OpenHands-Cloud** (Helm chart) | the release version itself (`charts/openhands/Chart.yaml` → `version`)            | equals the Enterprise release version |
-| **Enterprise Server**            | `charts/openhands/values.yaml` → top-level `image:` → `repository: ghcr.io/openhands/enterprise-server`, `tag:` | see prefix note below |
-| **Software Agent SDK**           | `charts/openhands/charts/runtime-api/values.yaml` → `repository: ghcr.io/openhands/agent-server`, `tag: X.Y.Z-python` | strip the `-python` suffix |
-| **Runtime API**                  | `charts/openhands/charts/runtime-api/values.yaml` → top-of-file `tag:` (the runtime-api image) | tags are `vX.Y.Z` in GitHub |
-| **Automation**                   | `charts/openhands/charts/automation/values.yaml` → top-of-file `tag:`             | tags are plain `X.Y.Z` in GitHub |
+| Component                         | Where the tag is pinned (in `OpenHands/OpenHands-Cloud` at `openhands/{version}`)                                     | Notes                                   |
+|-----------------------------------|-----------------------------------------------------------------------------------------------------------------------|-----------------------------------------|
+| **OpenHands-Cloud** (Helm chart)  | the release version itself (`charts/openhands/Chart.yaml` → `version`)                                                | equals the Enterprise release version   |
+| **Enterprise Server**             | `charts/openhands/values.yaml` → top-level `image:` → `repository: ghcr.io/openhands/enterprise-server`, `tag:`       | see prefix note below                   |
+| **Software Agent SDK**            | `charts/openhands/charts/runtime-api/values.yaml` → `repository: ghcr.io/openhands/agent-server`, `tag: X.Y.Z-python` | strip the `-python` suffix              |
+| **Runtime API**                   | `charts/openhands/charts/runtime-api/values.yaml` → top-of-file `tag:` (the runtime-api image)                        | tags are `vX.Y.Z` in GitHub             |
+| **Automation**                    | `charts/openhands/charts/automation/values.yaml` → top-of-file `tag:`                                                 | tags are plain `X.Y.Z` in GitHub        |
 
 Fetch any of these files with the GitHub contents API:
 
@@ -113,15 +111,6 @@ curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
 
 Do this for both the **previous** and **new** Enterprise versions to build the range for each
 component (previous → new).
-
-> **Enterprise Server repo move + tag prefix (one-time transition):** The enterprise-server code
-> used to live in `OpenHands/OpenHands`, where the image and GitHub release tags were `cloud-X.Y.Z`.
-> It has since moved to its own repo, **`OpenHands/enterprise`**, where releases use plain semver
-> (`1.48.0`, `1.49.0`, …). Starting with Enterprise `0.36.0` the chart tag also switched from
-> `cloud-1.47.1` to plain semver (`1.49.0`). When you fetch enterprise-server release notes:
-> - Look in **`OpenHands/enterprise`** for plain-semver releases (`1.48.0`, `1.49.0`, …).
-> - For older ranges whose lower bound predates the move, the previous bound may still be a
->   `cloud-X.Y.Z` tag in `OpenHands/OpenHands`. Check both repos for the versions in your range.
 
 #### 1c. Confirm the derived versions with the user
 
@@ -141,13 +130,13 @@ ask the user to confirm, exactly as this skill does interactively. Example:
 For each component repo, list all GitHub releases and identify which fall **after** the previous
 version and **up to and including** the new version.
 
-| Component | Repo | GitHub tag format |
-|-----------|------|-------------------|
-| Enterprise Server | `OpenHands/enterprise` (moved; legacy `OpenHands/OpenHands`) | `X.Y.Z` (legacy `cloud-X.Y.Z`) |
-| Software Agent SDK | `OpenHands/software-agent-sdk` | `vX.Y.Z` |
-| Runtime API | `OpenHands/runtime-api` | `vX.Y.Z` |
-| Automation | `OpenHands/automation` | `X.Y.Z` |
-| OpenHands-Cloud | `OpenHands/OpenHands-Cloud` | `openhands/X.Y.Z` |
+| Component           | Repo                           | GitHub tag format              |
+|---------------------|--------------------------------|--------------------------------|
+| Enterprise Server   | `OpenHands/enterprise`         | `X.Y.Z` (legacy `cloud-X.Y.Z`) |
+| Software Agent SDK  | `OpenHands/software-agent-sdk` | `vX.Y.Z`                       |
+| Runtime API         | `OpenHands/runtime-api`        | `vX.Y.Z`                       |
+| Automation          | `OpenHands/automation`         | `X.Y.Z`                        |
+| OpenHands-Cloud     | `OpenHands/OpenHands-Cloud`    | `openhands/X.Y.Z`              |
 
 ```bash
 curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \

--- a/.agents/skills/ohe-release-notes.md
+++ b/.agents/skills/ohe-release-notes.md
@@ -160,7 +160,7 @@ curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
 Group bullet points **by component section**, with each section having its own Features, Bug Fixes,
 and Maintenance sub-headings. The component sections are:
 
-1. **Enterprise Server** — from `OpenHands/enterprise` (legacy: `OpenHands/OpenHands`)
+1. **Enterprise Server** — from `OpenHands/enterprise`
 2. **Software Agent SDK** — from `OpenHands/software-agent-sdk`
 3. **Runtime API** — from `OpenHands/runtime-api`
 4. **Automation** — from `OpenHands/automation`

--- a/.agents/skills/ohe-release-notes.md
+++ b/.agents/skills/ohe-release-notes.md
@@ -10,43 +10,144 @@ triggers:
 Generate a consolidated release notes page for an OpenHands Enterprise release by collecting and
 merging GitHub release notes from all component repositories into a single page under `enterprise/`.
 
+## Prerequisite: REPLICATED_API_KEY
+
+This skill derives **all** component versions automatically from the Replicated Vendor API, so it
+requires a `REPLICATED_API_KEY` environment variable with (at least) read access.
+
+**Before doing anything else, verify the key exists and works:**
+
+```bash
+if [ -z "$REPLICATED_API_KEY" ]; then
+  echo "MISSING"
+else
+  curl -s -o /dev/null -w "%{http_code}\n" \
+    -H "Authorization: $REPLICATED_API_KEY" \
+    "https://api.replicated.com/vendor/v3/apps"
+fi
+```
+
+If the variable is missing (prints `MISSING`) or the request does not return `200`, **stop and ask
+the user to add it** before proceeding:
+
+> This skill needs a `REPLICATED_API_KEY` (read access is enough) to look up the component versions
+> for each Enterprise release. Please add it as a secret and let me know when it's ready.
+
 ## When to use
 
-Use this skill when asked to create or update Enterprise release notes. The user provides version
-ranges for four components. If any are missing, ask before proceeding.
+Use this skill when asked to create or update Enterprise release notes. You derive every component
+version yourself from Replicated — you do **not** ask the user for version ranges.
 
-## Required inputs
+## What you need to determine
 
-Ask the user for **all four** component version ranges and the **Enterprise release version**:
+The only thing you truly need is **which two Enterprise releases to diff**: the `previous` release
+(already documented, usually the top `## X.Y.Z` heading in `enterprise/release-notes.mdx`) and the
+`new` release (the target you're documenting). Everything else — the four component version ranges
+plus the derived software-agent-sdk range — is derived from the Replicated release charts.
 
-| Input                      | Example                        | Description                                                      |
-|----------------------------|--------------------------------|------------------------------------------------------------------|
-| Enterprise release version | `0.24.0`                       | The version number for the `## X.X.X` heading                    |
-| automations                | `1.1.5 to 1.1.7`               | Tags in `OpenHands/automation` repo                              |
-| enterprise-server          | `cloud-1.40.1 to cloud-1.46.2` | Tags in `OpenHands/OpenHands` repo                               |
-| runtime-api                | `0.3.1 to 0.5.0`               | Tags in `OpenHands/runtime-api` repo (prefixed `v` in GitHub)    |
-| OpenHands-Cloud            | `0.13.3 to 0.24.0`             | Tags in `OpenHands/OpenHands-Cloud` repo (prefixed `openhands/`) |
+By default:
+- **new** = the latest release on the Replicated `Stable` channel
+- **previous** = the most recent release already documented at the top of `enterprise/release-notes.mdx`
 
-**software-agent-sdk** is derived automatically — you do NOT ask the user for it. See the
-"Deriving the software-agent-sdk version range" section below.
-
-If the user omits any of the four inputs above, ask:
-
-> To generate the Enterprise release notes I need the previous and new version for each component:
-> - **automations**: previous → new
-> - **enterprise-server**: previous → new (tags are `cloud-X.Y.Z` in OpenHands/OpenHands)
-> - **runtime-api**: previous → new (tags are `vX.Y.Z` in OpenHands/runtime-api)
-> - **OpenHands-Cloud**: previous → new (tags are `openhands/X.Y.Z` in OpenHands/OpenHands-Cloud)
-> - **Enterprise release version**: the version number for the heading (e.g. `0.25.0`)
+Confirm these two with the user before generating the page.
 
 ## Step-by-step procedure
 
-### 1. Identify releases in range
+### 1. Derive component versions from Replicated
+
+Each Replicated channel release bundles a set of Helm charts whose pinned image tags give you every
+component version. The Enterprise release version itself equals the `openhands` chart version (which
+is also the OpenHands-Cloud release version).
+
+#### 1a. Find the app, channel, and the two release sequences
+
+```bash
+# App id + default channel id (Stable)
+curl -s -H "Authorization: $REPLICATED_API_KEY" \
+  "https://api.replicated.com/vendor/v3/apps" \
+  | python3 -c "
+import json,sys
+for a in json.load(sys.stdin)['apps']:
+    if a['slug']=='openhands':
+        print('app', a['id'])
+        for c in a['channels']:
+            if c.get('isDefault'):
+                print('channel', c['id'], '| current', c.get('currentVersion'))
+"
+```
+
+```bash
+# List releases on the channel to find the sequence numbers for the two versions
+curl -s -H "Authorization: $REPLICATED_API_KEY" \
+  "https://api.replicated.com/vendor/v3/app/{APP_ID}/channel/{CHANNEL_ID}/releases?pageSize=50" \
+  | python3 -c "
+import json,sys
+for r in json.load(sys.stdin)['releases']:
+    print(r.get('semver'), '| seq', r.get('sequence'), '| created', r.get('created'))
+"
+```
+
+The Enterprise release version is the `semver` of the **new** release (e.g. `0.36.0`).
+
+#### 1b. Read the pinned component versions from the OpenHands-Cloud chart
+
+The `openhands` chart version equals the Enterprise release version and lives in the
+`OpenHands/OpenHands-Cloud` repo under the tag `openhands/{version}`. Read the pinned tags at both
+the **previous** and **new** versions to get each component's version range.
+
+| Component | Where the tag is pinned (in `OpenHands/OpenHands-Cloud` at `openhands/{version}`) | Notes |
+|-----------|-----------------------------------------------------------------------------------|-------|
+| **OpenHands-Cloud** (Helm chart) | the release version itself (`charts/openhands/Chart.yaml` → `version`)            | equals the Enterprise release version |
+| **Enterprise Server**            | `charts/openhands/values.yaml` → top-level `image:` → `repository: ghcr.io/openhands/enterprise-server`, `tag:` | see prefix note below |
+| **Software Agent SDK**           | `charts/openhands/charts/runtime-api/values.yaml` → `repository: ghcr.io/openhands/agent-server`, `tag: X.Y.Z-python` | strip the `-python` suffix |
+| **Runtime API**                  | `charts/openhands/charts/runtime-api/values.yaml` → top-of-file `tag:` (the runtime-api image) | tags are `vX.Y.Z` in GitHub |
+| **Automation**                   | `charts/openhands/charts/automation/values.yaml` → top-of-file `tag:`             | tags are plain `X.Y.Z` in GitHub |
+
+Fetch any of these files with the GitHub contents API:
+
+```bash
+curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
+  "https://api.github.com/repos/OpenHands/OpenHands-Cloud/contents/{path}?ref=openhands/{version}" \
+  | python3 -c "import json,sys,base64; print(base64.b64decode(json.load(sys.stdin)['content']).decode())"
+```
+
+Do this for both the **previous** and **new** Enterprise versions to build the range for each
+component (previous → new).
+
+> **Enterprise Server repo move + tag prefix (one-time transition):** The enterprise-server code
+> used to live in `OpenHands/OpenHands`, where the image and GitHub release tags were `cloud-X.Y.Z`.
+> It has since moved to its own repo, **`OpenHands/enterprise`**, where releases use plain semver
+> (`1.48.0`, `1.49.0`, …). Starting with Enterprise `0.36.0` the chart tag also switched from
+> `cloud-1.47.1` to plain semver (`1.49.0`). When you fetch enterprise-server release notes:
+> - Look in **`OpenHands/enterprise`** for plain-semver releases (`1.48.0`, `1.49.0`, …).
+> - For older ranges whose lower bound predates the move, the previous bound may still be a
+>   `cloud-X.Y.Z` tag in `OpenHands/OpenHands`. Check both repos for the versions in your range.
+
+#### 1c. Confirm the derived versions with the user
+
+Before generating the page, present the derived table (previous → new for all five components) and
+ask the user to confirm, exactly as this skill does interactively. Example:
+
+| Component | Previous | New |
+|---|---|---|
+| OpenHands-Cloud (Helm chart) | 0.28.0 | 0.36.0 |
+| Enterprise Server | 1.47.1 | 1.49.0 |
+| Software Agent SDK | 1.36.0 | 1.39.1 |
+| Runtime API | 0.5.2 | 0.7.0 |
+| Automation | 1.1.5 | 1.5.0 |
+
+### 2. Identify GitHub releases in range
 
 For each component repo, list all GitHub releases and identify which fall **after** the previous
 version and **up to and including** the new version.
 
-Use the GitHub API to list releases:
+| Component | Repo | GitHub tag format |
+|-----------|------|-------------------|
+| Enterprise Server | `OpenHands/enterprise` (moved; legacy `OpenHands/OpenHands`) | `X.Y.Z` (legacy `cloud-X.Y.Z`) |
+| Software Agent SDK | `OpenHands/software-agent-sdk` | `vX.Y.Z` |
+| Runtime API | `OpenHands/runtime-api` | `vX.Y.Z` |
+| Automation | `OpenHands/automation` | `X.Y.Z` |
+| OpenHands-Cloud | `OpenHands/OpenHands-Cloud` | `openhands/X.Y.Z` |
 
 ```bash
 curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
@@ -54,7 +155,7 @@ curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
   | python3 -c "import json,sys; [print(r['tag_name']) for r in json.load(sys.stdin)]"
 ```
 
-### 2. Fetch release notes
+### 3. Fetch release notes
 
 For each release in range, fetch the body:
 
@@ -64,45 +165,12 @@ curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
   | python3 -c "import json,sys; print(json.load(sys.stdin).get('body',''))"
 ```
 
-### 2b. Derive the software-agent-sdk version range
-
-The `software-agent-sdk` version is pinned in the OpenHands-Cloud Helm chart. To find the range:
-
-1. Fetch `charts/openhands/values.yaml` from the OpenHands-Cloud repo at the **old** OpenHands-Cloud
-   tag (the "previous" version) and the **new** tag.
-2. In each file, find the `global:` → `agentServerImage:` → `tag:` value (e.g. `1.34.0-python`).
-3. Strip the `-python` suffix to get the SDK version number (e.g. `1.34.0`).
-4. The SDK release range is everything after `v{old_version}` up to and including `v{new_version}`
-   in the `OpenHands/software-agent-sdk` repo.
-
-```bash
-# Fetch the tag from a specific OpenHands-Cloud version
-curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
-  "https://api.github.com/repos/OpenHands/OpenHands-Cloud/contents/charts/openhands/values.yaml?ref=openhands/{version}" \
-  | python3 -c "
-import json, sys, base64
-data = json.load(sys.stdin)
-content = base64.b64decode(data['content']).decode()
-lines = content.split('\n')
-in_global = False
-in_agent = False
-for line in lines:
-    if line.startswith('global:'):
-        in_global = True
-    if in_global and 'agentServerImage' in line:
-        in_agent = True
-    if in_agent and 'tag:' in line:
-        print(line.strip())
-        break
-"
-```
-
-### 3. Categorize by component
+### 4. Categorize by component
 
 Group bullet points **by component section**, with each section having its own Features, Bug Fixes,
 and Maintenance sub-headings. The component sections are:
 
-1. **Enterprise Server** — from `OpenHands/OpenHands`
+1. **Enterprise Server** — from `OpenHands/enterprise` (legacy: `OpenHands/OpenHands`)
 2. **Software Agent SDK** — from `OpenHands/software-agent-sdk`
 3. **Runtime API** — from `OpenHands/runtime-api`
 4. **OpenHands Cloud (Helm Chart)** — from `OpenHands/OpenHands-Cloud`
@@ -112,7 +180,7 @@ Within each section, sort items into:
 - **Bug Fixes** — lines starting with `* fix`
 - **Maintenance** — lines starting with `* chore`, `* ci`, `* build`, `* refactor`, `* test`, etc.
 
-### 4. Filter out noise
+### 5. Filter out noise
 
 Remove these automated/housekeeping lines that don't add value to customer-facing release notes:
 
@@ -129,7 +197,7 @@ Remove these automated/housekeeping lines that don't add value to customer-facin
 | `Release vX.Y.Z`                            | Automated release PRs in software-agent-sdk                |
 | `Verify ... model`                          | Model verification entries in software-agent-sdk           |
 
-### 5. Write the page
+### 6. Write the page
 
 Create or update `enterprise/release-notes.mdx`. Prepend the new release at the top of the file
 (after the frontmatter), so the most recent release appears first.
@@ -158,13 +226,13 @@ if it's only bug fixes, say something like "This release was focused on stabilit
 ### Enterprise Server
 
 #### Features
-* feat: ... by @author in https://github.com/OpenHands/OpenHands/pull/...
+* feat: ... by @author in https://github.com/OpenHands/enterprise/pull/...
 
 #### Bug Fixes
-* fix: ... by @author in https://github.com/OpenHands/OpenHands/pull/...
+* fix: ... by @author in https://github.com/OpenHands/enterprise/pull/...
 
 #### Maintenance
-* ci: ... by @author in https://github.com/OpenHands/OpenHands/pull/...
+* ci: ... by @author in https://github.com/OpenHands/enterprise/pull/...
 
 ---
 
@@ -205,13 +273,13 @@ if it's only bug fixes, say something like "This release was focused on stabilit
 - Keep the exact bullet text from the original release notes (author, PR link)
 - If a category has zero items after filtering, omit that sub-heading entirely
 
-### 6. Update navigation
+### 7. Update navigation
 
 Ensure `enterprise/release-notes` is listed in `docs.json` under the Enterprise tab. It should
 appear in the `"OpenHands Enterprise"` group. If it's already there (from a previous release),
 no change is needed.
 
-### 7. Commit
+### 8. Commit
 
 ```bash
 git add enterprise/release-notes.mdx docs.json

--- a/.agents/skills/ohe-release-notes.md
+++ b/.agents/skills/ohe-release-notes.md
@@ -112,10 +112,11 @@ curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
 Do this for both the **previous** and **new** Enterprise versions to build the range for each
 component (previous → new).
 
-#### 1c. Confirm the derived versions with the user
+#### 1c. Inform the user of the version jumps
 
-Before generating the page, present the derived table (previous → new for all five components) and
-ask the user to confirm, exactly as this skill does interactively. Example:
+You don't need the user to confirm before proceeding — just **inform** them of the derived version
+jumps (previous → new for all five components) so they can double-check if they want to. Present the
+table and continue generating the page. Example:
 
 | Component | Previous | New |
 |---|---|---|
@@ -162,7 +163,8 @@ and Maintenance sub-headings. The component sections are:
 1. **Enterprise Server** — from `OpenHands/enterprise` (legacy: `OpenHands/OpenHands`)
 2. **Software Agent SDK** — from `OpenHands/software-agent-sdk`
 3. **Runtime API** — from `OpenHands/runtime-api`
-4. **OpenHands Cloud (Helm Chart)** — from `OpenHands/OpenHands-Cloud`
+4. **Automation** — from `OpenHands/automation`
+5. **OpenHands Cloud (Helm Chart)** — from `OpenHands/OpenHands-Cloud`
 
 Within each section, sort items into:
 - **Features** — lines starting with `* feat`
@@ -239,6 +241,16 @@ if it's only bug fixes, say something like "This release was focused on stabilit
 
 #### Features
 * feat: ... by @author in https://github.com/OpenHands/runtime-api/pull/...
+
+---
+
+### Automation
+
+#### Features
+* feat: ... by @author in https://github.com/OpenHands/automation/pull/...
+
+#### Bug Fixes
+* fix: ... by @author in https://github.com/OpenHands/automation/pull/...
 
 ---
 

--- a/.agents/skills/ohe-release-notes.md
+++ b/.agents/skills/ohe-release-notes.md
@@ -118,13 +118,13 @@ You don't need the user to confirm before proceeding — just **inform** them of
 jumps (previous → new for all five components) so they can double-check if they want to. Present the
 table and continue generating the page. Example:
 
-| Component | Previous | New |
-|---|---|---|
-| OpenHands-Cloud (Helm chart) | 0.28.0 | 0.36.0 |
-| Enterprise Server | 1.47.1 | 1.49.0 |
-| Software Agent SDK | 1.36.0 | 1.39.1 |
-| Runtime API | 0.5.2 | 0.7.0 |
-| Automation | 1.1.5 | 1.5.0 |
+| Component                    | Previous | New    |
+|------------------------------|----------|--------|
+| OpenHands-Cloud (Helm chart) | 0.28.0   | 0.36.0 |
+| Enterprise Server            | 1.47.1   | 1.49.0 |
+| Software Agent SDK           | 1.36.0   | 1.39.1 |
+| Runtime API                  | 0.5.2    | 0.7.0  |
+| Automation                   | 1.1.5    | 1.5.0  |
 
 ### 2. Identify GitHub releases in range
 

--- a/enterprise/release-notes.mdx
+++ b/enterprise/release-notes.mdx
@@ -6,15 +6,9 @@ icon: clipboard-list
 
 ## 0.36.0
 
-This release promotes **Agent Canvas** to the default experience at `/canvas`, wired through
-Replicated/Helm installs — building on the preview shipped in 0.28.0. It also strengthens security
-(Content-Security-Policy enforcement, WebSocket authentication, and tighter secret handling),
-expands deployment flexibility (external S3 and an optional in-cluster object store, a
-single-wildcard hostname layout, and SMTP wiring), and adds Bitbucket Data Center personal repos as
-marketplace sources. The Software Agent SDK gains opt-in persistent memory across sessions and MCP
-settings management, while automation adds telemetry, capability reporting, and preflight
-validation. The remainder of the release focuses on database-pool resiliency, LLM usage-metrics
-accuracy, and runtime cleanup performance.
+This release makes the **Agent Canvas** experience available to users at `/canvas`.  As mentioned in 0.28.0 release notes, Agent Canvas will coexist with the current OpenHands Enterprise conversation interface for the time being. A future release will announce the deprecation date for the current interface, after which Agent Canvas will become the default UI.
+
+Additionally, this release improves security and adds support for Bitbucket Data Center as a supported Git provider for Skills marketplace registrations. Improvements to database-pool resiliency, LLM usage-metrics accuracy, and runtime cleanup performance have also made it into this release.
 
 ### Enterprise Server
 
@@ -175,7 +169,7 @@ accuracy, and runtime cleanup performance.
 
 ## 0.28.0
 
-This release adds the embedded **Agent Canvas** (mounted under `{your-openhands-instance.example.com}/canvas`), which will coexist with the current OpenHands Enterprise conversation interface for the time being. A future release will announce the deprecation date for the existing interface, after which Agent Canvas will become the default UI; in the meantime, teams can begin experimenting with the new Agent Canvas experience and share feedback with the OpenHands product teams.
+This release adds the embedded **Agent Canvas** endpoint (mounted under `{your-openhands-instance.example.com}/canvas`). Agent Canvas will coexist with the current OpenHands Enterprise conversation interface for the time being. A future release will announce the deprecation date for the current interface, after which Agent Canvas will become the default UI; in the meantime, teams can begin experimenting with the new Agent Canvas experience and share feedback with the OpenHands product teams.
 
 Additionally, this release brings better Helm chart validation and more configuration options to make installs easier to configure and validate. The rest of the release is focused on stability and maintenance fixes.
 

--- a/enterprise/release-notes.mdx
+++ b/enterprise/release-notes.mdx
@@ -6,7 +6,7 @@ icon: clipboard-list
 
 ## 0.36.0
 
-This release makes the **Agent Canvas** experience available to users at `/canvas`.  As mentioned in 0.28.0 release notes, Agent Canvas will coexist with the current OpenHands Enterprise conversation interface for the time being. A future release will announce the deprecation date for the current interface, after which Agent Canvas will become the default UI.
+This release makes the **Agent Canvas** experience available to users at `your-openhands-instance.acmeco.com/canvas`.  As mentioned in 0.28.0 release notes, Agent Canvas will coexist with the current OpenHands Enterprise conversation interface for the time being. A future release will announce the deprecation date for the current interface, after which Agent Canvas will become the default UI.
 
 Additionally, this release improves security and adds support for Bitbucket Data Center as a supported Git provider for Skills marketplace registrations. Improvements to database-pool resiliency, LLM usage-metrics accuracy, and runtime cleanup performance have also made it into this release.
 
@@ -169,7 +169,7 @@ Additionally, this release improves security and adds support for Bitbucket Data
 
 ## 0.28.0
 
-This release adds the embedded **Agent Canvas** endpoint (mounted under `{your-openhands-instance.example.com}/canvas`). Agent Canvas will coexist with the current OpenHands Enterprise conversation interface for the time being. A future release will announce the deprecation date for the current interface, after which Agent Canvas will become the default UI; in the meantime, teams can begin experimenting with the new Agent Canvas experience and share feedback with the OpenHands product teams.
+This release adds the embedded **Agent Canvas** endpoint (mounted under `your-openhands-instance.acmeco.com/canvas`). Agent Canvas will coexist with the current OpenHands Enterprise conversation interface for the time being. A future release will announce the deprecation date for the current interface, after which Agent Canvas will become the default UI; in the meantime, teams can begin experimenting with the new Agent Canvas experience and share feedback with the OpenHands product teams.
 
 Additionally, this release brings better Helm chart validation and more configuration options to make installs easier to configure and validate. The rest of the release is focused on stability and maintenance fixes.
 

--- a/enterprise/release-notes.mdx
+++ b/enterprise/release-notes.mdx
@@ -4,6 +4,175 @@ description: Release notes for OpenHands Enterprise
 icon: clipboard-list
 ---
 
+## 0.36.0
+
+This release promotes **Agent Canvas** to the default experience at `/canvas`, wired through
+Replicated/Helm installs — building on the preview shipped in 0.28.0. It also strengthens security
+(Content-Security-Policy enforcement, WebSocket authentication, and tighter secret handling),
+expands deployment flexibility (external S3 and an optional in-cluster object store, a
+single-wildcard hostname layout, and SMTP wiring), and adds Bitbucket Data Center personal repos as
+marketplace sources. The Software Agent SDK gains opt-in persistent memory across sessions and MCP
+settings management, while automation adds telemetry, capability reporting, and preflight
+validation. The remainder of the release focuses on database-pool resiliency, LLM usage-metrics
+accuracy, and runtime cleanup performance.
+
+### Enterprise Server
+
+#### Features
+* feat: Expose app and SDK versions in server info by @malhotra5 in https://github.com/OpenHands/OpenHands/pull/15345
+* feat: surface sandbox start-failure reason in conversation start errors by @ak684 in https://github.com/OpenHands/OpenHands/pull/14885
+* feat(settings): support title generation profile preference by @simonrosenberg in https://github.com/OpenHands/OpenHands/pull/15366
+* feat: Allow disabling redis_rate_limiter via empty RATE_LIMIT_AUTH_WINDOWS by @tofarr in https://github.com/OpenHands/enterprise/pull/97
+* feat: Enforce CSP via middleware (OHE-2815) by @tofarr in https://github.com/OpenHands/enterprise/pull/94
+
+#### Bug Fixes
+* fix(app-server): support Bitbucket Data Center personal repos as marketplace sources by @ak684 in https://github.com/OpenHands/OpenHands/pull/15334
+* fix(frontend): add jittered rate-limit backoff by @aivong-openhands in https://github.com/OpenHands/OpenHands/pull/15236
+* fix: upgraded instances with no superadmin by @tofarr in https://github.com/OpenHands/OpenHands/pull/15349
+* fix: clear member key on managed profile switch by @saurya in https://github.com/OpenHands/OpenHands/pull/15356
+* fix(enterprise): avoid rotating keys on LiteLLM non-auth errors by @saurya in https://github.com/OpenHands/OpenHands/pull/15267
+* fix(app-server): persist combined LLM usage metrics across all usage buckets by @ak684 in https://github.com/OpenHands/OpenHands/pull/15354
+* fix(app-server): prevent webhook callbacks from starving the database pool by @ak684 in https://github.com/OpenHands/OpenHands/pull/15379
+* fix: filter automation event forwarding by requested types by @malhotra5 in https://github.com/OpenHands/OpenHands/pull/15388
+* fix: enforce cloud analytics consent from TOS by @malhotra5 in https://github.com/OpenHands/enterprise/pull/79
+* fix(ci): use private bot PAT for pr-artifacts cleanup job by @jlav in https://github.com/OpenHands/enterprise/pull/88
+* fix(enterprise): atomically migrate legacy empty tool settings by @simonrosenberg in https://github.com/OpenHands/enterprise/pull/12
+* fix(settings): accept legacy detached MCP configs by @neubig in https://github.com/OpenHands/enterprise/pull/93
+
+#### Maintenance
+* test: PLTF-1269 split enterprise test_user_model into focused per-model tests by @aivong-openhands in https://github.com/OpenHands/OpenHands/pull/13997
+* chore: Suppress verbose Laminar info logs by @tofarr in https://github.com/OpenHands/OpenHands/pull/15374
+* chore: Unify release-please into a single semver release line by @mamoodi in https://github.com/OpenHands/enterprise/pull/76
+
+---
+
+### Software Agent SDK
+
+#### Features
+* feat: surface plugin contents in the agent-server plugins API by @hieptl in https://github.com/OpenHands/software-agent-sdk/pull/4103
+* Lazily hydrate persisted conversations by @neubig in https://github.com/OpenHands/software-agent-sdk/pull/4100
+* feat(agent-server): support deployment context on profile launches by @simonrosenberg in https://github.com/OpenHands/software-agent-sdk/pull/4030
+* feat(agent-server): sanitized product-analytics telemetry with split consent policy by @VascoSch92 in https://github.com/OpenHands/software-agent-sdk/pull/4172
+* feat: add opt-in persistent memory across sessions by @hieptl in https://github.com/OpenHands/software-agent-sdk/pull/4178
+* feat(marketplace): auto-load standalone marketplace skills by @ak684 in https://github.com/OpenHands/software-agent-sdk/pull/4176
+* feat(mcp): subscribe to tools/list_changed for progressive-disclosure servers by @neubig in https://github.com/OpenHands/software-agent-sdk/pull/3894
+* feat(agent-server): persist parent/child conversation relationships by @VascoSch92 in https://github.com/OpenHands/software-agent-sdk/pull/4188
+* feat: expose agent_context.load_memory in the agent-settings schema by @hieptl in https://github.com/OpenHands/software-agent-sdk/pull/4205
+* feat: publish typed Agent Server OpenAPI contract by @neubig in https://github.com/OpenHands/software-agent-sdk/pull/4229
+* feat: automate TypeScript client contract handoff by @neubig in https://github.com/OpenHands/software-agent-sdk/pull/4234
+* feat(agent-server): add MCP settings CRUD endpoints by @neubig in https://github.com/OpenHands/software-agent-sdk/pull/4294
+* feat: add MCPServer.enabled to switch a server off without removing it by @hieptl in https://github.com/OpenHands/software-agent-sdk/pull/4307
+
+#### Bug Fixes
+* fix(sdk): rehydrate persisted subscription LLMs by @lufen in https://github.com/OpenHands/software-agent-sdk/pull/4092
+* fix(observability): stamp tool_call_id onto the TOOL span by @simonrosenberg in https://github.com/OpenHands/software-agent-sdk/pull/4010
+* Fix REST API contract summary deduplication by @enyst in https://github.com/OpenHands/software-agent-sdk/pull/3918
+* fix(acp): bound ACP server startup with a timeout by @rsd-darshan in https://github.com/OpenHands/software-agent-sdk/pull/4126
+* fix(visualizer): show per-request token usage alongside cumulative by @luciobaiocchi in https://github.com/OpenHands/software-agent-sdk/pull/4146
+* fix(agent): apply filter_tools_regex to runtime tools by @VascoSch92 in https://github.com/OpenHands/software-agent-sdk/pull/4186
+* fix(sdk): accept boolean JSON Schema nodes in _process_schema_node by @VascoSch92 in https://github.com/OpenHands/software-agent-sdk/pull/4185
+* fix(sdk): mask all registered secrets, not only exported ones by @VascoSch92 in https://github.com/OpenHands/software-agent-sdk/pull/4191
+* fix(acp): persist rotated Codex credentials by @simonrosenberg in https://github.com/OpenHands/software-agent-sdk/pull/4124
+* fix(settings): restore MCP schema migration by @neubig in https://github.com/OpenHands/software-agent-sdk/pull/4013
+* fix(terminal): submit multiline PowerShell commands on Windows by @VascoSch92 in https://github.com/OpenHands/software-agent-sdk/pull/4155
+* fix(agent-server): default bind host to loopback without a session API key by @neubig in https://github.com/OpenHands/software-agent-sdk/pull/4180
+* fix: parallel tool metrics by @luciobaiocchi in https://github.com/OpenHands/software-agent-sdk/pull/4193
+* fix(agent-server): /api/vscode/url without base_url advertises the configured VSCode port by @harish-chandramowli in https://github.com/OpenHands/software-agent-sdk/pull/4181
+* fix(agent-server): require credential reactivation before cold load by @simonrosenberg in https://github.com/OpenHands/software-agent-sdk/pull/4198
+* fix(sdk): reject unknown event parents on append by @hxaxd in https://github.com/OpenHands/software-agent-sdk/pull/4089
+* fix(agent-server): redact LLM & condenser secrets in download-trajectory by @smolpaws in https://github.com/OpenHands/software-agent-sdk/pull/4217
+* fix: honor the stored memory preference on profile launches by @hieptl in https://github.com/OpenHands/software-agent-sdk/pull/4223
+* fix(agent-server): include server_base_path in the advertised VSCode URL by @harish-chandramowli in https://github.com/OpenHands/software-agent-sdk/pull/4222
+* fix(sdk): mark corrective nudge as environment event by @Sehlani042 in https://github.com/OpenHands/software-agent-sdk/pull/3954
+* fix(security): authenticate WebSockets outside URLs by @simonrosenberg in https://github.com/OpenHands/software-agent-sdk/pull/4279
+* fix(llm): generalize model capability resolution by @neubig in https://github.com/OpenHands/software-agent-sdk/pull/4200
+* fix(security): stop logging runtime command contents by @simonrosenberg in https://github.com/OpenHands/software-agent-sdk/pull/4280
+
+#### Maintenance
+* chore(deps): bump starlette from 1.0.1 to 1.3.1 by @dependabot[bot] in https://github.com/OpenHands/software-agent-sdk/pull/4140
+* chore(deps): bump pyjwt from 2.12.0 to 2.13.0 by @dependabot[bot] in https://github.com/OpenHands/software-agent-sdk/pull/4138
+* chore(deps): bump tornado from 6.5.5 to 6.5.7 by @dependabot[bot] in https://github.com/OpenHands/software-agent-sdk/pull/4139
+* chore(deps): bump python-multipart from 0.0.27 to 0.0.31 by @dependabot[bot] in https://github.com/OpenHands/software-agent-sdk/pull/4141
+* chore(deps): bump cryptography from 46.0.7 to 48.0.1 by @dependabot[bot] in https://github.com/OpenHands/software-agent-sdk/pull/4142
+* bump laminar to latest version, fix compat issues by @dinmukhamedm in https://github.com/OpenHands/software-agent-sdk/pull/4179
+* perf(agent-server): index conversation execution status for search/count by @VascoSch92 in https://github.com/OpenHands/software-agent-sdk/pull/4201
+* perf(agent-server): evict idle conversations from memory after a configurable TTL by @VascoSch92 in https://github.com/OpenHands/software-agent-sdk/pull/4202
+* Import SkillInfo from the SDK instead of redefining it in skills_router by @onatozmenn in https://github.com/OpenHands/software-agent-sdk/pull/4277
+* Move duplicated LLM option blocks into common.py by @onatozmenn in https://github.com/OpenHands/software-agent-sdk/pull/4276
+* Share the Gemini edit/write_file diff rendering by @onatozmenn in https://github.com/OpenHands/software-agent-sdk/pull/4278
+
+---
+
+### Runtime API
+
+#### Features
+* feat(cleanup): paginate cleanup_stuck_pvcs PVC list by @tofarr in https://github.com/OpenHands/runtime-api/pull/658
+* feat: surface pod scheduling/image failure reason in sandbox status by @ak684 in https://github.com/OpenHands/runtime-api/pull/615
+
+#### Bug Fixes
+* fix(cleanup): archive with actual conversation IDs by @simonrosenberg in https://github.com/OpenHands/runtime-api/pull/654
+* fix: reap runtimes stuck Pending/unschedulable by @ak684 in https://github.com/OpenHands/runtime-api/pull/655
+* fix: Optimize idle runtime cleanup pod listing by @tofarr in https://github.com/OpenHands/runtime-api/pull/662
+
+#### Maintenance
+* perf(cleanup): page snapshot_and_delete_idle_pvcs over bound PVCs by @tofarr in https://github.com/OpenHands/runtime-api/pull/660
+* build(deps): bump starlette from 0.49.1 to 1.3.1 by @dependabot[bot] in https://github.com/OpenHands/runtime-api/pull/650
+
+---
+
+### Automation
+
+#### Features
+* feat: add automation server info endpoint by @malhotra5 in https://github.com/OpenHands/automation/pull/248
+* feat: capture automation telemetry events by @malhotra5 in https://github.com/OpenHands/automation/pull/254
+* feat: expose requested automation event types by @malhotra5 in https://github.com/OpenHands/automation/pull/260
+* feat: expose automation capabilities and preflight validation by @hieptl in https://github.com/OpenHands/automation/pull/270
+
+#### Bug Fixes
+* fix: add server versions to telemetry by @malhotra5 in https://github.com/OpenHands/automation/pull/256
+* fix: normalize MCP config shapes in automation presets by @malhotra5 in https://github.com/OpenHands/automation/pull/257
+* fix: attribute PostHog events to automation actors by @neubig in https://github.com/OpenHands/automation/pull/265
+* fix(security): keep injected secrets out of commands by @simonrosenberg in https://github.com/OpenHands/automation/pull/267
+
+#### Maintenance
+* chore: Add missing index on automation_runs.automation_id by @aivong-openhands in https://github.com/OpenHands/automation/pull/250
+
+---
+
+### OpenHands Cloud (Helm Chart)
+
+#### Features
+* feat: enable the pending-runtime reaper on OHE installs by @ak684 in https://github.com/OpenHands/OpenHands-Cloud/pull/931
+* feat(charts): add external S3 file store support by @jlav in https://github.com/OpenHands/OpenHands-Cloud/pull/946
+* feat(openhands): PLTF-3258 re-add fail guard for postgresql disabled without external database by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/948
+* feat: add SMTP and budget maintenance deployment wiring by @saurya in https://github.com/OpenHands/OpenHands-Cloud/pull/780
+* feat: wire Agent Canvas through Replicated/Helm installs by @lilagrc in https://github.com/OpenHands/OpenHands-Cloud/pull/954
+* feat(rustfs): PLTF-1250 optional in-cluster object store by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/983
+* feat(charts): adopt kubernetes recommended labels by @jlav in https://github.com/OpenHands/OpenHands-Cloud/pull/960
+* feat(dns): add a simple single-wildcard hostname layout by @jlav in https://github.com/OpenHands/OpenHands-Cloud/pull/985
+
+#### Bug Fixes
+* fix(openhands): namespace-qualify bundled litellm url for sandboxes by @jlav in https://github.com/OpenHands/OpenHands-Cloud/pull/937
+* fix(openhands): validate filestore values and test external S3 env by @jlav in https://github.com/OpenHands/OpenHands-Cloud/pull/947
+* fix(openhands): PLTF-3258 scope render guards to enabled releases by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/950
+* fix: increase Replicated MinIO resource headroom by @ak684 in https://github.com/OpenHands/OpenHands-Cloud/pull/970
+* fix(integrations-hub): default admin.emails to empty by @tofarr in https://github.com/OpenHands/OpenHands-Cloud/pull/976
+* fix(budget-maintenance): disable the budget maintenance cronjob by default by @jlav in https://github.com/OpenHands/OpenHands-Cloud/pull/978
+* fix(minio): PLTF-1250 stop the bundled bucket job purging data on every upgrade by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/981
+* fix(integrations-hub): derive public base URL by @neubig in https://github.com/OpenHands/OpenHands-Cloud/pull/963
+* fix(litellm): PLTF-3363 bump pinned litellm image to 1.93.0 by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/987
+* fix(auth): extend Keycloak identity provider timeout by @ak684 in https://github.com/OpenHands/OpenHands-Cloud/pull/975
+* fix(troubleshoot): PLTF-3264 unblock support bundle exec collectors on Helm installs by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/989
+* fix(replicated): PLTF-3264 include app and license info in support bundles by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/992
+* fix(replicated): PLTF-3264 pass the SDK its pull secret in map form by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/996
+
+#### Maintenance
+* ci: PLTF-3287 sticky comment notify on openhands chart appVersion drift by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/951
+* chore(openhands-secrets): remove no-op config keys by @jlav in https://github.com/OpenHands/OpenHands-Cloud/pull/871
+* chore(openhands): remove no-op values file keys by @jlav in https://github.com/OpenHands/OpenHands-Cloud/pull/869
+* chore(openhands): pin redis master resources to effective values by @jlav in https://github.com/OpenHands/OpenHands-Cloud/pull/868
+* revert: re-enable budget maintenance by default by @saurya in https://github.com/OpenHands/OpenHands-Cloud/pull/982
+
 ## 0.28.0
 
 This release adds the embedded **Agent Canvas** (mounted under `{your-openhands-instance.example.com}/canvas`), which will coexist with the current OpenHands Enterprise conversation interface for the time being. A future release will announce the deprecation date for the existing interface, after which Agent Canvas will become the default UI; in the meantime, teams can begin experimenting with the new Agent Canvas experience and share feedback with the OpenHands product teams.


### PR DESCRIPTION
## Summary

Adds the **OpenHands Enterprise 0.36.0** release notes to `enterprise/release-notes.mdx`, and updates the `ohe-release-notes` skill so component versions are derived automatically from Replicated rather than provided by the user.

### Release notes (0.36.0)

Component versions were derived from the Replicated release charts, diffing Enterprise `0.28.0` → `0.36.0`:

| Component | Previous | New |
|---|---|---|
| OpenHands-Cloud (Helm chart) | 0.28.0 | 0.36.0 |
| Enterprise Server | 1.47.1 | 1.49.0 |
| Software Agent SDK | 1.36.0 | 1.39.1 |
| Runtime API | 0.5.2 | 0.7.0 |
| Automation | 1.1.5 | 1.5.0 |

GitHub release notes for each in-range version were collected, grouped by component (Features / Bug Fixes / Maintenance), and filtered to drop automated/housekeeping noise (release PRs, version-bump PRs, model-verification entries, backports).

### Skill updates (`.agents/skills/ohe-release-notes.md`)

- Added a **`REPLICATED_API_KEY` prerequisite check** at the top — the skill verifies the key exists and works, and asks the user to add it if missing.
- Rewrote the procedure to **derive all component versions from the Replicated Vendor API + OpenHands-Cloud chart** instead of prompting the user for version ranges.
- Documented the **enterprise-server repo move** from `OpenHands/OpenHands` (legacy `cloud-X.Y.Z` tags) to **`OpenHands/enterprise`** (plain semver), which came up while generating this release.

### Notes

- `enterprise/release-notes` is already present in the Enterprise nav group in `docs.json`, so no navigation change was needed.

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@mamoodi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/583d1a66-b493-48fc-8403-af527c141bc0)