### PR TITLE
docs: update documentation for OpenHands v1.9.0

### DIFF
--- a/openhands/usage/agent-canvas/conversations.mdx
+++ b/openhands/usage/agent-canvas/conversations.mdx
@@ -5,6 +5,14 @@ description: Work with Agent Canvas conversations, including branching from prev
 
 A conversation is a single agent session on the active backend. It has its own message history, tool calls, file changes, selected agent profile, and conversation-specific plugins.
 
+## Follow Agent Activity
+
+While an agent is running, the composer shows a live activity chip for its current unresolved action, such as reading a file or running a command. If no action-specific label is available, it shows `Thinking`. The chip disappears when the agent pauses or completes its work.
+
+## Handle a Failed Message
+
+If a message fails to send, select `Retry` to send it again or `Dismiss` to remove the failed message bubble. Dismissing a message does not restore its text to the composer.
+
 ## Branch From a Message
 
 Use `Branch from here` on a message when you want to explore a different path without changing the original conversation.

--- a/openhands/usage/agent-canvas/managing-automations.mdx
+++ b/openhands/usage/agent-canvas/managing-automations.mdx
@@ -20,6 +20,10 @@ Click an automation to open its detail view. The detail view shows:
 - LLM profile used for runs
 - Recent run history and status
 
+### Run Statuses
+
+A run can be `PENDING`, `RUNNING`, `COMPLETED`, `FAILED`, `CANCELLED`, or `SKIPPED`. A `SKIPPED` run can occur when the backend reaches its concurrency limit. Future backend statuses appear as a neutral status badge so they do not prevent you from viewing the automation.
+
 ## Enable and disable automations
 
 Toggle an automation on or off from the kebab menu (⋮) on the automation row, or from the detail view. Disabled automations do not fire on their scheduled trigger or in response to events, but their configuration is preserved.

--- a/openhands/usage/agent-canvas/prebuilt-automations.mdx
+++ b/openhands/usage/agent-canvas/prebuilt-automations.mdx
@@ -36,6 +36,8 @@ In practice, new automation setup often starts in one of two ways:
 - From a conversation, where you ask OpenHands to create an automation for you
 - From a recommended automation flow in the `Automations` view
 
+For recommended automations that support direct setup, Agent Canvas checks the active backend's capabilities and any prerequisites, then guides you through the required fields, a review step, and creation. If direct setup is unavailable, it offers a conversation-assisted setup instead. Review the proposed configuration before creating an automation.
+
 For a detailed walkthrough, see [Creating Automations](/openhands/usage/automations/creating-automations).
 
 Automations run against the active backend. Use [Manage Backends](/openhands/usage/agent-canvas/backends) to see and switch which backend your automations run on.

--- a/openhands/usage/agent-canvas/prebuilt-automations.mdx
+++ b/openhands/usage/agent-canvas/prebuilt-automations.mdx
@@ -31,12 +31,12 @@ In the `Automate` view, you can:
 
 The `Automations` view is mainly for browsing and managing automations that already exist.
 
-In practice, new automation setup often starts in one of two ways:
+In practice, new automation setup starts in one of two ways:
 
-- From a conversation, where you ask OpenHands to create an automation for you
+- From a conversation, where you ask OpenHands to `create an automation` for you
 - From a recommended automation flow in the `Automations` view
 
-For recommended automations that support direct setup, Agent Canvas checks the active backend's capabilities and any prerequisites, then guides you through the required fields, a review step, and creation. If direct setup is unavailable, it offers a conversation-assisted setup instead. Review the proposed configuration before creating an automation.
+For recommended automations that support a direct form setup, Agent Canvas checks the active backend's capabilities and any prerequisites, then guides you through the required input fields, a review step, and creation. If direct form setup is unavailable, it offers a conversation-assisted setup instead. Review the proposed configuration before creating an automation.
 
 For a detailed walkthrough, see [Creating Automations](/openhands/usage/automations/creating-automations).
 


### PR DESCRIPTION
Source issue: https://github.com/OpenHands/docs/issues/683

## Documentation changes

- Document direct recommended-automation setup, including backend capability and prerequisite checks, review before creation, and conversation-assisted fallback.
- Add automation detail run-status guidance for `CANCELLED` and `SKIPPED`, including concurrency-limit skips and neutral rendering for future statuses.
- Explain live agent activity and the `Retry`/`Dismiss` failed-message actions in conversations.

## Validation

- Passed: `uv run --with pytest pytest -q tests/test_sync_code_blocks.py tests/test_sync_use_case_automations.py` (30 passed)
- `uv run --with pytest --with requests pytest -q tests/` was also run; 34 tests passed, with 2 pre-existing errors because `tests/test_pricing_documentation.py` requests the stale URL `OpenHands/OpenHands/main/openhands/utils/llm.py` (HTTP 404).

This pull request was created by an AI agent (OpenHands) on behalf of the user.
