### PR TITLE
docs: add TrustedRouter LLM provider page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -142,7 +142,8 @@
                       "openhands/usage/llms/litellm-proxy",
                       "openhands/usage/llms/moonshot",
                       "openhands/usage/llms/openai-llms",
-                      "openhands/usage/llms/openrouter"
+                      "openhands/usage/llms/openrouter",
+                      "openhands/usage/llms/trustedrouter"
                     ]
                   }
                 ]

--- a/openhands/usage/llms/trustedrouter.mdx
+++ b/openhands/usage/llms/trustedrouter.mdx
@@ -1,0 +1,20 @@
+---
+title: TrustedRouter
+description: OpenHands uses LiteLLM to make calls to chat models on TrustedRouter, an OpenAI-compatible LLM router with attested routing. You can find their documentation [here](https://trustedrouter.com/docs).
+---
+
+## Configuration
+
+TrustedRouter exposes an OpenAI-compatible endpoint, so you can access it as you
+would access any OpenAI-compatible endpoint. In the OpenHands UI through the
+Settings under the `LLM` tab:
+
+1. Enable `Advanced` options
+2. Set the following:
+   - `Custom Model` to the prefix `openai/` + the model you will be using (e.g. `openai/trustedrouter/auto`)
+   - `Base URL` to `https://api.trustedrouter.com/v1`
+   - `API Key` to your TrustedRouter API key. To find or create your API key, [see here](https://trustedrouter.com/keys).
+
+[Visit here to see the full list of TrustedRouter models](https://trustedrouter.com/models).
+Routing model ids include `trustedrouter/auto`, `trustedrouter/zdr` (zero data
+retention), and `trustedrouter/e2e` (end-to-end confidential).


### PR DESCRIPTION
Adds a TrustedRouter provider page under **LLM Configuration → LLM Providers**, following the existing OpenRouter/Groq page pattern (OpenAI-compatible endpoint via Advanced options: `openai/` custom-model prefix + base URL `https://api.trustedrouter.com/v1`).

Also registers the page in `docs.json` navigation right after OpenRouter.

Docs-only change; `docs.json` validated as JSON.