### PR TITLE
Add Enterprise 0.36.1 release notes

### DIFF
--- a/enterprise/release-notes.mdx
+++ b/enterprise/release-notes.mdx
@@ -4,6 +4,17 @@ description: Release notes for OpenHands Enterprise
 icon: clipboard-list
 ---
 
+## 0.36.1
+
+This patch release was focused on stability fixes for the Enterprise Server, including preserving user sessions during transient network failures and giving deployments the ability to disable email changes.
+
+### Enterprise Server
+
+#### Bug Fixes
+* fix(auth): preserve sessions during transient network failures by @ak684 in https://github.com/OpenHands/enterprise/pull/81
+* fix: allow deployments to disable email changes by @ak684 in https://github.com/OpenHands/enterprise/pull/110
+* fix(enterprise): fix broken import in run_budget_maintenance.py by @saurya in https://github.com/OpenHands/enterprise/pull/80
+
 ## 0.36.0
 
 This release makes the **Agent Canvas** experience available to users at `your-openhands-instance.acmeco.com/canvas`.  As mentioned in 0.28.0 release notes, Agent Canvas will coexist with the current OpenHands Enterprise conversation interface for the time being. A future release will announce the deprecation date for the current interface, after which Agent Canvas will become the default UI.


### PR DESCRIPTION
## Summary

Adds consolidated release notes for OpenHands Enterprise **0.36.1**, prepended to `enterprise/release-notes.mdx`.

This is a patch release. Component versions were derived from the Replicated `Stable` channel (release seq 1387) by extracting the bundled `openhands-0.36.1.tgz` Helm chart.

### Version jumps (0.36.0 → 0.36.1)

| Component | Previous | New |
|-----------|----------|-----|
| OpenHands-Cloud (Helm chart) | 0.36.0 | 0.36.1 |
| Enterprise Server | 1.49.0 | 1.49.0 + 3 commits (SHA `1d542f8`) |
| Software Agent SDK | 1.39.1 | 1.39.1 (unchanged) |
| Runtime API | 0.7.0 | 0.7.0 (unchanged) |
| Automation | 1.5.0 | 1.5.0 (unchanged) |

Only the **Enterprise Server** image changed. It is pinned to a commit SHA (3 commits ahead of `1.49.0`) rather than a clean release tag. Notably, the `OpenHands-Cloud` repo has no `openhands/0.36.1` tag (it jumps 0.36.0 → 0.37.0), so pinned tags were read from the chart bundled in the Replicated release itself.

### Enterprise Server bug fixes included
- fix(auth): preserve sessions during transient network failures (PR #81)
- fix: allow deployments to disable email changes (PR #110)
- fix(enterprise): fix broken import in run_budget_maintenance.py (PR #80)

### Navigation
`enterprise/release-notes` is already present in `docs.json` under the Enterprise tab — no change needed.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@mamoodi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/457baa36-af62-4831-ab65-865a543f1537)