### PR TITLE
docs: update repository boundaries and Agent Canvas architecture

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -98,6 +98,12 @@
             "group": "Additional Documentation",
             "pages": [
               {
+                "group": "Sandbox Server",
+                "pages": [
+                  "openhands/usage/api/v1"
+                ]
+              },
+              {
                 "group": "V0 Reference",
                 "pages": [
                   "openhands/usage/v0/runtimes/V0_overview",
@@ -259,16 +265,48 @@
         "tab": "Agent Canvas",
         "pages": [
           "openhands/usage/agent-canvas/overview",
-          "openhands/usage/agent-canvas/setup",
-          "openhands/usage/agent-canvas/first-time-setup",
-          "openhands/usage/agent-canvas/llm-profiles",
-          "openhands/usage/agent-canvas/conversations",
-          "openhands/usage/agent-canvas/agent-profiles",
-          "openhands/usage/agent-canvas/plugins",
-          "openhands/usage/agent-canvas/managing-automations",
+          "openhands/usage/agent-canvas/architecture",
           {
-            "group": "Pre-built Automations",
+            "group": "Install Canvas",
             "pages": [
+              "openhands/usage/agent-canvas/setup",
+              "openhands/usage/agent-canvas/first-time-setup"
+            ]
+          },
+          {
+            "group": "Connect Backends",
+            "pages": [
+              "openhands/usage/agent-canvas/backends",
+              "openhands/usage/agent-canvas/backend-setup/local",
+              "openhands/usage/agent-canvas/backend-setup/cloud",
+              "openhands/usage/agent-canvas/backend-setup/modal"
+            ]
+          },
+          {
+            "group": "Self-Host Backend Services",
+            "pages": [
+              "openhands/usage/agent-canvas/backend-setup/vm",
+              "openhands/usage/agent-canvas/backend-setup/docker",
+              "openhands/usage/agent-canvas/backend-setup/kubernetes"
+            ]
+          },
+          {
+            "group": "Use Canvas",
+            "pages": [
+              "openhands/usage/agent-canvas/conversations",
+              "openhands/usage/agent-canvas/agent-profiles",
+              "openhands/usage/agent-canvas/llm-profiles",
+              "openhands/usage/agent-canvas/acp-agents",
+              "openhands/usage/agent-canvas/plugins",
+              "openhands/usage/agent-canvas/critic",
+              "openhands/usage/agent-canvas/customize-and-settings",
+              "openhands/usage/agent-canvas/mobile-access"
+            ]
+          },
+          {
+            "group": "Automations",
+            "pages": [
+              "openhands/usage/agent-canvas/managing-automations",
               "openhands/usage/agent-canvas/prebuilt-automations",
               "openhands/usage/agent-canvas/prebuilt/github-pr-review",
               "openhands/usage/agent-canvas/prebuilt/github-repo-monitor",
@@ -276,23 +314,12 @@
             ]
           },
           {
-            "group": "Backends",
+            "group": "Contribute And Troubleshoot",
             "pages": [
-              "openhands/usage/agent-canvas/backends",
-              "openhands/usage/agent-canvas/backend-setup/local",
-              "openhands/usage/agent-canvas/backend-setup/vm",
-              "openhands/usage/agent-canvas/backend-setup/docker",
-              "openhands/usage/agent-canvas/backend-setup/kubernetes",
-              "openhands/usage/agent-canvas/backend-setup/cloud",
-              "openhands/usage/agent-canvas/backend-setup/modal"
+              "openhands/usage/agent-canvas/development",
+              "openhands/usage/agent-canvas/troubleshooting"
             ]
-          },
-          "openhands/usage/agent-canvas/customize-and-settings",
-          "openhands/usage/agent-canvas/mobile-access",
-          "openhands/usage/agent-canvas/critic",
-          "openhands/usage/agent-canvas/acp-agents",
-          "openhands/usage/agent-canvas/development",
-          "openhands/usage/agent-canvas/troubleshooting"
+          }
         ]
       },
       {
@@ -442,7 +469,6 @@
           {
             "group": "Settings",
             "pages": [
-              "openhands/usage/settings/integrations-settings",
               "openhands/usage/settings/api-keys-settings"
             ]
           },
@@ -459,8 +485,7 @@
                 "group": "Cloud API",
                 "pages": [
                   "openhands/usage/cloud/cloud-api",
-                  "openhands/usage/cloud/plugin-launcher",
-                  "openhands/usage/api/v1"
+                  "openhands/usage/cloud/plugin-launcher"
                 ]
               }
             ]
@@ -535,13 +560,13 @@
     "links": [],
     "primary": {
       "type": "github",
-      "href": "https://github.com/OpenHands/OpenHands"
+      "href": "https://github.com/orgs/OpenHands/repositories"
     }
   },
   "footer": {
     "socials": {
       "slack": "https://openhands.dev/joinslack",
-      "github": "https://github.com/OpenHands/OpenHands"
+      "github": "https://github.com/OpenHands"
     },
     "links": [
       {

--- a/docs.json
+++ b/docs.json
@@ -274,21 +274,13 @@
             ]
           },
           {
-            "group": "Connect Backends",
+            "group": "Automations",
             "pages": [
-              "openhands/usage/agent-canvas/backends",
-              "openhands/usage/agent-canvas/backend-setup/local",
-              "openhands/usage/agent-canvas/backend-setup/remote",
-              "openhands/usage/agent-canvas/backend-setup/cloud"
-            ]
-          },
-          {
-            "group": "Self-Host Backend Services",
-            "pages": [
-              "openhands/usage/agent-canvas/backend-setup/vm",
-              "openhands/usage/agent-canvas/backend-setup/docker",
-              "openhands/usage/agent-canvas/backend-setup/kubernetes",
-              "openhands/usage/agent-canvas/backend-setup/modal"
+              "openhands/usage/agent-canvas/managing-automations",
+              "openhands/usage/agent-canvas/prebuilt-automations",
+              "openhands/usage/agent-canvas/prebuilt/github-pr-review",
+              "openhands/usage/agent-canvas/prebuilt/github-repo-monitor",
+              "openhands/usage/agent-canvas/prebuilt/slack-channel-monitor"
             ]
           },
           {
@@ -305,13 +297,21 @@
             ]
           },
           {
-            "group": "Automations",
+            "group": "Connect Backends",
             "pages": [
-              "openhands/usage/agent-canvas/managing-automations",
-              "openhands/usage/agent-canvas/prebuilt-automations",
-              "openhands/usage/agent-canvas/prebuilt/github-pr-review",
-              "openhands/usage/agent-canvas/prebuilt/github-repo-monitor",
-              "openhands/usage/agent-canvas/prebuilt/slack-channel-monitor"
+              "openhands/usage/agent-canvas/backends",
+              "openhands/usage/agent-canvas/backend-setup/local",
+              "openhands/usage/agent-canvas/backend-setup/remote",
+              "openhands/usage/agent-canvas/backend-setup/cloud"
+            ]
+          },
+          {
+            "group": "Self-Host Backend Services",
+            "pages": [
+              "openhands/usage/agent-canvas/backend-setup/vm",
+              "openhands/usage/agent-canvas/backend-setup/docker",
+              "openhands/usage/agent-canvas/backend-setup/kubernetes",
+              "openhands/usage/agent-canvas/backend-setup/modal"
             ]
           },
           {

--- a/docs.json
+++ b/docs.json
@@ -278,8 +278,8 @@
             "pages": [
               "openhands/usage/agent-canvas/backends",
               "openhands/usage/agent-canvas/backend-setup/local",
-              "openhands/usage/agent-canvas/backend-setup/cloud",
-              "openhands/usage/agent-canvas/backend-setup/modal"
+              "openhands/usage/agent-canvas/backend-setup/remote",
+              "openhands/usage/agent-canvas/backend-setup/cloud"
             ]
           },
           {
@@ -287,7 +287,8 @@
             "pages": [
               "openhands/usage/agent-canvas/backend-setup/vm",
               "openhands/usage/agent-canvas/backend-setup/docker",
-              "openhands/usage/agent-canvas/backend-setup/kubernetes"
+              "openhands/usage/agent-canvas/backend-setup/kubernetes",
+              "openhands/usage/agent-canvas/backend-setup/modal"
             ]
           },
           {

--- a/enterprise/enterprise-vs-oss.mdx
+++ b/enterprise/enterprise-vs-oss.mdx
@@ -68,9 +68,9 @@ OpenHands Enterprise is the right choice when you need:
   <Card
     title="Try Agent Canvas"
     icon="desktop"
-    href="/openhands/usage/run-openhands/local-setup#start-the-app"
+    href="/openhands/usage/agent-canvas/setup"
   >
-    Get started with OpenHands on your local machine using Docker or the CLI launcher.
+    Install Agent Canvas locally with npm, npx, Docker, or a source checkout.
   </Card>
   <Card
     title="Contact Enterprise Sales"

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -29030,13 +29030,7 @@ If you choose OpenHands, the setup flow also configures the LLM profile that the
 ### Agent Canvas Architecture
 Source: https://docs.openhands.dev/openhands/usage/agent-canvas/architecture.md
 
-Agent Canvas is the open-source browser client and control center for OpenHands conversations and automations. It presents backend state and sends requests to backend services; it is not an agent runtime or sandbox.
-
-<Warning>
-  **Agent Canvas does not execute tools.** Agent Server or an ACP agent process executes tools in the selected workspace.
-
-  **Agent Canvas does not provide sandbox isolation.** Isolation comes from the selected workspace, container, sandbox service, or remote platform.
-</Warning>
+Agent Canvas is the open-source browser client and control center for OpenHands conversations and automations. It presents backend state and sends requests to backend services; it is not an agent runtime or sandbox. Agent Server or an ACP agent process executes tools, and the selected workspace or sandbox provides the execution boundary.
 
 ## Core Components
 
@@ -29045,8 +29039,9 @@ Agent Canvas is the open-source browser client and control center for OpenHands 
 | **Agent Canvas** | Browser interface for conversations, files, settings, backends, and automations | [`OpenHands/OpenHands`](https://github.com/OpenHands/OpenHands) |
 | **Agent Server** | Runs conversations, agents, tools, and workspace operations; streams events to clients | [`OpenHands/software-agent-sdk`](https://github.com/OpenHands/software-agent-sdk/tree/main/openhands-agent-server) |
 | **Automation Server** | Stores schedules and event triggers, tracks runs, and dispatches conversations | [`OpenHands/automation`](https://github.com/OpenHands/automation) |
-| **Sandbox Server** | Creates and manages sandboxed environments that host Agent Server | [`OpenHands/sandbox-server`](https://github.com/OpenHands/sandbox-server) |
 | **Workspace or sandbox** | Defines which files, processes, credentials, and networks an agent can access | Deployment-specific |
+
+Sandbox Server is a community-driven standalone API and sandbox control plane. It is not a core Agent Canvas backend or a supported deployment option. [Learn more about Sandbox Server](https://github.com/OpenHands/sandbox-server).
 
 ## Service Relationships
 
@@ -29055,30 +29050,34 @@ Agent Canvas is the open-source browser client and control center for OpenHands 
 flowchart TB
     Browser["Browser"] --> Canvas["Agent Canvas<br/>browser client"]
 
-    Canvas -->|conversations and settings| AgentServer["Agent Server"]
-    Canvas -->|schedules, events, and runs| Automation["Automation Server"]
-    Automation -->|dispatch conversation| AgentServer
-    AgentServer -->|execute agent and tools| Workspace["Workspace or sandbox"]
+    subgraph Backend["Selected backend"]
+        AgentServer["Agent Server"] -->|execute agent and tools| Workspace["Workspace or sandbox"]
+        Automation["Automation Server"] -->|dispatch conversation| AgentServer
+    end
 
-    Canvas -.->|optional control plane| SandboxServer["Sandbox Server"]
-    SandboxServer -->|create and manage| Sandbox["Sandbox"]
-    Sandbox -->|hosts| SandboxedAgentServer["Agent Server"]
+    Canvas -->|conversations and settings| AgentServer
+    Canvas -->|schedules, events, and runs| Automation
 
-    Canvas -.->|remote backend| Remote["OpenHands Cloud or Enterprise"]
+    subgraph Platform["OpenHands Cloud or Enterprise"]
+        ControlPlane["Platform control plane"] -->|create and manage| Sandbox["Conversation sandbox"]
+        Sandbox -->|hosts| PlatformAgentServer["Agent Server"]
+    end
+
+    Canvas -.->|managed backend| PlatformAgentServer
 
     classDef primary fill:#f3e8ff,stroke:#7c3aed,stroke-width:2px
     classDef secondary fill:#e8f3ff,stroke:#2b6cb0,stroke-width:2px
     classDef tertiary fill:#fff4df,stroke:#b7791f,stroke-width:2px
     classDef service fill:#e9f9ef,stroke:#2f855a,stroke-width:2px
     class Canvas primary
-    class AgentServer,Automation,SandboxedAgentServer secondary
+    class AgentServer,Automation,PlatformAgentServer secondary
     class Workspace,Sandbox tertiary
-    class SandboxServer,Remote service
+    class ControlPlane service
 ```
 
-The normal browser path is **Browser → Agent Canvas → backend services**. Agent Server owns conversation execution. Automation Server owns scheduled and event-driven run lifecycle. A backend distribution can expose both services behind one URL, but they remain separate responsibilities.
+The normal browser path is **Browser → Agent Canvas → selected backend**. Agent Server owns conversation execution. Automation Server owns scheduled and event-driven run lifecycle. A backend distribution can expose both services behind one URL, but they remain separate responsibilities.
 
-Sandbox Server is an optional control plane. It creates sandboxes that host Agent Server, while Agent Canvas remains the client. OpenHands Cloud and OpenHands Enterprise provide remote backend and sandbox infrastructure behind their service endpoints.
+A remote backend uses the same Agent Server API as a local backend. The Agent Server can run on another machine, or in a separate container on the same machine as Canvas. OpenHands Cloud and OpenHands Enterprise are managed backend platforms: their platform control planes create conversation sandboxes that host Agent Server.
 
 ## Client And Launcher Boundaries
 
@@ -29107,8 +29106,8 @@ The workspace determines the execution boundary:
 |----------------|----------------------------------|
 | **Local process** | Agent Server and tools run directly on the backend host without container isolation. |
 | **Docker or Kubernetes** | Agent Server and tools run inside the configured container or pod with its mounts and network policy. |
-| **Sandbox Server** | The control plane creates a sandbox that hosts Agent Server and applies the configured sandbox boundary. |
-| **OpenHands Cloud or Enterprise** | The remote platform selects and manages the execution environment. |
+| **Remote Agent Server** | Agent Server runs on another machine or in a separate container, with the workspace boundary configured there. |
+| **OpenHands Cloud or Enterprise** | The managed platform creates and operates the conversation sandbox that hosts Agent Server. |
 
 Connecting Canvas to a remote backend does not grant the browser direct access to that backend's filesystem. Canvas displays files and terminal output returned by Agent Server.
 
@@ -29128,9 +29127,9 @@ Switching backends changes which backend-managed conversations, settings, automa
 | Pattern | Relationship |
 |---------|--------------|
 | **Local all-in-one** | The launcher starts Canvas and local backend services on one machine. |
-| **Split local or self-hosted** | Canvas runs separately and connects to a backend-only launcher on a workstation, VM, or cluster. |
-| **Sandbox control plane** | Canvas connects through Sandbox Server to Agent Server instances hosted in managed sandboxes. |
-| **Remote platform** | Canvas connects to OpenHands Cloud or OpenHands Enterprise endpoints. |
+| **Remote Agent Server** | Canvas connects to an Agent Server running on another machine or in a separate container on the same machine. |
+| **Self-hosted backend services** | You deploy Agent Server, and optionally Automation Server, on a VM, Docker host, Kubernetes cluster, or Modal. |
+| **Managed platform** | Canvas connects to OpenHands Cloud or OpenHands Enterprise, which operate their backend and sandbox infrastructure. |
 
 ## Next Steps
 
@@ -30193,6 +30192,54 @@ modal volume delete openhands-data
 - [VM / Self-Hosted Backend](/openhands/usage/agent-canvas/backend-setup/vm)
 - [Cloud Backend](/openhands/usage/agent-canvas/backend-setup/cloud)
 
+### Remote Backend
+Source: https://docs.openhands.dev/openhands/usage/agent-canvas/backend-setup/remote.md
+
+A remote backend is an Agent Server endpoint that runs somewhere other than the Agent Canvas client. It uses the same Agent Server API as a local backend. The backend can run on another machine, on a VM, or in a separate container on the same machine.
+
+Agent Canvas does not distinguish a remote backend by where it runs. It connects to the endpoint URL and displays the conversations, files, settings, and automations that backend provides.
+
+## What A Remote Backend Needs
+
+A remote backend must provide:
+
+- An accessible Agent Server URL.
+- An API key when the backend requires authentication.
+- A workspace or sandbox where Agent Server can execute tools.
+
+To use scheduled or event-driven automations, the backend must also provide Automation Server.
+
+## Connect To A Remote Backend
+
+1. Start or obtain the URL for the Agent Server backend.
+2. In Agent Canvas, open the backend switcher and choose `Manage Backends`.
+3. Select `Add Backend`.
+4. Enter a display name, the **Host / Base URL**, and the API key when required.
+5. Save the backend and select it.
+
+The selected backend becomes the execution environment for new conversations. Its workspace, settings, profiles, secrets, MCP servers, and automation state remain separate from other backends.
+
+<Warning>
+  Anyone who can reach Agent Server with its API key can request agent execution in that backend's workspace. Use TLS, access controls, and a high-entropy API key before exposing a backend outside a trusted network.
+</Warning>
+
+## Deployment Examples
+
+| Location | Start here |
+|----------|------------|
+| Another local process or container | [Local Backend](/openhands/usage/agent-canvas/backend-setup/local) |
+| A VM or dedicated machine | [VM / Self-Hosted Installation](/openhands/usage/agent-canvas/backend-setup/vm) |
+| Docker | [Use Docker with Agent Canvas](/openhands/usage/agent-canvas/backend-setup/docker) |
+| Kubernetes | [Kubernetes (Helm)](/openhands/usage/agent-canvas/backend-setup/kubernetes) |
+| Modal | [Modal Backend](/openhands/usage/agent-canvas/backend-setup/modal) |
+| A managed OpenHands platform | [Cloud Backend](/openhands/usage/agent-canvas/backend-setup/cloud) |
+
+## Next Steps
+
+- [Connect And Manage Backends](/openhands/usage/agent-canvas/backends)
+- [Agent Canvas Architecture](/openhands/usage/agent-canvas/architecture)
+- [Agent Server Overview](/sdk/guides/agent-server/overview)
+
 ### VM / Self-Hosted Installation
 Source: https://docs.openhands.dev/openhands/usage/agent-canvas/backend-setup/vm.md
 
@@ -30547,16 +30594,23 @@ Settings, LLM configuration, MCP servers, and automations are all scoped to the 
 
 | Setup | When to use | How |
 |-------|-------------|-----|
-| **Default local** | Quick local work on your machine | Run `agent-canvas` — a local backend is created automatically |
-| **Backend-only (local)** | Multiple projects, or separate frontend and backend processes | Run `agent-canvas --backend-only` (optionally on different ports), connect with `--frontend-only`. See [Local Backend](/openhands/usage/agent-canvas/backend-setup/local). |
-| **Self-hosted VM** | Always-on server, more powerful hardware, team-shared access, or a full self-hosted Canvas | Run `agent-canvas --backend-only --public` for backend-only mode, or `agent-canvas --public` for the full UI and backend. Expose it with SSH, ngrok, or a reverse proxy. See [VM / Self-Hosted Installation](/openhands/usage/agent-canvas/backend-setup/vm). |
-| **Cloud** | Managed sandboxes without local resources | Connect to [OpenHands Cloud](/openhands/usage/cloud/openhands-cloud) from **Manage Backends**. See [Cloud Backend](/openhands/usage/agent-canvas/backend-setup/cloud). |
-| **Modal** | Cloud backend with per-second billing, no VM management | Deploy the agent server on [Modal](https://modal.com) with a single command. See [Modal Backend](/openhands/usage/agent-canvas/backend-setup/modal). |
+| **Default local** | Quick local work on your machine | Run `agent-canvas`—a local backend is created automatically. |
+| **Remote Agent Server** | An Agent Server on another machine or in a separate local container | Add its host URL and API key in `Manage Backends`. See [Remote Backend](/openhands/usage/agent-canvas/backend-setup/remote). |
+| **Self-hosted VM** | Always-on server, more powerful hardware, team-shared access, or a full self-hosted Canvas | Run `agent-canvas --backend-only --public` for backend-only mode, or `agent-canvas --public` for the full UI and backend. See [VM / Self-Hosted Installation](/openhands/usage/agent-canvas/backend-setup/vm). |
+| **Cloud or Enterprise** | Managed backend and sandbox infrastructure | Connect from `Manage Backends`. See [Cloud Backend](/openhands/usage/agent-canvas/backend-setup/cloud). |
 
 ### Conversations
 Source: https://docs.openhands.dev/openhands/usage/agent-canvas/conversations.md
 
 A conversation is a single agent session on the active backend. It has its own message history, tool calls, file changes, selected agent profile, and conversation-specific plugins.
+
+## Follow Agent Activity
+
+While an agent is running, the composer shows a live activity chip for its current unresolved action, such as reading a file or running a command. If no action-specific label is available, it shows `Thinking`. The chip disappears when the agent pauses or completes its work.
+
+## Handle a Failed Message
+
+If a message fails to send, select `Retry` to send it again or `Dismiss` to remove the failed message bubble. Dismissing a message does not restore its text to the composer.
 
 ## Branch From a Message
 
@@ -31138,6 +31192,10 @@ Click an automation to open its detail view. The detail view shows:
 - LLM profile used for runs
 - Recent run history and status
 
+### Run Statuses
+
+A run can be `PENDING`, `RUNNING`, `COMPLETED`, `FAILED`, `CANCELLED`, or `SKIPPED`. A `SKIPPED` run can occur when the backend reaches its concurrency limit. Future backend statuses appear as a neutral status badge so they do not prevent you from viewing the automation.
+
 ## Enable and disable automations
 
 Toggle an automation on or off from the kebab menu (⋮) on the automation row, or from the detail view. Disabled automations do not fire on their scheduled trigger or in response to events, but their configuration is preserved.
@@ -31490,10 +31548,12 @@ In the `Automate` view, you can:
 
 The `Automations` view is mainly for browsing and managing automations that already exist.
 
-In practice, new automation setup often starts in one of two ways:
+In practice, new automation setup starts in one of two ways:
 
-- From a conversation, where you ask OpenHands to create an automation for you
+- From a conversation, where you ask OpenHands to `create an automation` for you
 - From a recommended automation flow in the `Automations` view
+
+For recommended automations that support a direct form setup, Agent Canvas checks the active backend's capabilities and any prerequisites, then guides you through the required input fields, a review step, and creation. If direct form setup is unavailable, it offers a conversation-assisted setup instead. Review the proposed configuration before creating an automation.
 
 For a detailed walkthrough, see [Creating Automations](/openhands/usage/automations/creating-automations).
 
@@ -43291,10 +43351,6 @@ The [Software Agent SDK](/sdk) is a composable Python library for building agent
 
 [Get started with the SDK](/sdk/getting-started) or [view the source](https://github.com/OpenHands/software-agent-sdk).
 
-## Sandbox Server
-
-[Sandbox Server](https://github.com/OpenHands/sandbox-server) is the standalone OpenHands API and sandbox control plane. It creates and manages sandboxed environments that host Agent Server. It does not bundle a frontend; use Agent Canvas as its browser client.
-
 ## OpenHands Cloud
 
 [OpenHands Cloud](/openhands/usage/cloud/openhands-cloud) is the managed commercial service for running OpenHands without operating your own backend and sandbox infrastructure. It provides hosted execution, integrations, collaboration, access controls, usage reporting, and budget management.
@@ -43307,6 +43363,11 @@ The [Software Agent SDK](/sdk) is a composable Python library for building agent
 
 Learn more at [openhands.dev/enterprise](https://openhands.dev/enterprise).
 
+## Sandbox Server
+
+[Sandbox Server](https://github.com/OpenHands/sandbox-server) is the community supported standalone OpenHands API and sandbox control plane. It creates and manages sandboxed environments that host Agent Server. It does not bundle a frontend but can be configured to use Agent Canvas as its browser client.
+
+
 ## Component And Repository Map
 
 | Component | Responsibility | Source |
@@ -43314,14 +43375,15 @@ Learn more at [openhands.dev/enterprise](https://openhands.dev/enterprise).
 | **Agent Canvas** | Browser client and control center | [`OpenHands/OpenHands`](https://github.com/OpenHands/OpenHands) |
 | **Software Agent SDK and Agent Server** | Agent framework and remote execution API | [`OpenHands/software-agent-sdk`](https://github.com/OpenHands/software-agent-sdk) |
 | **Automation Server** | Scheduled and event-driven automation lifecycle | [`OpenHands/automation`](https://github.com/OpenHands/automation) |
-| **Sandbox Server** | Standalone API and sandbox control plane | [`OpenHands/sandbox-server`](https://github.com/OpenHands/sandbox-server) |
-| **OpenHands CLI** | Terminal, IDE, and headless client | [`OpenHands/OpenHands-CLI`](https://github.com/OpenHands/OpenHands-CLI) |
 | **Documentation** | Documentation for the OpenHands ecosystem | [`OpenHands/docs`](https://github.com/OpenHands/docs) |
 | **Evaluations** | Benchmark and evaluation infrastructure | [`OpenHands/benchmarks`](https://github.com/OpenHands/benchmarks) |
 
 Each public repository includes its own license. Check the repository you use or modify instead of assuming one license applies to the entire ecosystem.
 
+
 ## Legacy
+
+The archived [`OpenHands/legacy`](https://github.com/OpenHands/legacy) snapshot also preserves the previous backend and runtime architecture for historical reference.
 
 <Accordion title="OpenHands CLI and Local GUI">
   **OpenHands CLI**
@@ -43330,18 +43392,16 @@ Each public repository includes its own license. Check the repository you use or
 
   [Check out the docs](/openhands/usage/cli/installation) or [view the source](https://github.com/OpenHands/OpenHands-CLI).
 
-  **OpenHands Local GUI**
+  **OpenHands Legacy Local GUI**
 
   The Local GUI is the deprecated Docker-based browser application from the former OpenHands monorepo. Use Agent Canvas for active browser-client development.
 
-  [Check out the legacy docs](/openhands/usage/run-openhands/local-setup) or [view the pinned source](https://github.com/OpenHands/legacy/tree/ee9e78b7defdfa744e0bbe48c9cafa90b6135ad7).
+  [View the pinned source](https://github.com/OpenHands/legacy).
 </Accordion>
-
-The archived [`OpenHands/legacy`](https://github.com/OpenHands/legacy/tree/ee9e78b7defdfa744e0bbe48c9cafa90b6135ad7) snapshot also preserves the previous backend and runtime architecture for historical reference. For active agent and Agent Server development, use the [Software Agent SDK repository](https://github.com/OpenHands/software-agent-sdk).
 
 ## Community
 
-Check the [product roadmap](https://github.com/orgs/openhands/projects/1), explore all [OpenHands repositories](https://github.com/orgs/OpenHands/repositories), or [join us on Slack](https://openhands.dev/joinslack).
+Explore all [OpenHands repositories](https://github.com/orgs/OpenHands/repositories) and [join us on Slack](https://openhands.dev/joinslack).
 
 ### Model Context Protocol (MCP)
 Source: https://docs.openhands.dev/overview/model-context-protocol.md
@@ -46070,6 +46130,77 @@ status, and model usage metrics.
 Use the events endpoint for messages, tool actions, tool observations, state
 changes, and errors. Use the current app-conversation record to reconcile
 status after a process restart or missed event.
+
+## Sandbox Status States
+
+The `sandbox_status` field indicates the lifecycle state of the sandbox. This is
+distinct from `execution_status`, which tracks the agent's task state.
+
+| Status | What it means | Can send messages | Workspace available | Notes |
+| --- | --- | --- | --- | --- |
+| `STARTING` | Sandbox is being created | No | No | Sandboxes provision on-demand |
+| `RUNNING` | Sandbox is active and ready | Yes | Yes | Normal operating state |
+| `PAUSED` | Sandbox is paused | Yes | Yes | Agent paused; sandbox still running |
+| `ERROR` | Sandbox encountered an error | No (read-only) | No | Terminal state; check UI for details |
+| `MISSING` | Sandbox was deleted/cleaned up | No (read-only) | No | Terminal state |
+
+### State Transitions
+
+```
+STARTING → RUNNING → PAUSED
+                 ↘ ERROR
+                 ↘ MISSING
+```
+
+- **STARTING → RUNNING**: Normal transition as the sandbox boots up
+- **RUNNING → PAUSED**: Happens when the agent pauses for user confirmation or
+  due to rate limits
+- **RUNNING → ERROR**: Unrecoverable error in the sandbox (e.g., container
+  failure)
+- **RUNNING → MISSING**: Sandbox was cleaned up due to idle timeout or manual
+  deletion
+
+## Execution Status
+
+The `execution_status` field indicates the agent's task state when the sandbox
+is `RUNNING`:
+
+| Status | What it means |
+| --- | --- |
+| `IDLE` | Agent is idle, waiting for input |
+| `RUNNING` | Agent is actively processing |
+| `PAUSED` | Agent has paused (e.g., waiting for confirmation mode) |
+| `WAITING_FOR_CONFIRMATION` | Agent is waiting for user to approve a high-risk action |
+| `FINISHED` | Task completed successfully |
+| `ERROR` | Task encountered an error |
+| `STUCK` | Agent appears to be stuck |
+
+## Read-Only Conversations
+
+When `sandbox_status` is `ERROR` or `MISSING`, the conversation becomes
+read-only. You can:
+
+- ✅ View the full conversation transcript
+- ✅ Scroll through all past messages and agent actions
+- ❌ Send new messages
+- ❌ Resume the sandbox
+- ❌ Access workspace files
+
+### What Gets Preserved
+
+| Artifact | Preserved after cleanup |
+| --- | --- |
+| Conversation transcript | ✅ Yes (always) |
+| Agent actions and observations | ✅ Yes (always) |
+| Workspace files | ❌ No (deleted with sandbox) |
+| Sandbox state | ❌ No (deleted with sandbox) |
+
+### Workspace Archive Capture
+
+When a sandbox is cleaned up, OpenHands captures an internal archive of the
+workspace contents. This archive is used for debugging, support, and audit
+trails (Enterprise plans). The workspace archive is an internal artifact and is
+not directly accessible to users.
 
 ## Manage Sandbox Lifecycle
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6119,43 +6119,46 @@ The **OpenHands Software Agent SDK** provides a unified, type-safe framework for
 
 Check [this document](/sdk/arch/design) for the core design principles that guided its architecture.
 
-## Relationship with OpenHands Applications
+## Relationship With OpenHands Applications
 
-The Software Agent SDK serves as the **source of truth for agents** in OpenHands. The [OpenHands repository](https://github.com/OpenHands/OpenHands) provides interfaces—web app, CLI, and cloud—that consume the SDK APIs. This architecture ensures consistency and enables flexible integration patterns.
-- **Software Agent SDK = foundation.** The SDK defines all core components: agents, LLMs, conversations, tools, workspaces, events, and security policies.
-- **Interfaces reuse SDK objects.** The OpenHands GUI or CLI hydrate SDK components from persisted settings and orchestrate execution through SDK APIs.
-- **Consistent configuration.** Whether you launch an agent programmatically or via the OpenHands GUI, the supported parameters and defaults come from the SDK.
+The Software Agent SDK is the source of truth for agents in OpenHands. Its repository also contains Agent Server, which exposes SDK conversations and workspaces to remote clients through REST and WebSocket APIs. OpenHands applications live in separate repositories and consume these SDK interfaces.
+
+- **The SDK defines agent behavior.** It provides agents, LLMs, conversations, tools, workspaces, events, and security policies.
+- **Agent Server exposes remote execution.** Clients use its APIs to run conversations and tools in the selected workspace or sandbox.
+- **Applications remain separate.** [Agent Canvas](https://github.com/OpenHands/OpenHands), the [OpenHands CLI](https://github.com/OpenHands/OpenHands-CLI), and custom clients integrate with the SDK or Agent Server without sharing one application repository.
 
 ```mermaid
 %%{init: {"theme": "default", "flowchart": {"nodeSpacing": 30, "rankSpacing": 50}} }%%
 graph TB
-    subgraph Interfaces["OpenHands Interfaces"]
-        UI[OpenHands GUI<br><i>React frontend</i>]
-        CLI[OpenHands CLI<br><i>Command-line interface</i>]
-        Custom[Your Custom Client<br><i>Automations & workflows</i>]
+    subgraph Clients["Clients"]
+        Canvas[Agent Canvas<br><i>Browser client</i>]
+        CLI[OpenHands CLI<br><i>Command-line client</i>]
+        Custom[Custom Client<br><i>Applications and workflows</i>]
     end
 
-    SDK[Software Agent SDK<br><i>openhands.sdk + tools + workspace</i>]
-    
+    Server[Agent Server<br><i>REST and WebSocket API</i>]
+    SDK[Software Agent SDK<br><i>Agents, tools, and workspaces</i>]
+
     subgraph External["External Services"]
-        LLM[LLM Providers<br><i>OpenAI, Anthropic, etc.</i>]
-        Runtime[Runtime Services<br><i>Docker, Remote API, etc.</i>]
+        LLM[LLM Providers]
+        Workspace[Workspace or Sandbox]
     end
 
-    UI --> SDK
+    Canvas --> Server
     CLI --> SDK
+    Custom --> Server
     Custom --> SDK
-    
+    Server --> SDK
     SDK --> LLM
-    SDK --> Runtime
-    
+    SDK --> Workspace
+
     classDef interface fill:#e8f3ff,stroke:#2b6cb0,stroke-width:2px
     classDef sdk fill:#f3e8ff,stroke:#7c3aed,stroke-width:2px
     classDef external fill:#fff4df,stroke:#b7791f,stroke-width:2px
-    
-    class UI,CLI,Custom interface
-    class SDK sdk
-    class LLM,Runtime external
+
+    class Canvas,CLI,Custom interface
+    class Server,SDK sdk
+    class LLM,Workspace external
 ```
 
 
@@ -22003,7 +22006,7 @@ If you are running OpenHands Enterprise (OHE), you can use the same Laminar inte
 1. Complete the [OpenHands Enterprise quick start](/enterprise/quick-start).
 2. Enable analytics in the Admin Console.
 3. Deploy OHE and wait for the analytics service to become ready.
-4. Open the Laminar UI at `https://analytics.app.<your-base-domain>`.
+4. Open the Laminar UI at `https://analytics.<your-base-domain>`.
 5. Create a Laminar project and an ingest-only API key.
 6. Save that key as the **Laminar Project API Key** in the Admin Console.
 7. Redeploy, then start a conversation in OpenHands.
@@ -28653,6 +28656,17 @@ These are some commonly used variables in V1 deployments:
   - <code>AGENT_SERVER_IMAGE_REPOSITORY</code>
   - <code>AGENT_SERVER_IMAGE_TAG</code>
 
+- **Sandbox networking (self-hosting behind a reverse proxy)**
+  - <code>SANDBOX_CONTAINER_URL_PATTERN</code> / <code>OH_SANDBOX_CONTAINER_URL_PATTERN</code>:
+    the URL pattern used to reach exposed sandbox ports, with <code>{port}</code> as a
+    placeholder (default `http://localhost:{port}`). Set this to your public
+    hostname, e.g. `https://my-domain:{port}`, when self-hosting behind a
+    reverse proxy. See [Docker Sandbox: Self-hosting behind a reverse proxy](/openhands/usage/sandboxes/docker#self-hosting-behind-a-reverse-proxy).
+  - <code>AGENT_SERVER_USE_HOST_NETWORK</code>: when <code>true</code> (also
+    <code>1</code>/<code>yes</code>), run agent-server containers in Docker host-network
+    mode so each container's ports are reachable directly on fixed host ports instead of
+    randomly assigned ones. See [Docker Sandbox: Self-hosting behind a reverse proxy](/openhands/usage/sandboxes/docker#self-hosting-behind-a-reverse-proxy).
+
 
 ## Sandbox provider selection
 
@@ -28854,7 +28868,7 @@ If you encounter issues with the search functionality:
 ### ACP Agents
 Source: https://docs.openhands.dev/openhands/usage/agent-canvas/acp-agents.md
 
-Agent Canvas can drive your conversations with the built-in **OpenHands** agent or with an external **ACP agent** — Claude Code, Codex, or Gemini CLI. This guide explains what ACP agents are, how to onboard one, and how to switch agents or models later.
+Use this guide when you want to bring Claude Code, Codex, or other agent CLIs into Agent Canvas. Agent Canvas can drive conversations with the built-in **OpenHands** agent or with an external **ACP agent**. For an ACP agent, the selected backend launches the provider's CLI and must have access to its subscription login or API key.
 
 ## What is an ACP agent?
 
@@ -28941,7 +28955,7 @@ Any stdio ACP server works: choose **Custom** in Settings → Agent and enter it
 ## Related Guides
 
 - [Customize and Settings](/openhands/usage/agent-canvas/customize-and-settings)
-- [LLM Profiles and Model Configuration](/openhands/usage/agent-canvas/llm-profiles)
+- [Manage LLM Profiles](/openhands/usage/agent-canvas/llm-profiles)
 - [Connect and Manage Backends](/openhands/usage/agent-canvas/backends)
 
 ### Agent Profiles
@@ -28949,7 +28963,7 @@ Source: https://docs.openhands.dev/openhands/usage/agent-canvas/agent-profiles.m
 
 Agent Profiles define which agent a new Agent Canvas conversation runs with. A profile can use the built-in OpenHands agent or an ACP agent such as Claude Code, Codex, or Gemini CLI.
 
-The active Agent Profile is the default agent for new conversations. You can also choose a different profile from the chat launcher before starting a conversation.
+The active Agent Profile is the default agent for new conversations.
 
 ## Agent Profiles vs LLM Profiles
 
@@ -28976,11 +28990,11 @@ From this page, you can:
 
 When you set a profile as active, new conversations use that profile by default.
 
-## Choose a Profile for a Conversation
+## Choose an Agent Profile for a Conversation
 
-On the home screen, use the agent profile picker in the chat launcher to choose the profile for the next conversation.
+Before starting a conversation, you can open the `+` tools menu in the chat launcher and select `Switch agent profile`. Choose an Agent Profile to switch to that agent, and use it for the new conversation.
 
-This selection affects the conversation you are about to start. Existing conversations keep the agent profile they were launched with.
+The LLM Model selector always remains visible in the chat launcher and allows you to select from any available LLM that the current Agent Profile supports. Once a conversation is started with an Agent Profile you are unable to switch to a different Agent Profile during the conversation.
 
 ## OpenHands Profiles
 
@@ -28999,7 +29013,7 @@ ACP profiles are useful for agents such as:
 - Gemini CLI
 - a custom ACP server
 
-The external ACP agent owns its own model and tool behavior. Agent Canvas starts the agent process and renders the conversation.
+The external ACP agent owns its own model and tool behavior. Agent Server starts and manages the ACP process, while Agent Canvas renders the conversation and profile controls.
 
 ## First-Time Setup
 
@@ -29011,7 +29025,120 @@ If you choose OpenHands, the setup flow also configures the LLM profile that the
 
 - [First Time Setup](/openhands/usage/agent-canvas/first-time-setup)
 - [ACP Agents](/openhands/usage/agent-canvas/acp-agents)
-- [LLM Profiles and Model Configuration](/openhands/usage/agent-canvas/llm-profiles)
+- [Manage LLM Profiles](/openhands/usage/agent-canvas/llm-profiles)
+
+### Agent Canvas Architecture
+Source: https://docs.openhands.dev/openhands/usage/agent-canvas/architecture.md
+
+Agent Canvas is the open-source browser client and control center for OpenHands conversations and automations. It presents backend state and sends requests to backend services; it is not an agent runtime or sandbox.
+
+<Warning>
+  **Agent Canvas does not execute tools.** Agent Server or an ACP agent process executes tools in the selected workspace.
+
+  **Agent Canvas does not provide sandbox isolation.** Isolation comes from the selected workspace, container, sandbox service, or remote platform.
+</Warning>
+
+## Core Components
+
+| Component | Responsibility | Source |
+|-----------|----------------|--------|
+| **Agent Canvas** | Browser interface for conversations, files, settings, backends, and automations | [`OpenHands/OpenHands`](https://github.com/OpenHands/OpenHands) |
+| **Agent Server** | Runs conversations, agents, tools, and workspace operations; streams events to clients | [`OpenHands/software-agent-sdk`](https://github.com/OpenHands/software-agent-sdk/tree/main/openhands-agent-server) |
+| **Automation Server** | Stores schedules and event triggers, tracks runs, and dispatches conversations | [`OpenHands/automation`](https://github.com/OpenHands/automation) |
+| **Sandbox Server** | Creates and manages sandboxed environments that host Agent Server | [`OpenHands/sandbox-server`](https://github.com/OpenHands/sandbox-server) |
+| **Workspace or sandbox** | Defines which files, processes, credentials, and networks an agent can access | Deployment-specific |
+
+## Service Relationships
+
+```mermaid
+%%{init: {"theme": "default", "flowchart": {"nodeSpacing": 30, "rankSpacing": 45}} }%%
+flowchart TB
+    Browser["Browser"] --> Canvas["Agent Canvas<br/>browser client"]
+
+    Canvas -->|conversations and settings| AgentServer["Agent Server"]
+    Canvas -->|schedules, events, and runs| Automation["Automation Server"]
+    Automation -->|dispatch conversation| AgentServer
+    AgentServer -->|execute agent and tools| Workspace["Workspace or sandbox"]
+
+    Canvas -.->|optional control plane| SandboxServer["Sandbox Server"]
+    SandboxServer -->|create and manage| Sandbox["Sandbox"]
+    Sandbox -->|hosts| SandboxedAgentServer["Agent Server"]
+
+    Canvas -.->|remote backend| Remote["OpenHands Cloud or Enterprise"]
+
+    classDef primary fill:#f3e8ff,stroke:#7c3aed,stroke-width:2px
+    classDef secondary fill:#e8f3ff,stroke:#2b6cb0,stroke-width:2px
+    classDef tertiary fill:#fff4df,stroke:#b7791f,stroke-width:2px
+    classDef service fill:#e9f9ef,stroke:#2f855a,stroke-width:2px
+    class Canvas primary
+    class AgentServer,Automation,SandboxedAgentServer secondary
+    class Workspace,Sandbox tertiary
+    class SandboxServer,Remote service
+```
+
+The normal browser path is **Browser → Agent Canvas → backend services**. Agent Server owns conversation execution. Automation Server owns scheduled and event-driven run lifecycle. A backend distribution can expose both services behind one URL, but they remain separate responsibilities.
+
+Sandbox Server is an optional control plane. It creates sandboxes that host Agent Server, while Agent Canvas remains the client. OpenHands Cloud and OpenHands Enterprise provide remote backend and sandbox infrastructure behind their service endpoints.
+
+## Client And Launcher Boundaries
+
+`Agent Canvas` can refer to two related surfaces:
+
+- **Canvas client** — The React browser application. It renders state and sends requests to backend services.
+- **`agent-canvas` launcher and distributions** — Packaging that can start the Canvas client, Agent Server, Automation Server, and ingress together.
+
+The launcher supports split modes:
+
+| Mode | Services started |
+|------|------------------|
+| `agent-canvas` | Canvas client, Agent Server, Automation Server, and ingress |
+| `agent-canvas --frontend-only` | Canvas client and ingress |
+| `agent-canvas --backend-only` | Agent Server, Automation Server, and ingress |
+
+Docker and Helm packages can also bundle the client and backend services. A bundled deployment changes how services are installed, not which component owns execution or isolation.
+
+## Execution And Isolation
+
+When you send a message, Agent Canvas sends it to the selected backend. Agent Server starts or resumes the conversation, runs the selected agent, invokes tools, updates backend state, and streams events to Canvas.
+
+The workspace determines the execution boundary:
+
+| Workspace type | Execution and isolation boundary |
+|----------------|----------------------------------|
+| **Local process** | Agent Server and tools run directly on the backend host without container isolation. |
+| **Docker or Kubernetes** | Agent Server and tools run inside the configured container or pod with its mounts and network policy. |
+| **Sandbox Server** | The control plane creates a sandbox that hosts Agent Server and applies the configured sandbox boundary. |
+| **OpenHands Cloud or Enterprise** | The remote platform selects and manages the execution environment. |
+
+Connecting Canvas to a remote backend does not grant the browser direct access to that backend's filesystem. Canvas displays files and terminal output returned by Agent Server.
+
+## State Ownership
+
+State belongs to backend services rather than the browser client:
+
+- Agent Server stores conversation history, agent and LLM profiles, secrets, MCP configuration, and related settings.
+- Automation Server stores automation definitions, schedules, events, and run history.
+- The workspace or sandbox stores files produced or changed by the agent.
+- Agent Canvas stores connection information needed to reach configured backends.
+
+Switching backends changes which backend-managed conversations, settings, automations, and workspaces Canvas displays.
+
+## Deployment Patterns
+
+| Pattern | Relationship |
+|---------|--------------|
+| **Local all-in-one** | The launcher starts Canvas and local backend services on one machine. |
+| **Split local or self-hosted** | Canvas runs separately and connects to a backend-only launcher on a workstation, VM, or cluster. |
+| **Sandbox control plane** | Canvas connects through Sandbox Server to Agent Server instances hosted in managed sandboxes. |
+| **Remote platform** | Canvas connects to OpenHands Cloud or OpenHands Enterprise endpoints. |
+
+## Next Steps
+
+- [Install Agent Canvas](/openhands/usage/agent-canvas/setup)
+- [Connect And Manage Backends](/openhands/usage/agent-canvas/backends)
+- [Self-Host On A VM](/openhands/usage/agent-canvas/backend-setup/vm)
+- [Use Docker](/openhands/usage/agent-canvas/backend-setup/docker)
+- [Agent Server Overview](/sdk/guides/agent-server/overview)
 
 ### Cloud Backend
 Source: https://docs.openhands.dev/openhands/usage/agent-canvas/backend-setup/cloud.md
@@ -29048,6 +29175,8 @@ If your organization runs OpenHands Enterprise, click **Advanced** in the Add Ba
 - **Sandboxed execution** — each conversation runs in an isolated cloud sandbox rather than on your host filesystem.
 - **Cloud integrations** — GitHub, GitLab, Bitbucket, Slack, and other integrations configured in OpenHands Cloud are available.
 - **Settings are per-backend** — LLM configuration, secrets, and MCP servers saved against the Cloud backend are independent from your local backend settings.
+- **Cloud-managed customization** — `Customize > Skills` becomes **Skills and Plugins** and opens the Cloud skills settings in a new tab. The local `Plugins` page is hidden; MCP Servers are still fully managed through the Canvas UI but installed on Cloud.
+- **Cloud settings links** — the `Cloud` link becomes **All Cloud Settings**, and `Integrations` opens the Cloud integrations settings in a new tab.
 
 ## Related Guides
 
@@ -29055,10 +29184,10 @@ If your organization runs OpenHands Enterprise, click **Advanced** in the Add Ba
 - [OpenHands Cloud](/openhands/usage/cloud/openhands-cloud)
 - [Local Backend](/openhands/usage/agent-canvas/backend-setup/local)
 
-### Docker Backend
+### Use Docker with Agent Canvas
 Source: https://docs.openhands.dev/openhands/usage/agent-canvas/backend-setup/docker.md
 
-The official Docker image packages the full Agent Canvas stack — backend and frontend — in a single container. The agent runs inside the container rather than directly on your host, giving you a sandboxed environment out of the box.
+Use Docker when you want the Agent Canvas distribution and its backend services to run in a container rather than directly on your host. The official image packages the Canvas client, Agent Server, Automation Server, and ingress in one container. Agent Server and its tools can access only the project directories and other resources you expose to the container.
 
 ## Prerequisites
 
@@ -29098,7 +29227,7 @@ Mount a persistence directory for settings, secrets, and conversation history, a
   </Tab>
 </Tabs>
 
-Agent Canvas is now running at `http://localhost:8000`. The agent can access any project under the mounted `/projects` path.
+Agent Canvas is now available at `http://localhost:8000/canvas`. The backend base URL remains `http://localhost:8000`, and the agent can access any project under the mounted `/projects` path.
 
 ### Environment Variables
 
@@ -29176,11 +29305,11 @@ Use this Helm chart for self-hosted, single-tenant setups; reach for OHE when yo
 
 ## Get the Chart
 
-The chart lives alongside the source in the `OpenHands/agent-canvas` repo. Clone it and install from the local path:
+The chart lives alongside the source in the `OpenHands/OpenHands` repository. Clone it and install from the local path:
 
 ```bash
-git clone https://github.com/OpenHands/agent-canvas.git
-cd agent-canvas
+git clone https://github.com/OpenHands/OpenHands.git
+cd OpenHands
 helm install agent-canvas ./helm/agent-canvas \
   --namespace agent-canvas --create-namespace
 ```
@@ -29599,7 +29728,7 @@ The chart's default `Service` is `ClusterIP`. Three common ways to reach the UI:
     kubectl -n agent-canvas port-forward svc/agent-canvas 8000:8000
     ```
 
-    Then open `http://localhost:8000`.
+    Then open `http://localhost:8000/canvas`.
 3. **LoadBalancer** — set `service.type: LoadBalancer` if your cloud provisions cloud load balancers for you. Cheaper than ingress for one-off installs, but skips TLS and auth.
 
 <Warning>
@@ -29639,7 +29768,7 @@ helm upgrade agent-canvas ./helm/agent-canvas -n agent-canvas -f values.yaml
 
 ### `ErrImagePull` on `ghcr.io/openhands/agent-canvas:<tag>`
 
-Verify the tag exists on GHCR — the chart's `appVersion` pins the default. To pull an image built from a specific commit, use `--set image.tag=sha-<short-sha>`. See [GHCR](https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas) for the tag list.
+Verify the tag exists on GHCR — the chart's `appVersion` pins the default. To pull an image built from a specific commit, use `--set image.tag=sha-<short-sha>`. See the [Agent Canvas package](https://github.com/orgs/OpenHands/packages/container/package/agent-canvas) for the tag list.
 
 ### WebSocket disconnects every minute
 
@@ -29661,7 +29790,7 @@ Either no `StorageClass` exists on the cluster, or the one you set doesn't provi
 
 ## Related Guides
 
-- [Docker Backend](/openhands/usage/agent-canvas/backend-setup/docker) — single-container equivalent for laptops and single-host VMs.
+- [Use Docker with Agent Canvas](/openhands/usage/agent-canvas/backend-setup/docker) — single-container equivalent for laptops and single-host VMs.
 - [VM / Self-Hosted Installation](/openhands/usage/agent-canvas/backend-setup/vm) — install directly on a Linux VM without Kubernetes.
 - [Connect and Manage Backends](/openhands/usage/agent-canvas/backends) — point a local Agent Canvas UI at a remote backend.
 
@@ -29714,12 +29843,12 @@ Switch between them from the backend selector depending on what you're working o
 
 - [Connect and Manage Backends](/openhands/usage/agent-canvas/backends)
 - [VM / Self-Hosted Installation](/openhands/usage/agent-canvas/backend-setup/vm) — backend-only or full Canvas on a remote machine
-- [Docker Backend](/openhands/usage/agent-canvas/backend-setup/docker) — run in a container
+- [Use Docker with Agent Canvas](/openhands/usage/agent-canvas/backend-setup/docker) — run in a container
 
 ### Modal Backend
 Source: https://docs.openhands.dev/openhands/usage/agent-canvas/backend-setup/modal.md
 
-Deploy the [OpenHands](https://github.com/OpenHands/OpenHands) agent server on [Modal](https://modal.com) as a remote backend for Agent Canvas. Canvas runs locally on your machine while the agent server runs on Modal and executes code inside the container — same execution model as running `npx @openhands/agent-canvas` locally.
+Deploy [Agent Server](https://github.com/OpenHands/software-agent-sdk/tree/main/openhands-agent-server) on [Modal](https://modal.com) as a remote backend for Agent Canvas. Canvas runs locally on your machine while Agent Server runs on Modal and executes code inside the container—the same execution model as the backend started by `npx @openhands/agent-canvas`.
 
 <Warning>
   The agent server runs with full access to the container's filesystem, environment, and network. Anyone with the API key can execute arbitrary code on your Modal container. Keep the API key secret and rotate it if it's ever exposed.
@@ -29835,7 +29964,7 @@ secrets = modal.Secret.from_name("openhands-server-keys")
 # canvas_ui_tool.py is required by the agent-server but ships with agent-canvas,
 # not the standalone server image. Fetch it from GitHub during image build.
 TOOLS_REMOTE_DIR = "/opt/canvas-tools"
-CANVAS_UI_TOOL_URL = "https://raw.githubusercontent.com/OpenHands/agent-canvas/main/tools/canvas_ui_tool.py"
+CANVAS_UI_TOOL_URL = "https://raw.githubusercontent.com/OpenHands/OpenHands/main/tools/canvas_ui_tool.py"
 
 agent_server_image = (
     modal.Image.from_registry(
@@ -30060,7 +30189,7 @@ modal volume delete openhands-data
 
 - [Connect and Manage Backends](/openhands/usage/agent-canvas/backends)
 - [Local Backend](/openhands/usage/agent-canvas/backend-setup/local)
-- [Docker Backend](/openhands/usage/agent-canvas/backend-setup/docker)
+- [Use Docker with Agent Canvas](/openhands/usage/agent-canvas/backend-setup/docker)
 - [VM / Self-Hosted Backend](/openhands/usage/agent-canvas/backend-setup/vm)
 - [Cloud Backend](/openhands/usage/agent-canvas/backend-setup/cloud)
 
@@ -30399,14 +30528,14 @@ Before exposing Agent Canvas beyond an SSH tunnel:
 - [Install](/openhands/usage/agent-canvas/setup)
 - [Connect and Manage Backends](/openhands/usage/agent-canvas/backends)
 - [Local Backend](/openhands/usage/agent-canvas/backend-setup/local)
-- [Docker Backend](/openhands/usage/agent-canvas/backend-setup/docker)
+- [Use Docker with Agent Canvas](/openhands/usage/agent-canvas/backend-setup/docker)
 - [Kubernetes (Helm)](/openhands/usage/agent-canvas/backend-setup/kubernetes)
 - [Cloud Backend](/openhands/usage/agent-canvas/backend-setup/cloud)
 
 ### Backends
 Source: https://docs.openhands.dev/openhands/usage/agent-canvas/backends.md
 
-A **backend** is an [agent server](/sdk/guides/agent-server/overview#what-is-a-remote-agent-server) and the workspace it operates in. All conversations, settings, and automations run against whichever backend is currently selected.
+A **backend** provides Agent Server and, when automations are enabled, Automation Server. Agent Server runs conversations and tools in a workspace: the folder, mounted project directory, container, or cloud sandbox where the agent reads and writes files. Automation Server manages schedules, events, and run lifecycle. Agent Canvas connects to these services and displays the state of whichever backend is selected.
 
 ## Connecting to a Backend
 
@@ -30487,7 +30616,7 @@ For example:
 /goal --max 3 add unit tests for the parser and verify they pass
 ```
 
-When you start a goal, Agent Canvas runs the agent and uses a judge LLM to check whether the objective is complete after each round. If the judge finds missing work, Agent Canvas sends that feedback back to the agent and continues until the goal is complete or the maximum number of rounds is reached.
+When you start a goal, Agent Canvas requests a goal run from Agent Server. Agent Server runs the agent and uses a judge LLM to check whether the objective is complete after each round. If the judge finds missing work, Agent Server sends that feedback to the agent and continues until the goal is complete or the maximum number of rounds is reached.
 
 While a goal is running, Agent Canvas shows a status banner with the objective, current round, status, judge score, and any missing work. When the goal finishes, the final status appears inline in the conversation history.
 
@@ -30676,7 +30805,7 @@ If the critic request fails with an API key or authentication error:
 ## Related Guides
 
 - [Customize and Settings](/openhands/usage/agent-canvas/customize-and-settings)
-- [LLM Profiles and Model Configuration](/openhands/usage/agent-canvas/llm-profiles)
+- [Manage LLM Profiles](/openhands/usage/agent-canvas/llm-profiles)
 - [OpenHands LLMs](/openhands/usage/llms/openhands-llms)
 - [SDK Critic Guide](/sdk/guides/critic)
 - [Critic Model Blog Post](https://openhands.dev/blog/sota-on-swe-bench-verified-with-inference-time-scaling-and-critic-model)
@@ -30696,12 +30825,34 @@ Open the top-level `Customize` area to manage:
 
 - [Skills](/overview/skills)
 - [MCP Servers](/openhands/usage/settings/mcp-settings)
+- [Plugins](/openhands/usage/agent-canvas/plugins)
 
-Use the section navigation inside `Customize` to switch between those pages.
+Use the section navigation inside `Customize` to switch between these pages.
 
 <Note>
-  MCP configuration lives under `Customize > MCP Servers`, not under `Settings`.
+  MCP Server configuration lives under `Customize > MCP Servers`, not under `Settings`.
 </Note>
+
+When using an OpenHands Cloud backend, **Skills** becomes **Skills and Plugins** and opens the Cloud settings in a new tab. The local `Plugins` page is hidden, while `MCP Servers` remains in Agent Canvas. In Settings, **Cloud** becomes **All Cloud Settings** and an **Integrations** link opens the Cloud integrations page. Switching back to a local backend restores the local navigation.
+
+### Install Skills From Chat
+
+You can install a skill from a conversation with `/add-skill <github-url>`. Because skills load when a conversation starts, Agent Canvas shows a banner after installation with **Start new conversation with this skill**. You will need to select it to start a conversation that includes the new skill.
+
+You can dismiss the banner. It appears again when you install another skill in the same session.
+
+### Check MCP Server Health
+
+Installed MCP server cards check their connection and retain the resulting status:
+
+| Status | Meaning | Available action |
+|--------|---------|------------------|
+| `Checking` | Agent Canvas is testing the server connection. | Wait for the check to finish. |
+| `Reachable` | The server responded. For a public or no-auth server, this means credentials were not verified. | Retry the check or view the server documentation. |
+| `Credential check failed` | The server responded but rejected its credentials. | Update credentials, then retry. |
+| `Connection failure` | Agent Canvas could not connect to the server. | Retry, check the configuration, or view its documentation. |
+
+Server URLs and errors redact embedded secrets. Select **Update credentials** to edit a server; saving a corrected configuration refreshes its health status without reloading the page.
 
 ## Settings
 
@@ -30718,7 +30869,19 @@ The `Settings` area currently includes the following sections:
 
 On local backends, the `LLM` page also includes an `Available Profiles` area for saved profiles.
 
+In `Settings > Application`, the **Conversation titles** setting selects the LLM profile used to generate conversation titles. **Automatic** uses the active local LLM profile; you can choose another saved profile, like a small, cheap LLM, when you want titles generated independently from the model selected for agent work. The same page shows the installed Agent Canvas version, update availability, and a **Check for updates** button.
+
 Use `Settings > Agent` to choose the active Agent Profile for new conversations. OpenHands profiles reference LLM profiles from `Settings > LLM`; ACP profiles use the external agent's own model configuration.
+
+### Persistent Agent Memory
+
+Open `Settings > Agent Context` to control persistent agent memory. When enabled, new OpenHands and ACP conversations can load saved memory from the workspace and user memory locations into their agent context.
+
+Disable it when you do not want new conversations to load that persistent memory.
+
+<Note>
+  Learn more about the Persistent Memory implementation from the SDK Guide: [Persistent Memory](/sdk/guides/persistent-memory)
+</Note>
 
 ## Configuration Is Per Backend
 
@@ -30752,8 +30915,8 @@ Agent Canvas is open source. To work on it from source:
 
 1. Clone the repo and install dependencies:
     ```bash
-    git clone https://github.com/OpenHands/agent-canvas.git
-    cd agent-canvas
+    git clone https://github.com/OpenHands/OpenHands.git
+    cd OpenHands
     npm install
     ```
 
@@ -30762,7 +30925,7 @@ Agent Canvas is open source. To work on it from source:
     npm run dev
     ```
 
-For development workflows, environment variables, testing, and advanced configuration, see the [Development Guide](https://github.com/OpenHands/agent-canvas/blob/main/docs/DEVELOPMENT.md) in the repository.
+For development workflows, environment variables, testing, and advanced configuration, see the [Development Guide](https://github.com/OpenHands/OpenHands/blob/main/docs/DEVELOPMENT.md) in the repository.
 
 ### First Time Setup
 Source: https://docs.openhands.dev/openhands/usage/agent-canvas/first-time-setup.md
@@ -30834,19 +30997,71 @@ Other available templates include:
 
 You can browse all pre-built automations from the `Automate` view at any time. See [Pre-built Automations](/openhands/usage/agent-canvas/prebuilt-automations) for the full list.
 
-### LLM Profiles and Model Configuration
+## After Your First Session
+
+Keep the terminal or Docker container that runs Agent Canvas active while you use the browser. When you are done, [stop Agent Canvas](/openhands/usage/agent-canvas/setup#stop-agent-canvas). Start it again with the same command when you return.
+
+For routine maintenance, see [update and uninstall](/openhands/usage/agent-canvas/setup#update-agent-canvas). If the UI, backend, or model does not work as expected, start with [Troubleshooting](/openhands/usage/agent-canvas/troubleshooting).
+
+### Manage LLM Profiles
 Source: https://docs.openhands.dev/openhands/usage/agent-canvas/llm-profiles.md
 
 Agent Canvas supports configuring your LLM provider, model, and credentials from the UI. It also supports saved **LLM profiles**, which make it easier to switch models without re-entering provider settings each time.
 
-## Where to Configure Models
+LLM profiles can also generate conversation titles. In `Settings > Application > Conversation titles`, leave the selection on **Automatic** to use the active local profile, or select a saved profile dedicated to title generation.
 
-Open `Settings > LLM` to:
+## Configure an LLM Profile
 
-- choose a provider
-- select or enter a model
-- add the required API key
-- save reusable LLM profiles
+Open `Settings > LLM` to add a reusable LLM profile. Use the **Basic** tab for a provider and model available in the dropdowns. Use the **Advanced** tab when you need to enter a model name and base URL directly. Use the **All** tab to view and customize the full set of model configuration fields.
+
+<Note>
+ACP agents such as Claude Code, Codex, and Gemini CLI manage their own model access. See [ACP Agents](/openhands/usage/agent-canvas/acp-agents) instead.
+</Note>
+
+### Choose a Configuration Path
+
+| I have | Profile tab | Configure |
+|---|---|---|
+| An API key from Anthropic, OpenAI, Google, or another provider | **Basic** | Select the provider and model, then add its API key. |
+| An OpenHands LLM API key | **Basic** | Select `OpenHands`, choose a model, and add your OpenHands LLM API key. |
+| A local OpenAI-compatible server | **Advanced** | Enter the provider, exact model ID, base URL, and any required API key. |
+| A LiteLLM proxy | **Advanced** | Use the `litellm_proxy/` model prefix, proxy base URL, and proxy API key. |
+
+### Direct Provider
+
+In the **Basic** tab, select your provider and model, add the API key issued by that provider, and save the profile. Use a new conversation to test the change; an existing conversation continues with the agent and model it started with.
+
+For provider and model recommendations, see [LLM Configuration](/openhands/usage/llms/llms).
+
+### OpenHands Provider
+
+Use an OpenHands LLM API key when you want Agent Canvas to access models through the OpenHands provider:
+
+1. Copy your LLM API key from [OpenHands Cloud](https://app.all-hands.dev/settings/api-keys).
+2. In the **Basic** tab, select `OpenHands`, choose a model, and add the key.
+3. Save the profile and start a new conversation.
+
+For key details and available models, see [OpenHands LLM Provider](/openhands/usage/llms/openhands-llms).
+
+### Local OpenAI-Compatible Endpoint
+
+A local server can be LM Studio, Ollama, vLLM, SGLang, or another service that exposes an OpenAI-compatible API. In the **Advanced** tab, enter the provider, exact model ID, endpoint base URL, and the required API key or a placeholder value when the server does not require one.
+
+The URL must be reachable from the **backend**, not only from your browser. For example, a backend in Docker cannot use `127.0.0.1` to reach a model server running on the host. Use the host address appropriate for that backend and confirm the endpoint's model inventory before saving.
+
+For example, if the model server runs on the host at port `1234` and the Agent Canvas backend runs in Docker, configure:
+
+- **Model**: `openai/<served-model-id>`, replacing `<served-model-id>` with the exact `id` returned by the server's `GET /v1/models` endpoint
+- **Base URL**: `http://host.docker.internal:1234/v1`
+- **API key**: `local-llm` or another placeholder value when the server does not require authentication
+
+See [Local LLMs](/openhands/usage/llms/local-llms) for LM Studio, Ollama, and other local-server examples.
+
+### LiteLLM Proxy
+
+In the **Advanced** tab, use the model name format `litellm_proxy/<model-name>`, then enter your LiteLLM proxy base URL and API key. The model name after the prefix must match a model configured on the proxy.
+
+See [LiteLLM Proxy](/openhands/usage/llms/litellm-proxy) for the complete configuration.
 
 ## Working with LLM Profiles
 
@@ -30858,26 +31073,43 @@ LLM profiles are useful when you want different model setups for different tasks
 
 LLM profiles are separate from [Agent Profiles](/openhands/usage/agent-canvas/agent-profiles). Agent Profiles choose which agent runs a new conversation. OpenHands Agent Profiles reference an LLM profile to decide which model configuration that agent uses.
 
+### Manage Saved Profiles
+
+The available profiles list shows each profile's name, configured model, and whether it is active. Use a profile's menu to edit or rename it, set it as the active profile for new conversations, or delete it when you no longer need it.
+
 ## Switching Profiles in a Conversation
 
-You can switch profiles from the chat input with the `/model` command:
+You can switch profiles from the profile selector in the chat input or with the `/model` command:
 
 - `/model` — list the saved profiles available to the conversation
 - `/model <profile-name>` — switch to a specific saved profile
 
-Agent Canvas also shows model-switch events in the conversation timeline so you can see when a profile changed during a task.
+A switch preserves the conversation history, workspace, and task state; it applies to future model requests only. Agent Canvas also shows model-switch events in the conversation timeline so you can see when a profile changed during a task.
 
 <Note>
-  LLM profiles are fully supported in Agent Canvas and are still rolling out in OpenHands Cloud. If you connect Agent Canvas to a cloud backend, profiles you configure in Agent Canvas may be available there before the same profiles appear in the hosted OpenHands Cloud UI for your account.
+Model switching requires saved LLM profiles. If `/model` is not available in the chat input, create a profile in `Settings > LLM` and confirm that the active backend supports profile switching.
 </Note>
+
+## Fix a Failed Configuration
+
+| Symptom | Check first | Next step |
+|---|---|---|
+| Provider is not recognized | Provider selection and model prefix | Use the matching configuration path above. |
+| Model format or identifier error | Exact model ID | Compare it with the provider or proxy model inventory. |
+| Local server cannot be reached | Base URL from the backend | Check host, port, and container or network reachability. |
+| Authentication or permission error | Key type and backend scope | Re-enter the key or follow the provider guide. |
+| Model cannot perform the task | Context and tool support | Choose a compatible model from the provider's recommendations. |
+
+For error-specific steps, see [Troubleshooting](/openhands/usage/agent-canvas/troubleshooting#model-or-api-key-errors).
+
 
 ## Recommended Workflow
 
-1. Configure a default profile in `Settings > LLM`.
-2. Create additional profiles for specific tasks or cost levels.
+1. Configure and save a default profile in `Settings > LLM`.
+2. Create additional profiles for specific tasks or cost levels, using descriptive names that make their purpose clear.
 3. Open `Settings > Agent` and choose which LLM profile an OpenHands Agent Profile should use.
-4. Start a conversation.
-5. Use `/model` when you want to switch profiles without leaving the chat.
+4. Start a new conversation and send a simple message to confirm the selected model responds.
+5. Use the profile selector or `/model` when you want to switch profiles without leaving the chat.
 
 ## Related Guides
 
@@ -31031,36 +31263,45 @@ ngrok also supports OAuth, IP allowlists, and other access controls for addition
 ### Agent Canvas Overview
 Source: https://docs.openhands.dev/openhands/usage/agent-canvas/overview.md
 
-Agent Canvas is an open-source control surface for agentic work. It gives you one browser UI for conversations, files, terminal output, model configuration, backends, and automations.
+Agent Canvas is an open-source control surface for agentic work. From one place, you can manage conversations, files, terminals, model configuration, backends, and automations.
 
-By default, Agent Canvas runs on your own machine. You can also connect the same UI to backends running in Docker, on a VM, on Modal, or in [OpenHands Cloud](/openhands/usage/cloud/openhands-cloud).
+The browser interface connects to one or more backends that run the agent and its tools. By default, that backend runs on your machine, but you can instead use Docker, a VM, Modal, or [OpenHands Cloud](/openhands/usage/cloud/openhands-cloud). The LLM models can run locally, through a provider API or be accessed through an ACP agent.
 
 ## When To Use Agent Canvas
 
-Use Agent Canvas when you want a self-hosted or local browser UI for agents that can work with real files, terminals, tools, and automations.
+Choose the path that matches where and how you want your agents to run:
 
 | If you want to... | Start here |
 |-------------------|------------|
 | Run OpenHands locally in a browser | [Install Agent Canvas](/openhands/usage/agent-canvas/setup) |
-| Use a sandboxed local environment | [Docker Backend](/openhands/usage/agent-canvas/backend-setup/docker) |
+| Use a sandboxed local environment | [Use Docker with Agent Canvas](/openhands/usage/agent-canvas/backend-setup/docker) |
 | Run agents on an always-on machine | [VM / Self-Hosted Installation](/openhands/usage/agent-canvas/backend-setup/vm) |
 | Connect to managed cloud sandboxes | [Cloud Backend](/openhands/usage/agent-canvas/backend-setup/cloud) |
 | Use Claude Code, Codex, Gemini CLI, or another ACP agent | [ACP Agents](/openhands/usage/agent-canvas/acp-agents) |
-| Create scheduled or event-driven workflows | [Pre-built Automations](/openhands/usage/agent-canvas/prebuilt-automations) |
+
+You can also test a preview build of the native desktop app. [Try the desktop preview](/openhands/usage/agent-canvas/setup#desktop-app-preview-build).
 
 ## How Agent Canvas Works
 
-Agent Canvas has four pieces to understand:
+Agent Canvas is the browser client. It connects to backend services that own execution and persistent state:
 
-| Concept | What It Means | Why It Matters |
-|-------|---------------|----------------|
-| **Browser UI** | The web interface you open in your browser. | This is where you chat, inspect files, manage settings, and configure automations. |
-| **Backend** | The agent server that runs conversations, tools, settings, secrets, and automations. | This determines where the agent runs and what machine or sandbox it can access. |
-| **Workspace** | The folder, repository, container mount, or cloud sandbox the agent works in. | This determines which files the agent can read and write. |
-| **Agent and model** | The OpenHands agent or an ACP agent, plus the model credentials it uses. | This determines which LLM or provider receives conversation context and powers the agent. |
+| Component | Responsibility |
+|-----------|----------------|
+| **Agent Canvas** | Displays conversations, files, terminals, settings, backends, and automations. |
+| **Agent Server** | Runs conversations, agents, tools, and workspace operations. |
+| **Automation Server** | Manages schedules, event triggers, dispatch, and run history. |
+| **Workspace or sandbox** | Defines which files, processes, credentials, and networks the agent can access. |
+
+<Warning>
+  Agent Canvas does not execute tools or provide sandbox isolation. Agent Server or an ACP process executes tools, and the selected workspace or sandbox provides the execution boundary.
+</Warning>
+
+The `agent-canvas` launcher can package the client and backend services into one local stack. You can also run the client separately and connect it to services on a VM, in Docker or Kubernetes, or through OpenHands Cloud or OpenHands Enterprise.
+
+See [Agent Canvas Architecture](/openhands/usage/agent-canvas/architecture) for the complete service and deployment model.
 
 <Note>
-  Settings, secrets, LLM configuration, MCP servers, skills, conversations, and automations are scoped to the active backend. Switching backends switches the environment the agent is using.
+  Switching backends switches the environment the agent is using. For details on how conversations and workspaces remain separate, see [Conversations](/openhands/usage/agent-canvas/conversations) and [Backends](/openhands/usage/agent-canvas/backends).
 </Note>
 
 ## Choosing A Trust Boundary
@@ -31078,25 +31319,39 @@ Before installing, decide where you want the agent to run and what files it shou
   Agent Canvas can run agents that execute shell commands, read files, write files, and use connected tools. Only connect a backend to files, secrets, and networks that you are willing to let the agent use.
 </Warning>
 
+## What Happens When You Close the Terminal?
+
+For a local npm or npx installation, closing the terminal stops the Agent Canvas process, so the browser UI can no longer use its local backend. Start Agent Canvas again with the same command to continue. A Docker container, VM, or cloud backend continues running until that backend is stopped.
+
+See [Install](/openhands/usage/agent-canvas/setup#run-agent-canvas-again) to restart Agent Canvas and [Troubleshooting](/openhands/usage/agent-canvas/troubleshooting) if the browser cannot reconnect.
+
 ## Model Access
 
 Agent Canvas supports several model access patterns:
 
 - **Direct provider key** — enter an API key from Anthropic, OpenAI, Google, or another supported provider.
-- **OpenHands Cloud key** — use an OpenHands Cloud API key for verified hosted models.
+- **OpenHands LLM API key** — use an OpenHands LLM API key for verified hosted models.
 - **ACP agent subscription login** — use a signed-in provider, such as Claude Code, Codex, or Gemini, when the backend runs on the same machine as that login.
 - **Local or OpenAI-compatible provider** — connect providers such as Ollama, LM Studio, LiteLLM, or a compatible gateway through model settings.
 
-See [LLM Profiles and Model Configuration](/openhands/usage/agent-canvas/llm-profiles) and [ACP Agents](/openhands/usage/agent-canvas/acp-agents) for details.
+See [Manage LLM Profiles](/openhands/usage/agent-canvas/llm-profiles) and [ACP Agents](/openhands/usage/agent-canvas/acp-agents) for details.
 
 ## How It Fits With Other OpenHands Products
 
-| Product | Use It When |
-|---------|-------------|
-| **Agent Canvas** | You want a self-hosted browser UI for local, remote, or cloud-backed agents and automations. |
-| **OpenHands Cloud** | You want a fully managed hosted experience with no local installation. |
-| **OpenHands SDK** | You want to build agents or agent-powered applications in Python. |
-| **Local GUI (Legacy)** | You are following older Docker-based Local GUI documentation. New local browser workflows should use Agent Canvas. |
+| Surface | Best for | Where it runs |
+|---------|----------|---------------|
+| **Agent Canvas** | Browser-first agent work, workspace access, and automations | The backend you select: your machine, Docker, a VM, Modal, or Cloud |
+| **OpenHands SDK** | Building agent-powered Python applications | Your application and the workspace you configure |
+| **OpenHands Cloud** | Fully managed hosted execution | Managed OpenHands Cloud infrastructure |
+| **Local GUI (Legacy)** | Following older Docker-based Local GUI documentation | Your local Docker environment |
+
+### Agent Canvas vs "openhands serve"
+
+`agent-canvas` starts the current Agent Canvas UI and backend stack. `openhands serve` starts the legacy OpenHands CLI GUI server and will not run if you have only installed agent-canvas.
+
+### How Conversations and Workspaces Are Isolated
+
+A conversation belongs to one active backend and has its own history, agent configuration, and backend-managed state. Its workspace is the folder, mount, or sandbox attached to that backend. Start a new conversation for a separate task, or [branch a conversation](/openhands/usage/agent-canvas/conversations#branch-from-a-message) to explore another path while preserving the original.
 
 ## Before You Start
 
@@ -31114,7 +31369,9 @@ For a sandboxed local setup, use Docker instead of the direct npm backend path.
 - [Install Agent Canvas](/openhands/usage/agent-canvas/setup)
 - [First Time Setup](/openhands/usage/agent-canvas/first-time-setup)
 - [Connect and Manage Backends](/openhands/usage/agent-canvas/backends)
-- [LLM Profiles and Model Configuration](/openhands/usage/agent-canvas/llm-profiles)
+- [Manage LLM Profiles](/openhands/usage/agent-canvas/llm-profiles)
+- [Conversations](/openhands/usage/agent-canvas/conversations)
+- [ACP Agents](/openhands/usage/agent-canvas/acp-agents)
 - [Troubleshooting](/openhands/usage/agent-canvas/troubleshooting)
 
 ### Plugins in Agent Canvas
@@ -31156,6 +31413,15 @@ Local plugins are discovered from user-level plugin directories such as `~/.agen
 <Note>
   Local plugins are read-only in the Plugins page. To change or remove a local plugin, edit the files in the local plugin directory.
 </Note>
+
+## Inspect Plugin Contents
+
+Select a plugin to open its details. Alongside its metadata, the detail view can show:
+
+- **Skills in this plugin bundle** — cards for bundled skills, including command-derived skills, with their icons, names, and descriptions.
+- **Files** — an expandable directory tree. Select a file to view it inline with syntax highlighting; select it again to close the viewer.
+
+Plugin content is provided by the active backend. A backend that does not provide this data shows plugin metadata only.
 
 ## Enable or Disable Installed Plugins
 
@@ -31208,7 +31474,7 @@ Agent Canvas ships with a set of pre-built automations for the most common agent
 
 ---
 
-Every canvas backend includes an automation service, so you can run agents on a schedule or in response to external events.
+Backends created by the `agent-canvas` launcher include Automation Server, so they can run agents on a schedule or in response to external events. Other backends must provide a compatible automation service for these features.
 
 ## What You Can Do
 
@@ -31590,13 +31856,13 @@ After the automation is created:
 - [Setup a Pre-built Automation](/openhands/usage/agent-canvas/prebuilt-automations)
 - [Customize and Settings](/openhands/usage/agent-canvas/customize-and-settings)
 
-### Install
+### Install Agent Canvas
 Source: https://docs.openhands.dev/openhands/usage/agent-canvas/setup.md
 
-Agent Canvas can run directly on your machine or inside Docker. Start with the simplest setup that matches the trust boundary you want.
+The `agent-canvas` launcher can run the Canvas client with Agent Server, Automation Server, and ingress as an all-in-one local stack. Use npm or npx for direct local execution, or Docker for a containerized stack with explicit project mounts. You can also run the client separately and connect it to an existing backend.
 
 <Warning>
-  Agent Canvas starts an agent server that can run shell commands, read files, write files, and use connected tools. Treat the machine or container where the backend runs as trusted infrastructure. Before exposing Agent Canvas to a network you do not control, review [VM / Self-Hosted Installation](/openhands/usage/agent-canvas/backend-setup/vm).
+  Agent Server and ACP processes can run shell commands, read files, write files, and use connected tools. Agent Canvas is the client and does not provide isolation. Treat the machine, container, or sandbox where the backend runs as trusted infrastructure. Before exposing backend services to a network you do not control, review [VM / Self-Hosted Installation](/openhands/usage/agent-canvas/backend-setup/vm).
 </Warning>
 
 ## Choose An Install Method
@@ -31705,7 +31971,7 @@ Agent Canvas can run directly on your machine or inside Docker. Start with the s
       ghcr.io/openhands/agent-canvas:latest
     ```
 
-    Agent Canvas starts on `http://localhost:8000`. The agent can access project files under the mounted `/projects` directory.
+    The Docker image serves Agent Canvas at `http://localhost:8000/canvas`. The agent can access project files under the mounted `/projects` directory.
 
     <Note>
       PowerShell uses backticks (`` ` ``) for line continuation. If Docker reports that it cannot connect to the daemon, start Docker Desktop and run the command again.
@@ -31728,8 +31994,8 @@ Agent Canvas can run directly on your machine or inside Docker. Start with the s
     Use the source workflow only when you want to modify Agent Canvas itself:
 
     ```bash
-    git clone https://github.com/OpenHands/agent-canvas.git
-    cd agent-canvas
+    git clone https://github.com/OpenHands/OpenHands.git
+    cd OpenHands
     npm install
     npm run dev
     ```
@@ -31749,6 +32015,30 @@ After startup:
 5. Return to the home screen and start a conversation.
 
 If the page does not load, check the terminal where Agent Canvas is running. Common causes are a missing prerequisite, a busy port, or Docker not running.
+
+## Run Agent Canvas Again
+
+After you close the terminal or restart your computer, start Agent Canvas with the same command you used to install it. Keep that terminal or Docker container running while you use the browser UI.
+
+<Tabs>
+  <Tab title="npm">
+    ```bash
+    agent-canvas
+    ```
+  </Tab>
+
+  <Tab title="npx">
+    ```bash
+    npx @openhands/agent-canvas
+    ```
+  </Tab>
+
+  <Tab title="Docker">
+    Run the same `docker run` command from [Install and Run](#install-and-run). The browser connects to the host port you map, while the backend and model configuration run where the Agent Canvas process or container is running.
+  </Tab>
+</Tabs>
+
+If the UI opens but the backend is disconnected or a model cannot respond, use [Troubleshooting](/openhands/usage/agent-canvas/troubleshooting) to identify the affected part of the stack.
 
 ## Common Startup Options
 
@@ -31780,11 +32070,12 @@ agent-canvas --port 3000
 ## Stop Agent Canvas
 
 <Tabs>
-  <Tab title="npx">
+
+  <Tab title="npm">
     Return to the terminal running Agent Canvas and press `Ctrl+C`.
   </Tab>
 
-  <Tab title="npm">
+  <Tab title="npx">
     Return to the terminal running Agent Canvas and press `Ctrl+C`.
   </Tab>
 
@@ -31803,20 +32094,20 @@ agent-canvas --port 3000
 ## Update Agent Canvas
 
 <Tabs>
-  <Tab title="npx">
-    Stop Agent Canvas, then run the latest package:
-
-    ```bash
-    npx @openhands/agent-canvas@latest
-    ```
-  </Tab>
-
   <Tab title="npm">
     Stop Agent Canvas, then reinstall the latest package:
 
     ```bash
     npm install -g @openhands/agent-canvas@latest
     agent-canvas --version
+    ```
+  </Tab>
+
+  <Tab title="npx">
+    Stop Agent Canvas, then run the latest package:
+
+    ```bash
+    npx @openhands/agent-canvas@latest
     ```
   </Tab>
 
@@ -31831,19 +32122,13 @@ agent-canvas --port 3000
 
 Your settings and conversation data are stored outside the package or image when you use the documented `~/.openhands` mount.
 
+<Note>
+  **Recover or reset:** Use [Troubleshooting](/openhands/usage/agent-canvas/troubleshooting) when the browser is blank, a port is busy, the backend is unreachable, a model or API key fails, or an update or uninstall is stuck. It also explains clean removal and reinstall.
+</Note>
+
 ## Uninstall Agent Canvas
 
 <Tabs>
-  <Tab title="npx">
-    There is no Agent Canvas package to uninstall when you use `npx`. Stop the running process with `Ctrl+C`.
-
-    If you want to clear downloaded package cache entries, use npm's cache commands:
-
-    ```bash
-    npm cache verify
-    ```
-  </Tab>
-
   <Tab title="npm">
     Stop any running Agent Canvas process, then uninstall the package:
 
@@ -31852,6 +32137,16 @@ Your settings and conversation data are stored outside the package or image when
     ```
 
     If Windows reports that `uv.exe` or another file is in use, close terminals running Agent Canvas, stop related processes, and run the uninstall command again.
+  </Tab>
+
+  <Tab title="npx">
+    There is no Agent Canvas package to uninstall when you use `npx`. Stop the running process with `Ctrl+C`.
+
+    If you want to clear downloaded package cache entries, use npm's cache commands:
+
+    ```bash
+    npm cache verify
+    ```
   </Tab>
 
   <Tab title="Docker">
@@ -31867,18 +32162,80 @@ Your settings and conversation data are stored outside the package or image when
 
 Uninstalling the package or image does not automatically remove your persisted data. If you want to delete local settings, secrets, and conversation history, remove the persistence directory you mounted or used, such as `~/.openhands`.
 
+## Desktop App (Preview Build)
+
+The Agent Canvas desktop app for macOS and Windows is an early preview build ready for user testing. It bundles the Node.js and `uv` runtimes, so you do not need to install prerequisites or keep a terminal open.
+
+<Note>
+  Please [join the OpenHands Slack community](https://openhands.dev/joinslack) to share feedback and [open an issue](https://github.com/OpenHands/OpenHands/issues) for problems you find while testing the preview.
+</Note>
+
+### Install and Run
+
+Download the installer for your operating system from the [OpenHands releases page](https://github.com/OpenHands/OpenHands/releases).
+
+**macOS (Apple silicon)**
+
+1. Download the `Agent-Canvas-<version>-arm64.dmg` file.
+2. Open the disk image and drag **Agent Canvas** to **Applications**.
+3. Launch Agent Canvas from Applications.
+
+Pre-built desktop releases support Apple silicon Macs. On an Intel Mac, use the npm or [from-source](#install-and-run) installation method.
+
+**Windows**
+
+1. Download the `Agent-Canvas-Setup-<version>.exe` installer.
+2. Run the installer. If Windows SmartScreen prompts you, confirm that you want to continue.
+3. Launch Agent Canvas from the Start menu.
+
+The desktop app starts its local backend automatically. During startup, select **Show details** to view and copy the live startup log. This is useful if startup takes longer than expected or fails.
+
+### Troubleshooting and Lifecycle
+
+On macOS, the app is ad-hoc signed. If macOS reports that Agent Canvas is damaged or cannot be opened, clear its quarantine attribute in Terminal, then launch it again:
+
+```bash
+xattr -d com.apple.quarantine /Applications/Agent\ Canvas.app
+```
+
+Do not use `xattr -cr`; that command does not clear this issue on macOS Sequoia.
+
+To stop the app, quit **Agent Canvas** from its application menu or window controls. To update it, download and install the latest desktop release; `Settings > Application` also shows the installed version and can check for updates. To uninstall, quit the app and move it to the Trash on macOS or uninstall it from **Installed apps** on Windows.
+
 ## Next Steps
 
 - [First Time Setup](/openhands/usage/agent-canvas/first-time-setup)
 - [Connect and Manage Backends](/openhands/usage/agent-canvas/backends)
-- [LLM Profiles and Model Configuration](/openhands/usage/agent-canvas/llm-profiles)
-- [Docker Backend](/openhands/usage/agent-canvas/backend-setup/docker)
+- [Manage LLM Profiles](/openhands/usage/agent-canvas/llm-profiles)
+- [Use Docker with Agent Canvas](/openhands/usage/agent-canvas/backend-setup/docker)
 - [Troubleshooting](/openhands/usage/agent-canvas/troubleshooting)
 
 ### Troubleshooting
 Source: https://docs.openhands.dev/openhands/usage/agent-canvas/troubleshooting.md
 
 Use this page when Agent Canvas does not start, the browser cannot reach it, the backend is disconnected, model setup fails, or uninstall/update commands get stuck.
+
+## Choose Your Situation
+
+**Agent Canvas cannot start**
+
+- ["agent-canvas" Command Not Found](#agent-canvas-command-not-found),
+- [Missing `uv` or `uvx`](#missing-uv-or-uvx)
+- [Port Already In Use](#port-already-in-use)
+- [Docker Daemon Not Running](#docker-daemon-not-running).
+
+**The browser works but Canvas cannot reach its backend**
+- [Backend Is Unreachable](#backend-is-unreachable)
+- [Wrong Backend URL Or API Key](#wrong-backend-url-or-api-key).
+
+**The backend works but the model fails**
+- [Model Or API Key Errors](#model-or-api-key-errors)
+- [`LLM Provider NOT provided`](#llm-provider-not-provided)
+- [ACP Agent Credentials Are Not Used](#acp-agent-credentials-are-not-used).
+
+**You need to remove or reset Canvas**
+- [Update Or Uninstall Is Stuck](#update-or-uninstall-is-stuck)
+- [Uninstall Agent Canvas](/openhands/usage/agent-canvas/setup#uninstall-agent-canvas) for clean removal and reinstall.
 
 ## Start With These Checks
 
@@ -32100,8 +32457,7 @@ Common causes:
 
 For model setup details, see:
 
-- [LLM Profiles and Model Configuration](/openhands/usage/agent-canvas/llm-profiles)
-- [LLM Settings](/openhands/usage/settings/llm-settings)
+- [Manage LLM Profiles](/openhands/usage/agent-canvas/llm-profiles)
 - [Local LLMs](/openhands/usage/llms/local-llms)
 - [LiteLLM Proxy](/openhands/usage/llms/litellm-proxy)
 
@@ -32215,8 +32571,8 @@ Uninstalling the package or image does not automatically delete persisted settin
 If you are still stuck:
 
 - [Join the OpenHands Slack community](https://openhands.dev/joinslack)
-- [Open an issue in the Agent Canvas repository](https://github.com/OpenHands/agent-canvas/issues)
-- [Browse the Agent Canvas source](https://github.com/OpenHands/agent-canvas)
+- [Open an issue in the OpenHands repository](https://github.com/OpenHands/OpenHands/issues)
+- [Browse the Agent Canvas source](https://github.com/OpenHands/OpenHands)
 
 ### Main Agent and Capabilities
 Source: https://docs.openhands.dev/openhands/usage/agents.md
@@ -32244,23 +32600,22 @@ https://github.com/OpenHands/OpenHands/assets/38853559/f592a192-e86c-4f48-ad31-d
 
 _Example of CodeActAgent with `gpt-4-turbo-2024-04-09` performing a data science task (linear regression)_.
 
-### REST API (V1)
+### Sandbox Server REST API (V1)
 Source: https://docs.openhands.dev/openhands/usage/api/v1.md
 
-<Note>
-  OpenHands is in a transition period: legacy (V0) endpoints still exist alongside
-  the new <code>/api/v1</code> endpoints.
+The [OpenHands Sandbox Server](https://github.com/OpenHands/sandbox-server) is the standalone API and sandbox control plane extracted from the former OpenHands monorepo. It exposes conversation and sandbox resources without bundling a frontend.
 
-  If you need the legacy OpenAPI reference, see the <b>Legacy (V0)</b> section in the Web tab.
+<Note>
+  The legacy (V0) API belongs to the archived Local GUI architecture. See the **V0 REST API** section in the Home tab when maintaining an existing V0 integration.
 </Note>
 
 ## Overview
 
-OpenHands V1 REST endpoints are mounted under:
+Sandbox Server V1 REST endpoints are mounted under:
 
 - <code>/api/v1</code>
 
-These endpoints back the current Web UI and are intended for newer integrations.
+Use these endpoints to integrate with the Sandbox Server control plane. Agent Canvas is the browser client for compatible deployments; Sandbox Server itself does not include a frontend.
 
 ## Key resources
 
@@ -32278,278 +32633,6 @@ The V1 API is organized around a few core concepts:
 
 - **Sandbox specs**: list the available sandbox “templates” (e.g., Docker image presets).
   - <code>GET /api/v1/sandbox-specs/search</code>
-
-### Backend Architecture
-Source: https://docs.openhands.dev/openhands/usage/architecture/backend.md
-
-This is a high-level overview of the system architecture. The system is divided into two main components: the frontend and the backend. The frontend is responsible for handling user interactions and displaying the results. The backend is responsible for handling the business logic and executing the agents.
-
-# System overview
-
-```mermaid
-flowchart LR
-  U["User"] --> FE["Frontend (SPA)"]
-  FE -- "HTTP/WS" --> BE["OpenHands Backend"]
-  BE --> ES["EventStream"]
-  BE --> ST["Storage"]
-  BE --> RT["Runtime Interface"]
-  BE --> LLM["LLM Providers"]
-
-  subgraph Runtime
-    direction TB
-    RT --> DRT["Docker Runtime"]
-    RT --> LRT["Local Runtime"]
-    RT --> RRT["Remote Runtime"]
-    DRT --> AES["Action Execution Server"]
-    LRT --> AES
-    RRT --> AES
-    AES --> Bash["Bash Session"]
-    AES --> Jupyter["Jupyter Plugin"]
-    AES --> Browser["BrowserEnv"]
-  end
-```
-
-This Overview is simplified to show the main components and their interactions. For a more detailed view of the backend architecture, see the Backend Architecture section below.
-
-# Backend Architecture
-
-
-```mermaid
-classDiagram
-  class Agent {
-    <<abstract>>
-    +sandbox_plugins: list[PluginRequirement]
-  }
-  class CodeActAgent {
-    +tools
-  }
-  Agent <|-- CodeActAgent
-
-  class EventStream
-  class Observation
-  class Action
-  Action --> Observation
-  Agent --> EventStream
-
-  class Runtime {
-    +connect()
-    +send_action_for_execution()
-  }
-  class ActionExecutionClient {
-    +_send_action_server_request()
-  }
-  class DockerRuntime
-  class LocalRuntime
-  class RemoteRuntime
-  Runtime <|-- ActionExecutionClient
-  ActionExecutionClient <|-- DockerRuntime
-  ActionExecutionClient <|-- LocalRuntime
-  ActionExecutionClient <|-- RemoteRuntime
-
-  class ActionExecutionServer {
-    +/execute_action
-    +/alive
-  }
-  class BashSession
-  class JupyterPlugin
-  class BrowserEnv
-  ActionExecutionServer --> BashSession
-  ActionExecutionServer --> JupyterPlugin
-  ActionExecutionServer --> BrowserEnv
-
-  Agent --> Runtime
-  Runtime ..> ActionExecutionServer : REST
-```
-
-<details>
-  <summary>Updating this Diagram</summary>
-  <div>
-    We maintain architecture diagrams inline with Mermaid in this MDX.
-
-    Guidance:
-    - Edit the Mermaid blocks directly (flowchart/classDiagram).
-    - Quote labels and edge text for GitHub preview compatibility.
-    - Keep relationships concise and reflect stable abstractions (agents, runtime client/server, plugins).
-    - Verify accuracy against code:
-      - openhands/runtime/impl/action_execution/action_execution_client.py
-      - openhands/runtime/impl/docker/docker_runtime.py
-      - openhands/runtime/impl/local/local_runtime.py
-      - openhands/runtime/action_execution_server.py
-      - openhands/runtime/plugins/*
-    - Build docs locally or view on GitHub to confirm diagrams render.
-
-  </div>
-</details>
-
-### Runtime Architecture
-Source: https://docs.openhands.dev/openhands/usage/architecture/runtime.md
-
-The OpenHands Docker Runtime is the core component that enables secure and flexible execution of AI agent's action.
-It creates a sandboxed environment using Docker, where arbitrary code can be run safely without risking the host system.
-
-## Why do we need a sandboxed runtime?
-
-OpenHands needs to execute arbitrary code in a secure, isolated environment for several reasons:
-
-1. Security: Executing untrusted code can pose significant risks to the host system. A sandboxed environment prevents malicious code from accessing or modifying the host system's resources
-2. Consistency: A sandboxed environment ensures that code execution is consistent across different machines and setups, eliminating "it works on my machine" issues
-3. Resource Control: Sandboxing allows for better control over resource allocation and usage, preventing runaway processes from affecting the host system
-4. Isolation: Different projects or users can work in isolated environments without interfering with each other or the host system
-5. Reproducibility: Sandboxed environments make it easier to reproduce bugs and issues, as the execution environment is consistent and controllable
-
-## How does the Runtime work?
-
-The OpenHands Runtime system uses a client-server architecture implemented with Docker containers. Here's an overview of how it works:
-
-```mermaid
-graph TD
-    A[User-provided Custom Docker Image] --> B[OpenHands Backend]
-    B -->|Builds| C[OH Runtime Image]
-    C -->|Launches| D[Action Executor]
-    D -->|Initializes| E[Browser]
-    D -->|Initializes| F[Bash Shell]
-    D -->|Initializes| G[Plugins]
-    G -->|Initializes| L[Jupyter Server]
-
-    B -->|Spawn| H[Agent]
-    B -->|Spawn| I[EventStream]
-    I <--->|Execute Action to
-    Get Observation
-    via REST API
-    | D
-
-    H -->|Generate Action| I
-    I -->|Obtain Observation| H
-
-    subgraph "Docker Container"
-    D
-    E
-    F
-    G
-    L
-    end
-```
-
-1. User Input: The user provides a custom base Docker image
-2. Image Building: OpenHands builds a new Docker image (the "OH runtime image") based on the user-provided image. This new image includes OpenHands-specific code, primarily the "runtime client"
-3. Container Launch: When OpenHands starts, it launches a Docker container using the OH runtime image
-4. Action Execution Server Initialization: The action execution server initializes an `ActionExecutor` inside the container, setting up necessary components like a bash shell and loading any specified plugins
-5. Communication: The OpenHands backend (client: `openhands/runtime/impl/action_execution/action_execution_client.py`; runtimes: `openhands/runtime/impl/docker/docker_runtime.py`, `openhands/runtime/impl/local/local_runtime.py`) communicates with the action execution server over RESTful API, sending actions and receiving observations
-6. Action Execution: The runtime client receives actions from the backend, executes them in the sandboxed environment, and sends back observations
-7. Observation Return: The action execution server sends execution results back to the OpenHands backend as observations
-
-The role of the client:
-
-- It acts as an intermediary between the OpenHands backend and the sandboxed environment
-- It executes various types of actions (shell commands, file operations, Python code, etc.) safely within the container
-- It manages the state of the sandboxed environment, including the current working directory and loaded plugins
-- It formats and returns observations to the backend, ensuring a consistent interface for processing results
-
-## How OpenHands builds and maintains OH Runtime images
-
-OpenHands' approach to building and managing runtime images ensures efficiency, consistency, and flexibility in creating and maintaining Docker images for both production and development environments.
-
-Check out the [relevant code](https://github.com/OpenHands/OpenHands/blob/main/openhands/runtime/utils/runtime_build.py) if you are interested in more details.
-
-### Image Tagging System
-
-OpenHands uses a three-tag system for its runtime images to balance reproducibility with flexibility.
-The tags are:
-
-- **Versioned Tag**: `oh_v{openhands_version}_{base_image}` (e.g.: `oh_v0.9.9_nikolaik_s_python-nodejs_t_python3.12-nodejs22`)
-- **Lock Tag**: `oh_v{openhands_version}_{16_digit_lock_hash}` (e.g.: `oh_v0.9.9_1234567890abcdef`)
-- **Source Tag**: `oh_v{openhands_version}_{16_digit_lock_hash}_{16_digit_source_hash}`
-  (e.g.: `oh_v0.9.9_1234567890abcdef_1234567890abcdef`)
-
-#### Source Tag - Most Specific
-
-This is the first 16 digits of the MD5 of the directory hash for the source directory. This gives a hash
-for only the openhands source
-
-#### Lock Tag
-
-This hash is built from the first 16 digits of the MD5 of:
-
-- The name of the base image upon which the image was built (e.g.: `nikolaik/python-nodejs:python3.12-nodejs22`)
-- The content of the `pyproject.toml` included in the image.
-- The content of the `poetry.lock` included in the image.
-
-This effectively gives a hash for the dependencies of Openhands independent of the source code.
-
-#### Versioned Tag - Most Generic
-
-This tag is a concatenation of openhands version and the base image name (transformed to fit in tag standard).
-
-#### Build Process
-
-When generating an image...
-
-- **No re-build**: OpenHands first checks whether an image with the same **most specific source tag** exists. If there is such an image,
-  no build is performed - the existing image is used.
-- **Fastest re-build**: OpenHands next checks whether an image with the **generic lock tag** exists. If there is such an image,
-  OpenHands builds a new image based upon it, bypassing all installation steps (like `poetry install` and
-  `apt-get`) except a final operation to copy the current source code. The new image is tagged with a
-  **source** tag only.
-- **Ok-ish re-build**: If neither a **source** nor **lock** tag exists, an image will be built based upon the **versioned** tag image.
-  In versioned tag image, most dependencies should already been installed hence saving time.
-- **Slowest re-build**: If all of the three tags don't exists, a brand new image is built based upon the base
-  image (Which is a slower operation). This new image is tagged with all the **source**, **lock**, and **versioned** tags.
-
-This tagging approach allows OpenHands to efficiently manage both development and production environments.
-
-1. Identical source code and Dockerfile always produce the same image (via hash-based tags)
-2. The system can quickly rebuild images when minor changes occur (by leveraging recent compatible images)
-3. The **lock** tag (e.g., `runtime:oh_v0.9.3_1234567890abcdef`) always points to the latest build for a particular base image, dependency, and OpenHands version combination
-
-## Volume mounts: named volumes and overlay
-
-OpenHands supports both bind mounts and Docker named volumes in SandboxConfig.volumes:
-
-- Bind mount: "/abs/host/path:/container/path[:mode]"
-- Named volume: "volume:`<name>`:/container/path[:mode]" or any non-absolute host spec treated as a named volume
-
-Overlay mode (copy-on-write layer) is supported for bind mounts by appending ":overlay" to the mode (e.g., ":ro,overlay").
-To enable overlay COW, set SANDBOX_VOLUME_OVERLAYS to a writable host directory; per-container upper/work dirs are created under it. If SANDBOX_VOLUME_OVERLAYS is unset, overlay mounts are skipped.
-
-Implementation references:
-- openhands/runtime/impl/docker/docker_runtime.py (named volumes in _build_docker_run_args; overlay mounts in _process_overlay_mounts)
-- openhands/core/config/sandbox_config.py (volumes field)
-
-
-## Runtime Plugin System
-
-The OpenHands Runtime supports a plugin system that allows for extending functionality and customizing the runtime environment. Plugins are initialized when the action execution server starts up inside the runtime.
-
-## Ports and URLs
-
-- Host port allocation uses file-locked ranges for stability and concurrency:
-  - Main runtime port: find_available_port_with_lock on configured range
-  - VSCode port: SandboxConfig.sandbox.vscode_port if provided, else find_available_port_with_lock in VSCODE_PORT_RANGE
-  - App ports: two additional ranges for plugin/web apps
-- DOCKER_HOST_ADDR (if set) adjusts how URLs are formed for LocalRuntime/Docker environments.
-- VSCode URL is exposed with a connection token from the action execution server endpoint /vscode/connection_token and rendered as:
-  - Docker/Local: `http://localhost:{port}/?tkn={token}&folder={workspace_mount_path_in_sandbox}`
-  - RemoteRuntime: `scheme://vscode-{host}/?tkn={token}&folder={workspace_mount_path_in_sandbox}`
-
-References:
-- openhands/runtime/impl/docker/docker_runtime.py (port ranges, locking, DOCKER_HOST_ADDR, vscode_url)
-- openhands/runtime/impl/local/local_runtime.py (vscode_url factory)
-- openhands/runtime/impl/remote/remote_runtime.py (vscode_url mapping)
-- openhands/runtime/action_execution_server.py (/vscode/connection_token)
-
-
-Examples:
-- Jupyter: openhands/runtime/plugins/jupyter/__init__.py (JupyterPlugin, Kernel Gateway)
-- VS Code: openhands/runtime/plugins/vscode/* (VSCodePlugin, exposes tokenized URL)
-- Agent Skills: openhands/runtime/plugins/agent_skills/*
-
-Key aspects of the plugin system:
-
-1. Plugin Definition: Plugins are defined as Python classes that inherit from a base `Plugin` class
-2. Plugin Registration: Available plugins are registered in `openhands/runtime/plugins/__init__.py` via `ALL_PLUGINS`
-3. Plugin Specification: Plugins are associated with `Agent.sandbox_plugins: list[PluginRequirement]`. Users can specify which plugins to load when initializing the runtime
-4. Initialization: Plugins are initialized asynchronously when the runtime starts and are accessible to actions
-5. Usage: Plugins extend capabilities (e.g., Jupyter for IPython cells); the server exposes any web endpoints (ports) via host port mapping
 
 ### Creating Automations
 Source: https://docs.openhands.dev/openhands/usage/automations/creating-automations.md
@@ -35465,7 +35548,6 @@ You can build custom event-triggered workflows using the Software Agent SDK. For
 
 For more event-driven automation patterns, see:
 - [SDK GitHub Workflows Guide](/sdk/guides/github-workflows/pr-review) - Build custom workflows triggered by GitHub events
-- [GitHub Action Integration](/openhands/usage/run-openhands/github-action) - Use the OpenHands resolver for issue triage
 
 ### When to Use OpenHands
 Source: https://docs.openhands.dev/openhands/usage/essential-guidelines/when-to-use-openhands.md
@@ -36808,8 +36890,10 @@ retry_max_wait = 30
 retry_multiplier = 2
 ```
 
-### Local LLMs
+### Run Local LLMs with OpenHands
 Source: https://docs.openhands.dev/openhands/usage/llms/local-llms.md
+
+Use this guide when you want a local model, rather than a local Agent Canvas backend or local project files. Local LLMs can have limited functionality; use a capable model and GPU-backed server for the best experience.
 
 ## News
 
@@ -37270,58 +37354,6 @@ If the model is not in the list, enable `Advanced` options, and enter it in
 `Custom Model` (e.g. openrouter/&lt;model-name&gt; like `openrouter/anthropic/claude-3.5-sonnet`).
 * `API Key` to your OpenRouter API key.
 
-### OpenHands GitHub Action
-Source: https://docs.openhands.dev/openhands/usage/run-openhands/github-action.md
-
-## Using the Action in the OpenHands Repository
-
-To use the OpenHands GitHub Action in a repository, you can:
-
-1. Create an issue in the repository.
-2. Add the `fix-me` label to the issue or leave a comment on the issue starting with `@openhands-agent`.
-
-The action will automatically trigger and attempt to resolve the issue.
-
-## Installing the Action in a New Repository
-
-To install the OpenHands GitHub Action in your own repository, follow
-the [README for the OpenHands Resolver](https://github.com/OpenHands/OpenHands/blob/main/openhands/resolver/README.md).
-
-## Usage Tips
-
-### Iterative resolution
-
-1. Create an issue in the repository.
-2. Add the `fix-me` label to the issue, or leave a comment starting with `@openhands-agent`.
-3. Review the attempt to resolve the issue by checking the pull request.
-4. Follow up with feedback through general comments, review comments, or inline thread comments.
-5. Add the `fix-me` label to the pull request, or address a specific comment by starting with `@openhands-agent`.
-
-### Label versus Macro
-
-- Label (`fix-me`): Requests OpenHands to address the **entire** issue or pull request.
-- Macro (`@openhands-agent`): Requests OpenHands to consider only the issue/pull request description and **the specific comment**.
-
-## Advanced Settings
-
-### Add custom repository settings
-
-You can provide custom directions for OpenHands by following the [README for the resolver](https://github.com/OpenHands/OpenHands/blob/main/openhands/resolver/README.md#providing-custom-instructions).
-
-### Custom configurations
-
-GitHub resolver will automatically check for valid [repository secrets](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions?tool=webui#creating-secrets-for-a-repository) or [repository variables](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#creating-configuration-variables-for-a-repository) to customize its behavior.
-The customization options you can set are:
-
-| **Attribute name**               | **Type** | **Purpose**                                                                                         | **Example**                                        |
-| -------------------------------- | -------- | --------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| `LLM_MODEL`                      | Variable | Set the LLM to use with OpenHands                                                                   | `LLM_MODEL="anthropic/claude-3-5-sonnet-20241022"` |
-| `OPENHANDS_MAX_ITER`             | Variable | Set max limit for agent iterations                                                                  | `OPENHANDS_MAX_ITER=10`                            |
-| `OPENHANDS_MACRO`                | Variable | Customize default macro for invoking the resolver                                                   | `OPENHANDS_MACRO=@resolveit`                       |
-| `OPENHANDS_BASE_CONTAINER_IMAGE` | Variable | Custom Sandbox ([learn more](/openhands/usage/advanced/custom-sandbox-guide))                       | `OPENHANDS_BASE_CONTAINER_IMAGE="custom_image"`    |
-| `TARGET_BRANCH`                  | Variable | Merge to branch other than `main`                                                                   | `TARGET_BRANCH="dev"`                              |
-| `TARGET_RUNNER`                  | Variable | Target runner to execute the agent workflow (default ubuntu-latest)                                 | `TARGET_RUNNER="custom-runner"`                    |
-
 ### Configure
 Source: https://docs.openhands.dev/openhands/usage/run-openhands/gui-mode.md
 
@@ -37658,7 +37690,6 @@ This version is unstable and is recommended for testing or development purposes 
 - [Mount your local code into the sandbox](/openhands/usage/sandboxes/docker#mounting-your-code-into-the-sandbox) to use OpenHands with your repositories
 - [Run OpenHands in a scriptable headless mode.](/openhands/usage/cli/headless)
 - [Run OpenHands with a friendly CLI.](/openhands/usage/cli/quick-start)
-- [Run OpenHands on tagged issues with a GitHub action.](/openhands/usage/run-openhands/github-action)
 
 ### Docker Sandbox
 Source: https://docs.openhands.dev/openhands/usage/sandboxes/docker.md
@@ -37705,6 +37736,74 @@ export SANDBOX_VOLUMES=$PWD:/workspace:rw
   Anything mounted read-write into <code>/workspace</code> can be modified by the
   agent.
 </Note>
+
+## Self-hosting Behind a Reverse Proxy
+
+When you self-host OpenHands behind a reverse proxy (nginx, Traefik, etc.), each
+Docker sandbox exposes its agent-server (and VS Code / worker) ports on a
+**randomly assigned host port**. The frontend reaches the sandbox by plugging
+that random port into the `container_url_pattern`, which defaults to
+`http://localhost:{port}`. Two things break for a typical reverse-proxy setup:
+
+1. The hostname is `localhost`, not your public domain.
+2. The port is random, so you cannot add a static proxy route for it.
+
+<Note>
+  <code>OH_WEB_URL</code> does **not** control these sandbox URLs. On the
+  OpenHands host it only adds the origin to the sandbox's CORS allow-list — it
+  is not forwarded into the sandbox container's environment, so it has no
+  effect on the host/port the browser uses to reach a sandbox.
+</Note>
+
+### Pin sandbox ports with host networking
+
+Set `AGENT_SERVER_USE_HOST_NETWORK=true` to run agent-server containers in
+Docker host-network mode. Instead of random host ports, each container's ports
+are reachable directly on fixed host ports:
+
+| Container port | Service |
+|-----------------|---------|
+| `8000` | Agent server |
+| `8001` | VS Code server |
+| `8011` | Worker 1 |
+| `8012` | Worker 2 |
+
+```bash
+export AGENT_SERVER_USE_HOST_NETWORK=true
+```
+
+This lets you add a single static reverse-proxy route for each fixed port.
+
+<Warning>
+  Host-network mode binds every sandbox to the **same** fixed host ports. Only
+  one sandbox can run at a time; concurrent conversations will collide on those
+  ports. OpenHands logs a warning if host networking is enabled with
+  <code>max_num_sandboxes &gt; 1</code>.
+</Warning>
+
+### Fix the sandbox URL hostname
+
+To point sandbox URLs at your public domain (keeping the per-sandbox port),
+set the `container_url_pattern` to your hostname with the `{port}` placeholder:
+
+```bash
+# OH_-prefixed form (recommended for V1):
+export OH_SANDBOX_CONTAINER_URL_PATTERN="https://my-domain:{port}"
+# Legacy form (also accepted):
+export SANDBOX_CONTAINER_URL_PATTERN="https://my-domain:{port}"
+```
+
+This replaces `localhost` with your domain, but the port is still random per
+sandbox. Traefik cannot natively route an arbitrary dynamic port; a regex-based
+proxy (e.g. nginx) is needed to forward each port to the right sandbox.
+
+### Summary
+
+| Goal | Variable | Effect |
+|------|----------|--------|
+| Fixed, static ports (one sandbox at a time) | `AGENT_SERVER_USE_HOST_NETWORK=true` | Containers use host networking; ports `8000`/`8001`/`8011`/`8012` are exposed directly on the host. |
+| Public hostname for sandbox URLs | `OH_SANDBOX_CONTAINER_URL_PATTERN` / `SANDBOX_CONTAINER_URL_PATTERN` | Replaces `localhost` with your domain in the URLs the browser uses. Port stays random per sandbox. |
+
 
 ## Custom sandbox images
 
@@ -38455,6 +38554,12 @@ Other options include:
 - **Docker-based proxies**: Containerized solutions for better isolation.
 - **Cloud-hosted MCP services**: Third-party services that provide MCP endpoints.
 
+## Manage Installed Servers
+
+In Agent Canvas, open `Customize > MCP Servers` to manage installed MCP servers. Use the control on an installed server card to disable it without deleting its configuration or saved credentials. Disabled servers are unavailable to new conversations until you enable them again.
+
+Use the editor's delete action only when you want to remove the server configuration. Editing a disabled server does not enable it.
+
 ## OAuth Authentication
 
 Some MCP servers (like Notion MCP) require OAuth authentication instead of API keys. OpenHands supports OAuth-based MCP servers through the [FastMCP](https://gofastmcp.com/) library.
@@ -38550,11 +38655,10 @@ Navigate to the `Settings > Secrets` page. Here, you'll see a list of all your e
 ## Editing a Secret
 
 1. Click the `Edit` button next to the secret you want to modify.
-2. You can update the name and description of the secret.
-<Note>
-  For security reasons, you cannot view or edit the value of an existing secret. If you need to change the
-  value, delete the secret and create a new one.
-</Note>
+2. Update its name, value, or description.
+3. Save the changes.
+
+For security, the existing value is not displayed. Enter a replacement value when you need to overwrite it.
 
 ## Deleting a Secret
 
@@ -40970,6 +41074,39 @@ make a POST request to the V1 app-conversations endpoint.
   </Tab>
 </Tabs>
 
+#### Optional observability fields
+
+When starting a conversation, you can attach observability context to the trace:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `observability_span_name` | string | Creates a named child span under the root `conversation` span. Use stable, low-cardinality names for grouping and signal routing. |
+| `observability_tags` | string array | Adds tags to the conversation root observability span. |
+| `observability_metadata` | object | Adds trace-level metadata. Values must be scalars or homogeneous scalar arrays, such as strings, numbers, booleans, `string[]`, `number[]`, or `boolean[]`. |
+
+Example:
+
+```json
+{
+  "initial_message": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Evaluate this repository against the WB rubric."
+      }
+    ]
+  },
+  "selected_repository": "yourusername/your-repo",
+  "observability_span_name": "wb_rubric_eval",
+  "observability_tags": ["wb-rubric", "evaluation"],
+  "observability_metadata": {
+    "evaluation": "wb",
+    "attempt": 1,
+    "replay": false
+  }
+}
+```
+
 #### Response
 
 The API will return a JSON object with details about the conversation start task:
@@ -41698,6 +41835,116 @@ Once you've connected your account, you can:
 - [Use OpenHands with your Bitbucket repositories](/openhands/usage/cloud/bitbucket-installation).
 - [Learn about the Cloud UI](/openhands/usage/cloud/cloud-ui).
 - [Install the OpenHands Slack app](/openhands/usage/cloud/slack-installation).
+
+### Budgets
+Source: https://docs.openhands.dev/openhands/usage/cloud/organizations/budgets.md
+
+## Overview
+
+Budgets let Admins and Owners cap AI spend at both the organization and individual user level. Use them to
+prevent runaway costs, give new members sensible default limits, and adjust limits on a per-user basis as
+needs change.
+
+<Note>
+  Managing budgets requires Admin or Owner permissions.
+</Note>
+
+## Budget Types
+
+OpenHands supports three complementary budget controls:
+
+- **Organization Budget** - A monthly spending cap for the entire organization, with alerts at defined thresholds.
+- **Default User Budget** - A budget automatically applied to new members when they join the organization.
+- **User Budget Overrides** - Per-user adjustments that raise or lower an individual's budget.
+
+## Organization Budget
+
+The organization budget defines the maximum amount your organization can spend on AI usage in a given month.
+When usage approaches or exceeds the cap, OpenHands notifies Admins and Owners.
+
+### Setting the Monthly Budget
+
+1. Hover over the profile icon in the lower left — an account menu will appear.
+2. Select **Organization**.
+3. Select the `Budgets` tab.
+4. Under `Organization Budget`, enter your monthly spending cap (e.g., `$10,000`).
+5. Click `Save Changes`.
+
+### Budget Alerts
+
+Once a monthly cap is set, OpenHands automatically tracks organization-wide spend and sends alerts to Admins
+and Owners when usage reaches the following thresholds:
+
+- **80%** of the monthly budget — early warning.
+- **90%** of the monthly budget — approaching the cap.
+- **100%** of the monthly budget — the cap has been reached.
+
+<Warning>
+  When the organization reaches 100% of its monthly budget, new conversations may be blocked until the next
+  billing cycle or until the budget is increased.
+</Warning>
+
+The budget resets automatically at the start of each calendar month.
+
+## Default User Budget
+
+The default user budget is applied to every new member when they are added to the organization. This ensures
+new users cannot spend beyond a defined amount before an Admin reviews their usage.
+
+### Setting the Default Budget
+
+1. Hover over the profile icon in the lower left — an account menu will appear.
+2. Select **Organization**.
+3. Select the `Budgets` tab.
+4. Under `Default User Budget`, enter the amount every new member should start with (e.g., `$500`).
+5. Click `Save Changes`.
+
+<Note>
+  Default user budgets are currently **lifetime budgets** — they represent the total amount a user can spend
+  from when they join until an Admin increases the limit. Monthly user budgets are on the roadmap.
+</Note>
+
+New members added to the organization after this setting is saved will automatically inherit the default
+budget. Existing members are not affected.
+
+## User Budget Overrides
+
+Admins and Owners can override an individual user's budget at any time — for example, to raise a developer's
+limit from `$500` to `$1,000` once they reach their default cap.
+
+### Adjusting a User's Budget
+
+1. Hover over the profile icon in the lower left — an account menu will appear.
+2. Select **Organization**.
+3. Select the `Members` tab.
+4. Locate the user in the member list and open their row.
+5. Update the `Budget` field to the new amount (increase or decrease).
+6. Click `Save Changes`.
+
+The new limit takes effect immediately. If the user was previously blocked by their old limit, they will be
+able to resume usage until the new limit is reached.
+
+## Monitoring Budget Usage
+
+Budget usage is visible from the **Organization** settings page:
+
+- The `Budgets` tab shows the current organization-wide spend against the monthly cap.
+- The `Members` tab shows each user's current spend against their individual budget.
+
+For programmatic access to per-member usage data, use:
+
+```
+GET /api/organizations/{org_id}/members/financial
+```
+
+This endpoint returns the current spend for each member, which you can compare against their configured
+budget.
+
+## Next Steps
+
+- [Organization Settings](/openhands/usage/cloud/organizations/settings) - Configure LLMs, credits, and Git organization claims.
+- [Managing Members](/openhands/usage/cloud/organizations/managing-members) - Invite users and manage roles.
+- [Roles and Permissions](/openhands/usage/cloud/organizations/roles-permissions) - Understand permission levels.
 
 ### Managing Members
 Source: https://docs.openhands.dev/openhands/usage/cloud/organizations/managing-members.md
@@ -42754,197 +43001,59 @@ At some point, we may transfer custody of OpenHands to an open source foundation
 ### Contributing
 Source: https://docs.openhands.dev/overview/contributing.md
 
-# Contributing to OpenHands
+# Contributing To OpenHands
 
-Welcome to the OpenHands community! We're building the future of AI-powered software development, and we'd love for you to be part of this journey.
+OpenHands is developed across several repositories. Choose the repository that owns the component you want to change, then follow that repository's setup and contribution guidance.
 
-## Our Vision: Free as in Freedom
+## Find The Right Repository
 
-The OpenHands community is built around the belief that **AI and AI agents are going to fundamentally change the way we build software**, and if this is true, we should do everything we can to make sure that the benefits provided by such powerful technology are **accessible to everyone**.
+| Area | Repository | Guidance | Issues | License |
+|------|------------|----------|--------|---------|
+| **Agent Canvas** | [`OpenHands/OpenHands`](https://github.com/OpenHands/OpenHands) | [README](https://github.com/OpenHands/OpenHands#quickstart) and [development docs](https://github.com/OpenHands/OpenHands/tree/main/docs) | [Issues](https://github.com/OpenHands/OpenHands/issues) | [License](https://github.com/OpenHands/OpenHands/blob/main/LICENSE) |
+| **Software Agent SDK and Agent Server** | [`OpenHands/software-agent-sdk`](https://github.com/OpenHands/software-agent-sdk) | [Development guide](https://github.com/OpenHands/software-agent-sdk/blob/main/DEVELOPMENT.md) and [contribution guide](https://github.com/OpenHands/software-agent-sdk/blob/main/CONTRIBUTING.md) | [Issues](https://github.com/OpenHands/software-agent-sdk/issues) | [License](https://github.com/OpenHands/software-agent-sdk/blob/main/LICENSE) |
+| **Sandbox Server** | [`OpenHands/sandbox-server`](https://github.com/OpenHands/sandbox-server) | [README](https://github.com/OpenHands/sandbox-server#local-development) | [Issues](https://github.com/OpenHands/sandbox-server/issues) | [License](https://github.com/OpenHands/sandbox-server/blob/main/LICENSE) |
+| **OpenHands CLI** | [`OpenHands/OpenHands-CLI`](https://github.com/OpenHands/OpenHands-CLI) | [Contribution guide](https://github.com/OpenHands/OpenHands-CLI/blob/main/CONTRIBUTING.md) | [Issues](https://github.com/OpenHands/OpenHands-CLI/issues) | [License](https://github.com/OpenHands/OpenHands-CLI/blob/main/LICENSE) |
+| **Documentation** | [`OpenHands/docs`](https://github.com/OpenHands/docs) | [Repository guide](https://github.com/OpenHands/docs/blob/main/AGENTS.md) | [Issues](https://github.com/OpenHands/docs/issues) | Check the repository before reuse |
+| **Evaluations and benchmarks** | [`OpenHands/benchmarks`](https://github.com/OpenHands/benchmarks) | [Contribution guide](https://github.com/OpenHands/benchmarks/blob/main/CONTRIBUTING.md) | [Issues](https://github.com/OpenHands/benchmarks/issues) | [License](https://github.com/OpenHands/benchmarks/blob/main/LICENSE) |
 
-We believe in the power of open source to democratize access to cutting-edge AI technology. Just as the internet transformed how we share information, we envision a world where AI-powered development tools are available to every developer, regardless of their background or resources.
+OpenHands Enterprise development is maintained privately. For an Enterprise support request or product question, use your support channel or [contact the OpenHands team](https://openhands.dev/enterprise).
 
-If this resonates with you, we'd love to have you join us in our quest!
+<Note>
+  The former OpenHands monorepo is preserved in the read-only [`OpenHands/legacy`](https://github.com/OpenHands/legacy) repository. Route active Canvas, SDK, Agent Server, Sandbox Server, CLI, and evaluation work to the repositories above.
+</Note>
 
-## 🚀 Getting Started
+## Start Contributing
 
-Ready to contribute? Here's your path to making an impact:
+1. Open the repository that owns your change.
+2. Read its `README`, `AGENTS.md`, and contribution or development guide when present.
+3. Search the repository's existing issues and pull requests.
+4. For a substantial change, open or join an issue before implementation so maintainers can confirm the direction.
+5. Run the repository's required formatting, linting, and tests before opening a pull request.
 
-### 1. Quick Wins
-Start with these easy contributions:
-- **Use OpenHands** and [report issues](https://github.com/OpenHands/OpenHands/issues) you encounter
-- **Give feedback** using the thumbs-up/thumbs-down buttons after each session
-- **Star our repository** on [GitHub](https://github.com/OpenHands/OpenHands)
-- **Share OpenHands** with other developers
+Good first issues are labeled per repository. Browse the [OpenHands organization repositories](https://github.com/orgs/OpenHands/repositories), or ask in the [OpenHands Slack community](https://openhands.dev/joinslack) if you are unsure where a change belongs.
 
-### 2. Set Up Your Development Environment
-Follow our setup guide:
-- **Requirements**: Linux/Mac/WSL, Docker, Python 3.12, Node.js 22+, Poetry 1.8+
-- **Quick setup**: `make build` to get everything ready
-- **Configuration**: `make setup-config` to configure your LLM
-- **Run locally**: `make run` to start the application
+## Pull Request Guidance
 
-*Full details in our [Development Guide](https://github.com/OpenHands/OpenHands/blob/main/Development.md)*
+Keep pull requests focused on one component and explain:
 
-### 3. Find Your First Issue
-Look for beginner-friendly opportunities:
-- Browse [good first issues](https://github.com/OpenHands/OpenHands/labels/good%20first%20issue)
-- Check our [project boards](https://github.com/OpenHands/OpenHands/projects) for organized tasks
-- Ask in [Slack](https://openhands.dev/joinslack) what needs help
+- What changed and why
+- Which issue the change addresses
+- How you tested it
+- Any user-facing behavior or compatibility impact
+- Screenshots for visible Agent Canvas changes
 
-### 4. Join the Community
-Connect with other contributors in our [Slack Community](https://openhands.dev/joinslack). You can connect with OpenHands contributors, maintainers, and more!
+Follow the target repository's title, changelog, and review requirements. Architecture and agent-behavior changes usually need more design discussion than small bug fixes or documentation corrections.
 
-## 📋 How to Contribute Code
+## Other Ways To Contribute
 
-### Understanding the Codebase
-Get familiar with our architecture:
-- **[Frontend](https://github.com/OpenHands/OpenHands/tree/main/frontend/README.md)** - React application
-- **[Backend](https://github.com/OpenHands/OpenHands/tree/main/openhands/README.md)** - Python core
-- **[Agents](https://github.com/OpenHands/OpenHands/tree/main/openhands/agenthub/README.md)** - AI agent implementations
-- **[Runtime](https://github.com/OpenHands/OpenHands/tree/main/openhands/runtime/README.md)** - Execution environments
-- **[Evaluation](https://github.com/OpenHands/benchmarks)** - Testing and benchmarks
+- Report reproducible issues in the repository that owns the affected component.
+- Improve guides and API documentation in [`OpenHands/docs`](https://github.com/OpenHands/docs).
+- Add or improve evaluations in [`OpenHands/benchmarks`](https://github.com/OpenHands/benchmarks).
+- Answer questions and share feedback in the [OpenHands Slack community](https://openhands.dev/joinslack).
 
-### Pull Request Process
-We welcome pull requests across our public repositories! Here's how we evaluate them:
+## Community Standards
 
-<Warning>
-**Enterprise Directory Restriction:** We cannot accept pull requests for changes in the `enterprise/` directory of the OpenHands repository at this time, as this part of the codebase is commercially licensed. If you have feedback or suggestions for [OpenHands Enterprise](/enterprise/index), please [create an issue](https://github.com/OpenHands/OpenHands/issues) in the OpenHands repository instead.
-</Warning>
-
-#### Small Improvements
-- Quick review and approval for obvious improvements
-- Make sure CI tests pass
-- Include clear description of changes
-
-#### Core Agent Changes
-We're more careful with agent changes since they affect user experience:
-- **Accuracy** - Does it make the agent better at solving problems?
-- **Efficiency** - Does it improve speed or reduce resource usage?
-- **Code Quality** - Is the code maintainable and well-tested?
-
-*Discuss major changes in [GitHub issues](https://github.com/OpenHands/OpenHands/issues) or [Slack](https://openhands.dev/joinslack) first!*
-
-### Pull Request Guidelines
-We recommend the following for smooth reviews but they're not required. Just know that the more you follow these guidelines, the more likely you'll get your PR reviewed faster and reduce the quantity of revisions.
-
-**Title Format:**
-- `feat: Add new agent capability`
-- `fix: Resolve memory leak in runtime`
-- `docs: Update installation guide`
-- `style: Fix code formatting`
-- `refactor: Simplify authentication logic`
-- `test: Add unit tests for parser`
-
-**Description:**
-- Explain what the PR does and why
-- Link to related issues
-- Include screenshots for UI changes
-- Add changelog entry for user-facing changes
-
-## What Can You Build?
-
-There are countless ways to contribute to OpenHands. Whether you're a seasoned developer, a researcher, a designer, or someone just getting started, there's a place for you in our community.
-
-### Frontend & UI/UX
-Make OpenHands more beautiful and user-friendly:
-- **React & TypeScript Development** - Improve the web interface
-- **UI/UX Design** - Enhance user experience and accessibility  
-- **Mobile Responsiveness** - Make OpenHands work great on all devices
-- **Component Libraries** - Build reusable UI components
-
-*Small fixes are always welcome! For bigger changes, join our **#eng-ui-ux** channel in [Slack](https://openhands.dev/joinslack) first.*
-
-### Agent Development
-Help make our AI agents smarter and more capable:
-- **Prompt Engineering** - Improve how agents understand and respond
-- **New Agent Types** - Create specialized agents for different tasks
-- **Agent Evaluation** - Develop better ways to measure agent performance
-- **Multi-Agent Systems** - Enable agents to work together
-
-*We use [SWE-bench](https://www.swebench.com/) to evaluate our agents. Join our  [Slack](https://openhands.dev/joinslack) to learn more.*
-
-### Backend & Infrastructure
-Build the foundation that powers OpenHands:
-- **Python Development** - Core functionality and APIs
-- **Runtime Systems** - Docker containers and sandboxes
-- **Cloud Integrations** - Support for different cloud providers
-- **Performance Optimization** - Make everything faster and more efficient
-
-### Testing & Quality Assurance
-Help us maintain high quality:
-- **Unit Testing** - Write tests for new features
-- **Integration Testing** - Ensure components work together
-- **Bug Hunting** - Find and report issues
-- **Performance Testing** - Identify bottlenecks and optimization opportunities
-
-### Documentation & Education
-Help others learn and contribute:
-- **Technical Documentation** - API docs, guides, and tutorials
-- **Video Tutorials** - Create learning content
-- **Translation** - Make OpenHands accessible in more languages
-- **Community Support** - Help other users and contributors
-
-### Research & Innovation
-Push the boundaries of what's possible:
-- **Academic Research** - Publish papers using OpenHands
-- **Benchmarking** - Develop new evaluation methods
-- **Experimental Features** - Try cutting-edge AI techniques
-- **Data Analysis** - Study how developers use AI tools
-
-## Becoming a Maintainer
-
-For contributors who have made significant and sustained contributions to the project, there is a possibility of joining the maintainer team.
-The process for this is as follows:
-
-1. Any contributor who has made sustained and high-quality contributions to the codebase can be nominated by any maintainer. If you feel that you may qualify you can reach out to any of the maintainers that have reviewed your PRs and ask if you can be nominated.
-2. Once a maintainer nominates a new maintainer, there will be a discussion period among the maintainers for at least 3 days.
-3. If no concerns are raised the nomination will be accepted by acclamation, and if concerns are raised there will be a discussion and possible vote.
-
-Note that just making many PRs does not immediately imply that you will become a maintainer. We will be looking at sustained high-quality contributions over a period of time, as well as good teamwork and adherence to our [Code of Conduct](https://github.com/OpenHands/OpenHands/blob/main/CODE_OF_CONDUCT.md).
-
-## License
-
-OpenHands is released under the **MIT License**, which means:
-
-### You Can:
-- **Use** OpenHands for any purpose, including commercial projects
-- **Modify** the code to fit your needs
-- **Share** your modifications
-- **Distribute** or sell copies of OpenHands
-
-### You Must:
-- **Include** the original copyright notice and license text
-- **Preserve** the license in any substantial portions you use
-
-### No Warranty:
-- OpenHands is provided "as is" without warranty
-- Contributors are not liable for any damages
-
-*Full license text: [LICENSE](https://github.com/OpenHands/OpenHands/blob/main/LICENSE)*
-
-**Special Note:** Content in the `enterprise/` directory has a separate license, and we cannot accept external pull requests for changes to this directory at this time. See `enterprise/LICENSE` for details.
-
-## Ready to make your first contribution?
-
-1. **⭐ Star** our [GitHub repository](https://github.com/OpenHands/OpenHands)
-2. **🔧 Set up** your development environment using our [Development Guide](https://github.com/OpenHands/OpenHands/blob/main/Development.md)
-3. **💬 Join** our [Slack community](https://openhands.dev/joinslack) to meet other contributors
-4. **🎯 Find** a [good first issue](https://github.com/OpenHands/OpenHands/labels/good%20first%20issue) to work on
-5. **📝 Read** our [Code of Conduct](https://github.com/OpenHands/OpenHands/blob/main/CODE_OF_CONDUCT.md)
-
-## Need Help?
-
-Don't hesitate to ask for help:
-- **Slack**: [Join our community](https://openhands.dev/joinslack) for real-time support
-- **GitHub Issues**: [Open an issue](https://github.com/OpenHands/OpenHands/issues) for bugs or feature requests
-- **Email**: Contact us at [contact@openhands.dev](mailto:contact@openhands.dev)
-
----
-
-Thank you for considering contributing to OpenHands! Together, we're building tools that will democratize AI-powered software development and make it accessible to developers everywhere. Every contribution, no matter how small, helps us move closer to that vision. 
-
-Welcome to the community! 🎉
+Follow the community and contribution guidance in the repository you are changing. Be respectful, provide enough context for maintainers to reproduce problems, and keep technical discussion focused on the proposed change.
 
 ### FAQs
 Source: https://docs.openhands.dev/overview/faqs.md
@@ -42979,23 +43088,15 @@ input on our product roadmap.
 
 ### It's doing stuff without asking, is that safe?
 
-**Generally yes, but with important considerations.** OpenHands runs all code in a secure, isolated Docker container
-(called a "sandbox") that is separate from your host system. However, the safety depends on your configuration:
-
-**What's protected:**
-- Your host system files and programs (unless you mount them using [this feature](/openhands/usage/sandboxes/docker#connecting-to-your-filesystem))
-- Host system resources
-- Other containers and processes
+**Safety depends on the backend and workspace you select.** A local process backend runs Agent Server and tools directly on its host. Docker, Kubernetes, Sandbox Server, Cloud, and Enterprise deployments can provide stronger isolation according to their container, sandbox, mount, and network configuration.
 
 **Potential risks to consider:**
-- The agent can access the internet from within the container.
-- If you provide credentials (API keys, tokens), the agent can use them.
-- Mounted files and directories can be modified or deleted.
-- Network requests can be made to external services.
+- The agent can modify any files exposed to its workspace.
+- The agent can use credentials and network access available to its execution environment.
+- A local process backend can access the host with the permissions of the user running Agent Server.
+- Container isolation can be weakened by broad mounts, privileged mode, host networking, or access to the Docker socket.
 
-For detailed security information, see our [Runtime Architecture](/openhands/usage/architecture/runtime),
-[Security Configuration](/openhands/usage/advanced/configuration-options#security-configuration),
-and [Hardened Docker Installation](/openhands/usage/sandboxes/docker#hardened-docker-installation) documentation.
+For current component and trust boundaries, see [Agent Canvas Architecture](/openhands/usage/agent-canvas/architecture), [Security Configuration](/openhands/usage/advanced/configuration-options#security-configuration), and [Hardened Docker Installation](/openhands/usage/sandboxes/docker#hardened-docker-installation).
 
 ## File Storage and Access
 
@@ -43177,67 +43278,70 @@ Source: https://docs.openhands.dev/overview/introduction.md
 There are a few ways to work with OpenHands:
 
 ## Agent Canvas
-Agent Canvas is a browser-based UI and backend server for running agents and automations. A single `agent-canvas` command starts the full stack locally. Self-host on a VM, or connect to OpenHands Cloud.
 
-[Get started with Agent Canvas](/openhands/usage/agent-canvas/overview) or [view the source](https://github.com/OpenHands/agent-canvas)
+[Agent Canvas](/openhands/usage/agent-canvas/overview) is the open-source browser client and control center for agent conversations and automations. It connects to one or more Agent Server backends.
+
+The `agent-canvas` launcher can start Canvas with local backend services as an all-in-one stack. You can also run the client separately and connect it to a local, self-hosted, Cloud, or Enterprise backend.
+
+[Get started with Agent Canvas](/openhands/usage/agent-canvas/overview) or [view the source](https://github.com/OpenHands/OpenHands).
+
+## OpenHands Software Agent SDK and Agent Server
+
+The [Software Agent SDK](/sdk) is a composable Python library for building agents that work with code. The same repository contains Agent Server, which exposes agent execution, conversations, tools, and workspaces through REST and WebSocket APIs.
+
+[Get started with the SDK](/sdk/getting-started) or [view the source](https://github.com/OpenHands/software-agent-sdk).
+
+## Sandbox Server
+
+[Sandbox Server](https://github.com/OpenHands/sandbox-server) is the standalone OpenHands API and sandbox control plane. It creates and manages sandboxed environments that host Agent Server. It does not bundle a frontend; use Agent Canvas as its browser client.
 
 ## OpenHands Cloud
-A fully managed version of OpenHands with source-available features and integrations:
-- Deeper integrations with GitHub, GitLab, and Bitbucket
-- Integrations with Slack, Jira, and Linear
-- Multi-user support
-- RBAC and permissions
-- Collaboration features (e.g., conversation sharing)
-- Usage reporting
-- Budgeting enforcement
 
-Try it free by [signing in with your GitHub account](https://app.all-hands.dev).
+[OpenHands Cloud](/openhands/usage/cloud/openhands-cloud) is the managed commercial service for running OpenHands without operating your own backend and sandbox infrastructure. It provides hosted execution, integrations, collaboration, access controls, usage reporting, and budget management.
+
+[Sign in with your GitHub account](https://app.all-hands.dev) to try it.
 
 ## OpenHands Enterprise
-Large enterprises can work with us to self-host OpenHands Cloud in their own VPC, via Kubernetes.
-OpenHands Enterprise can also work with the CLI and SDK above.
 
-OpenHands Enterprise is source-available--you can see all the source code here in the enterprise/ directory,
-but you'll need to purchase a license if you want to run it for more than one month.
+[OpenHands Enterprise](/enterprise) provides commercial capabilities and support for organizations that need licensed self-hosting or managed deployment options. Enterprise development lives in a private repository rather than a public `enterprise/` directory.
 
-Enterprise contracts also come with extended support and access to our research team.
+Learn more at [openhands.dev/enterprise](https://openhands.dev/enterprise).
 
-Learn more at [openhands.dev/enterprise](https://openhands.dev/enterprise)
+## Component And Repository Map
 
-## OpenHands Software Agent SDK
-The SDK is a composable Python library that contains all of our agentic tech. It's the engine that powers everything else.
+| Component | Responsibility | Source |
+|-----------|----------------|--------|
+| **Agent Canvas** | Browser client and control center | [`OpenHands/OpenHands`](https://github.com/OpenHands/OpenHands) |
+| **Software Agent SDK and Agent Server** | Agent framework and remote execution API | [`OpenHands/software-agent-sdk`](https://github.com/OpenHands/software-agent-sdk) |
+| **Automation Server** | Scheduled and event-driven automation lifecycle | [`OpenHands/automation`](https://github.com/OpenHands/automation) |
+| **Sandbox Server** | Standalone API and sandbox control plane | [`OpenHands/sandbox-server`](https://github.com/OpenHands/sandbox-server) |
+| **OpenHands CLI** | Terminal, IDE, and headless client | [`OpenHands/OpenHands-CLI`](https://github.com/OpenHands/OpenHands-CLI) |
+| **Documentation** | Documentation for the OpenHands ecosystem | [`OpenHands/docs`](https://github.com/OpenHands/docs) |
+| **Evaluations** | Benchmark and evaluation infrastructure | [`OpenHands/benchmarks`](https://github.com/OpenHands/benchmarks) |
 
-Define agents in code, then run them locally, or scale to 1000s of agents in the cloud.
-
-[Check out the docs](https://docs.openhands.dev/sdk) or [view the source](https://github.com/OpenHands/software-agent-sdk)
+Each public repository includes its own license. Check the repository you use or modify instead of assuming one license applies to the entire ecosystem.
 
 ## Legacy
 
 <Accordion title="OpenHands CLI and Local GUI">
   **OpenHands CLI**
 
-  The CLI is a terminal-based interface for running OpenHands agents. You can power it with Claude, GPT, or any other LLM.
+  The CLI is a terminal-based interface powered by the Software Agent SDK. It is feature-complete and primarily maintained for stability.
 
-  [Check out the docs](https://docs.openhands.dev/openhands/usage/run-openhands/cli-mode) or [view the source](https://github.com/OpenHands/OpenHands-CLI)
+  [Check out the docs](/openhands/usage/cli/installation) or [view the source](https://github.com/OpenHands/OpenHands-CLI).
 
   **OpenHands Local GUI**
 
-  A legacy UI requiring Docker for running agents on your laptop. It comes with a REST API and a single-page React application.
+  The Local GUI is the deprecated Docker-based browser application from the former OpenHands monorepo. Use Agent Canvas for active browser-client development.
 
-  [Check out the docs](https://docs.openhands.dev/openhands/usage/run-openhands/local-setup) or view the source in this repo.
+  [Check out the legacy docs](/openhands/usage/run-openhands/local-setup) or [view the pinned source](https://github.com/OpenHands/legacy/tree/ee9e78b7defdfa744e0bbe48c9cafa90b6135ad7).
 </Accordion>
 
-## Everything Else
+The archived [`OpenHands/legacy`](https://github.com/OpenHands/legacy/tree/ee9e78b7defdfa744e0bbe48c9cafa90b6135ad7) snapshot also preserves the previous backend and runtime architecture for historical reference. For active agent and Agent Server development, use the [Software Agent SDK repository](https://github.com/OpenHands/software-agent-sdk).
 
-Check out our [Product Roadmap](https://github.com/orgs/openhands/projects/1), and feel free to
-[open up an issue](https://github.com/OpenHands/OpenHands/issues) if there's something you'd like to see!
+## Community
 
-You might also be interested in our [evaluation infrastructure](https://github.com/OpenHands/benchmarks), our [chrome extension](https://github.com/OpenHands/openhands-chrome-extension/), or our [Theory-of-Mind module](https://github.com/OpenHands/ToM-SWE).
-
-All our work is available under the MIT license, except for the `enterprise/` directory in this repository (see the [enterprise license](https://github.com/OpenHands/OpenHands/blob/main/enterprise/LICENSE) for details).
-The core `openhands` and `agent-server` Docker images are fully MIT-licensed as well.
-
-If you need help with anything, or just want to chat, [come find us on Slack](https://openhands.dev/joinslack).
+Check the [product roadmap](https://github.com/orgs/openhands/projects/1), explore all [OpenHands repositories](https://github.com/orgs/OpenHands/repositories), or [join us on Slack](https://openhands.dev/joinslack).
 
 ### Model Context Protocol (MCP)
 Source: https://docs.openhands.dev/overview/model-context-protocol.md
@@ -43892,152 +43996,142 @@ Get started with OpenHands in minutes.
   </Card>
 </CardGroup>
 
-### Overview
+### Skills Overview
 Source: https://docs.openhands.dev/overview/skills.md
 
-Skills are specialized prompts that enhance OpenHands with domain-specific knowledge, expert guidance, and automated task handling. They provide consistent practices across projects and can be triggered automatically based on keywords or context.
+Skills give OpenHands reusable instructions for specialized tasks. A skill can capture domain knowledge, define a repeatable workflow, and include supporting scripts, references, or templates.
+
+Skills guide the agent's behavior; they do not grant permissions or install dependencies by themselves. The agent can only use the files, tools, secrets, and network access available in its environment.
 
 <Info>
-OpenHands supports an **extended version** of the [AgentSkills standard](https://agentskills.io/specification) with optional keyword triggers for automatic activation. See the [SDK Skills Guide](/sdk/guides/skill) for details on the SKILL.md format.
+OpenHands supports the [Agent Skills specification](https://agentskills.io/specification) and adds optional features such as keyword triggers and path-triggered rules. Other Agent Skills clients may ignore these OpenHands extensions.
 </Info>
+
+## Choose the Right Mechanism
+
+| Need | Use | Recommended Location | Loading Behavior |
+|---|---|---|---|
+| Instructions for every task in a repository | `AGENTS.md` | Repository root | Full content is included in the initial system prompt |
+| Reusable expertise or a workflow for a specific task | Agent Skills `SKILL.md` | `.agents/skills/<skill-name>/SKILL.md` | Name and description are advertised first; the agent invokes the full skill when relevant |
+| Automatic activation for specific words or commands | `SKILL.md` with `triggers` | `.agents/skills/<skill-name>/SKILL.md` | The skill remains available for model invocation and its content is also injected when a trigger matches |
+| Deterministic guidance for specific files | A skill with `paths` | `.agents/skills/<skill-name>/SKILL.md` or `.agents/skills/<rule-name>.md` | Content is injected when the agent first touches a matching file |
+
+Use `AGENTS.md` for short, repository-wide conventions. Use `SKILL.md` for focused knowledge that is needed only for some tasks. A legacy `.md` skill without a trigger is always loaded in full; prefer `AGENTS.md` for that use case so its purpose is clear.
+
+OpenHands also recognizes `CLAUDE.md` and `GEMINI.md` as model-specific repository context.
+
+## How Progressive Disclosure Works
+
+Agent Skills use three levels of context:
+
+1. **Discovery**: OpenHands loads each skill's `name` and `description` into the available-skills catalog.
+2. **Invocation**: When a task matches the description, the agent invokes the skill by name and receives the full `SKILL.md` instructions.
+3. **Resources**: The agent reads referenced files from `scripts/`, `references/`, or `assets/` only when needed.
+
+This keeps the initial prompt smaller than loading every skill in full. Write the description to explain both what the skill does and when it applies; the agent uses that metadata to decide whether to invoke it.
+
+OpenHands supports two deterministic activation paths:
+
+- `triggers` injects the skill when a keyword or command appears in a user message. The skill is still available for model invocation.
+- `paths` turns the file into a path-triggered rule. The rule is not advertised to the model and is injected once per conversation when a matching file is read, edited, or created. If a file declares both `paths` and `triggers`, `paths` takes precedence.
+
+<Note>
+Always-on content occupies the conversation context from the beginning. Keep `AGENTS.md` concise and move lengthy or specialized instructions into on-demand skills and references.
+</Note>
 
 ## Official Skill Registry
 
 The official global skill registry is maintained at [github.com/OpenHands/extensions](https://github.com/OpenHands/extensions). This repository contains community-shared skills that can be used by all OpenHands agents. You can browse available skills, contribute your own, and learn from examples created by the community.
 
-## How Skills Work
 
-Skills inject additional context and rules into the agent's behavior.
+## Five-Minute Setup
 
-At a high level, OpenHands supports three loading models:
+Add concise repository guidance and one on-demand skill:
 
-- **Always-on context** (e.g., `AGENTS.md`) that is injected into the system prompt at conversation start.
-- **On-demand skills** that are either:
-  - **triggered by the user** (keyword matches), or
-  - **invoked by the agent** (the agent decides to look up the full skill content).
-- **Path-triggered rules** that are injected deterministically when the agent reads, edits, or creates a file whose path matches a glob pattern.
-
-## Permanent agent context (recommended)
-
-For repository-wide, always-on instructions, prefer a root-level `AGENTS.md` file.
-
-We also support model-specific variants:
-- `GEMINI.md` for Gemini
-- `CLAUDE.md` for Claude
-
-## Triggered and optional skills
-
-To add optional skills that are loaded on demand:
-
-- **AgentSkills standard (recommended for progressive disclosure)**: create one directory per skill and add a `SKILL.md` file.
-- **Legacy/OpenHands format (simple)**: put markdown files in `.agents/skills/*.md` at the repository root.
-
-<Note>
-Loaded skills take up space in the context window. On-demand skills help keep the system prompt smaller because the agent sees a summary first and reads the full content only when needed.
-</Note>
-
-### Example Repository Structure
-
-```
-some-repository/
-├── AGENTS.md                       # Permanent repository guidelines (recommended)
+```text
+my-repository/
+├── AGENTS.md
 └── .agents/
     └── skills/
-        ├── rot13-encryption/       # AgentSkills standard (progressive disclosure)
-        │   ├── SKILL.md
-        │   ├── scripts/
-        │   │   └── rot13.sh
-        │   └── references/
-        │       └── README.md
-        ├── another-agentskill/     # AgentSkills standard (progressive disclosure)
-        │   ├── SKILL.md
-        │   └── scripts/
-        │       └── placeholder.sh
-        └── legacy_trigger_this.md  # Legacy/OpenHands format (keyword-triggered)
+        └── release-checklist/
+            └── SKILL.md
 ```
 
-## Skill Loading Precedence
+```markdown title="AGENTS.md"
+# Repository Guidance
 
-For project location, paths are relative to the repository root; `.agents/skills/` is a subdirectory of the project directory.
-For user home location, paths are relative to the user home: `~/`
+Run the test suite before committing. Keep changes focused and follow the existing project conventions.
+```
 
-When multiple skills share the same name, OpenHands keeps the first match in this order:
+```markdown title=".agents/skills/release-checklist/SKILL.md"
+---
+name: release-checklist
+description: Prepare and verify a release checklist. Use when creating release notes or publishing a release.
+---
 
-1. `.agents/skills/` (recommended)
-2. `.openhands/skills/` (deprecated)
-3. `.openhands/microagents/` (deprecated)
+Check the version, changelog, validation commands, and release notes before publishing.
+```
 
-Project-specific skills take precedence over user skills.
+For a portable Agent Skills package, `name` and `description` are required. The `name` must match the parent directory and use lowercase letters, numbers, and hyphens. See [Creating Skills](/overview/skills/creating) for the complete format and authoring guidance.
 
-## Skill Types
+Start a new conversation after changing skill files so OpenHands rebuilds the available-skills catalog.
 
-Currently supported skill types:
+## Skill Locations and Precedence
 
-- **[Permanent Context](/overview/skills/repo)**: Repository-wide guidelines and best practices. We recommend `AGENTS.md` (and optionally `GEMINI.md` / `CLAUDE.md`).
-- **[Keyword-Triggered Skills](/overview/skills/keyword)**: Guidelines activated by specific keywords in user prompts.
-- **[Path-Triggered Rules](/overview/skills/path)**: Guidelines injected automatically when the agent touches files matching a glob pattern.
-- **[Organization Skills](/overview/skills/org)**: Team or organization-wide standards.
-- **[Global Skills](/overview/skills/public)**: Community-shared skills and templates.
+OpenHands can combine skills from several scopes:
 
-### Skills Frontmatter Requirements
+| Scope | Recommended Location | Applies To |
+|---|---|---|
+| Repository context | `<repository>/AGENTS.md` | Conversations in that repository |
+| Project skills | `<project>/.agents/skills/` | Conversations using that project workspace |
+| User skills | `~/.agents/skills/` | Conversations for that user |
+| Public skills | [OpenHands extensions registry](https://github.com/OpenHands/extensions/tree/main/skills) | Conversations configured to load the public registry |
 
-Each skill file may include frontmatter that provides additional information. In some cases, this frontmatter is required:
+Both the legacy `.openhands/skills/` and `.openhands/microagents/` directories remain supported, but use `.agents/skills/` for new skills. This location follows the Agent Skills standard and makes skills portable across compatible agent tools.
 
-| Skill Type  | Required |
-|-------------|----------|
-| General Skills                           | No       |
-| Keyword-Triggered Skills                 | Yes      |
-| Path-Triggered Rules                     | Yes      |
+Name conflicts are resolved by precedence rather than by merging skill bodies. For automatically loaded sources, project skills override user skills, and user skills override public skills. Within a project or user scope, `.agents/skills/` takes precedence over the legacy directories.
 
-## Skills Support Matrix
+<Note>
+In the SDK, explicitly supplied skills override automatically loaded user and public skills. Project skills are resolved from the conversation workspace and override a same-named skill from another source. See the [SDK Skills Guide](/sdk/guides/skill) for loader configuration.
+</Note>
 
-| Platform | Support Level | Configuration Method | Implementation | Documentation |
-|----------|---------------|---------------------|----------------|---------------|
-| **CLI** | ✅ Full Support | `~/.agents/skills/` (user-level) and `.agents/skills/` (repo-level) | File-based markdown | [Skills Overview](/overview/skills) |
-| **SDK** | ✅ Full Support | Programmatic `Skill` objects | Code-based configuration | [SDK Skills Guide](/sdk/guides/skill) |
-| **Local GUI** | ✅ Full Support | `.agents/skills/` + UI | File-based with UI management | [Local Setup](/openhands/usage/run-openhands/local-setup) |
-| **OpenHands Cloud** | ✅ Full Support | Cloud UI + repository integration | Managed skill library | [Cloud UI](/openhands/usage/cloud/cloud-ui) |
+## OpenHands-Specific Skill Types
 
-## Platform-Specific Differences
+- [Repository Context](/overview/skills/repo) provides always-on project instructions.
+- [Keyword-Triggered Skills](/overview/skills/keyword) activate when a user message contains configured terms.
+- [Path-Triggered Rules](/overview/skills/path) apply deterministic instructions to matching files.
+- [Organization and User Skills](/overview/skills/org) share guidance across repositories.
+- [Global Skills](/overview/skills/public) are reusable skills published through the OpenHands extensions registry.
 
-<Tabs>
-  <Tab title="CLI">
-    - File-based configuration in two locations:
-      - `~/.agents/skills/` - User-level skills (all conversations).
-      - `.agents/skills/` - Repository-level skills (current directory)
-    - Markdown format for skill definitions
-    - Manual file management required
-    - Supports both general and keyword-triggered skills
-  </Tab>
-  <Tab title="SDK">
-    - Programmatic `Skill` objects in code
-    - Dynamic skill creation and management
-    - Integration with custom workflows
-    - Full control over skill lifecycle
-  </Tab>
-  <Tab title="Local GUI">
-    - Visual skill management through UI
-    - File-based storage with GUI editing
-    - Real-time skill status display
-    - Drag-and-drop skill organization
-  </Tab>
-  <Tab title="OpenHands Cloud">
-    - Cloud-based skill library management
-    - Team-wide skill sharing and templates
-    - Organization-level skill policies
-    - Integrated skill marketplace
-  </Tab>
-</Tabs>
+## Using Skills Across OpenHands
+
+| Surface | How Skills Are Loaded |
+|---|---|
+| **Agent Canvas** | Manage installed skills under `Customize > Skills`; configuration is scoped to the active backend |
+| **SDK and agent server** | Pass `Skill` objects directly or enable the user, project, and public file-based loaders in `AgentContext` |
+| **OpenHands Cloud** | Select or import skills for a conversation, including skills stored in Git repositories |
+
+In Agent Canvas, disabling a bundled or custom skill prevents it from being included in the agent context for new OpenHands and ACP conversations. Enabled skills remain available to new conversations.
+
+See [Customize and Settings](/openhands/usage/agent-canvas/customize-and-settings) for Agent Canvas and [Plugin Launcher](/openhands/usage/cloud/plugin-launcher) for loading a Git-hosted skill into an OpenHands Cloud conversation.
+
+<Warning>
+Review a skill and its bundled resources before installing it. A skill can instruct the agent to run scripts, read files, use secrets, or call connected tools. Only install skills from sources you trust.
+</Warning>
+
+## Next Steps
+
+- [Add an Existing Skill](/overview/skills/adding)
+- [Create a Skill](/overview/skills/creating)
+- [Browse the OpenHands Skills Registry](https://github.com/OpenHands/extensions/tree/main/skills)
+- [Bundle Skills in a Plugin](/overview/plugins)
+- [Monitor and Improve Skills](/overview/skills/monitoring)
 
 ## Learn More
 
-- **To add existing skills**: See [Adding New Skills](/overview/skills/adding)
-- **To create your own skills**: See [Creating New Skills](/overview/skills/creating)
-- **To monitor skill performance**: See [Monitoring and Improving Skills](/overview/skills/monitoring)
-- **For bundling multiple components**: See [Plugins](/overview/plugins)
-- **For SDK integration**: See [SDK Skills Guide](/sdk/guides/skill)
-- **For architecture details**: See [Skills Architecture](/sdk/arch/skill)
-- **For specific skill types**: See [Repository Skills](/overview/skills/repo), [Keyword Skills](/overview/skills/keyword), [Path-Triggered Rules](/overview/skills/path), [Organization Skills](/overview/skills/org), and [Global Skills](/overview/skills/public)
+- **For SDK integration**: See [**SDK Skills Guide**](/sdk/guides/skill)
+- **For architecture details**: See [**Skills Architecture**](/sdk/arch/skill)
+- **For specific skill types**: See [**Repository Skills**](/overview/skills/repo), [**Keyword Skills**](/overview/skills/keyword), [**Path-Triggered Rules**](/overview/skills/path), [**Organization Skills**](/overview/skills/org), and [**Global Skills**](/overview/skills/public)
 
 ### Adding New Skills
 Source: https://docs.openhands.dev/overview/skills/adding.md
@@ -45475,7 +45569,7 @@ Before you begin, complete the [Quick Start guide](/enterprise/quick-start).
       frontend:
         ingress:
           enabled: true
-          hostname: "analytics.app.<your-base-domain>"
+          hostname: "analytics.<your-base-domain>"
           tls:
             enabled: true
             secretName: "laminar-frontend-tls"
@@ -45528,7 +45622,7 @@ Before you begin, complete the [Quick Start guide](/enterprise/quick-start).
 
 Once the deployment status shows **Ready**, navigate to the Laminar frontend URL:
 
-- VM install: `https://analytics.app.<your-base-domain>`
+- VM install: `https://analytics.<your-base-domain>`
 - Kubernetes install: the hostname configured in `laminar.frontend.ingress.hostname`
 
 Click the **Continue with Keycloak** button:
@@ -45848,6 +45942,39 @@ Conversation startup is asynchronous. The response is a start task. Poll the
 start task until it reaches `READY` and returns `app_conversation_id` and
 `sandbox_id`.
 
+### Add Observability Context
+
+Conversation start requests can include optional observability fields:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `observability_span_name` | string | Creates a named child span under the root `conversation` span. Use stable, low-cardinality names for grouping and signal routing. |
+| `observability_tags` | string array | Adds tags to the conversation root observability span. |
+| `observability_metadata` | object | Adds trace-level metadata. Values must be scalars or homogeneous scalar arrays, such as strings, numbers, booleans, `string[]`, `number[]`, or `boolean[]`. |
+
+```json
+{
+  "initial_message": {
+    "role": "user",
+    "content": [
+      {
+        "type": "text",
+        "text": "Evaluate this repository against the WB rubric."
+      }
+    ],
+    "run": true
+  },
+  "selected_repository": "yourorganization/yourrepository",
+  "observability_span_name": "wb_rubric_eval",
+  "observability_tags": ["wb-rubric", "evaluation"],
+  "observability_metadata": {
+    "evaluation": "wb",
+    "attempt": 1,
+    "replay": false
+  }
+}
+```
+
 ### Pass Secrets At Conversation Start
 
 For credentials needed by only one conversation, include a `secrets` map in
@@ -46056,7 +46183,7 @@ so the agent can refresh only the parts that need updating without a full rebuil
 
 Once your image is built and pushed to a registry, point the Replicated Admin Console at it.
 
-1. Open the **Admin Console** at `https://<your-base-domain>:30000`.
+1. Open the **Admin Console** at `https://admin.<your-base-domain>:30000`.
 2. Navigate to **Config** and find the **Sandbox Image** section.
 3. Set the following fields:
 
@@ -46334,9 +46461,9 @@ OpenHands Enterprise is the right choice when you need:
   <Card
     title="Try Agent Canvas"
     icon="desktop"
-    href="/openhands/usage/run-openhands/local-setup#start-the-app"
+    href="/openhands/usage/agent-canvas/setup"
   >
-    Get started with OpenHands on your local machine using Docker or the CLI launcher.
+    Install Agent Canvas locally with npm, npx, Docker, or a source checkout.
   </Card>
   <Card
     title="Contact Enterprise Sales"
@@ -46513,12 +46640,12 @@ In the Azure portal, create a Microsoft Entra app registration for OpenHands.
 5. Add a **Web** redirect URI:
 
    ```text
-   https://auth.app.<your-openhands-domain>/realms/allhands/broker/azure_devops/endpoint
+   https://<your-auth-hostname>/realms/allhands/broker/azure_devops/endpoint
    ```
 
-   Replace `<your-openhands-domain>` with the domain for your OpenHands
-   Enterprise installation. If you configured a custom authentication hostname,
-   use that hostname instead of `auth.app.<your-openhands-domain>`.
+   Replace `<your-auth-hostname>` with your installation's Authentication
+   hostname (`auth.<your-openhands-domain>` by default), for example
+   `https://auth.openhands.example.com/realms/allhands/broker/azure_devops/endpoint`.
 
 6. Click **Register**.
 7. Copy the **Directory (tenant) ID** and **Application (client) ID**.
@@ -46674,7 +46801,7 @@ To configure this pattern:
 | Symptom | Check |
 | --- | --- |
 | The Azure DevOps login option is not visible | Confirm **Azure DevOps Authentication** is enabled in the Admin Console or Helm values and the deployment has been applied. |
-| OAuth redirects fail | Confirm the Entra redirect URI exactly matches `https://auth.app.<your-openhands-domain>/realms/allhands/broker/azure_devops/endpoint`. |
+| OAuth redirects fail | Confirm the Entra redirect URI exactly matches `https://<your-auth-hostname>/realms/allhands/broker/azure_devops/endpoint`. |
 | Microsoft sign-in shows an invalid client or secret error | Confirm the Azure DevOps Client ID and Client Secret match the Microsoft Entra app registration. If the secret expired, create a new one and redeploy. |
 | Microsoft sign-in succeeds but no repositories are listed | Confirm the user has access to the Azure DevOps organization, project, and repositories. Also confirm the default organization value is the organization name only. |
 | Consent fails or Azure DevOps API calls are denied | Confirm the Entra application has the required Azure DevOps delegated permission and that admin consent has been granted if your tenant requires it. |
@@ -46713,19 +46840,17 @@ The exact menu labels can vary by Bitbucket version, but this is usually under
 
 ![Bitbucket Data Center Application Links settings](../images/bitbucket-data-center-application-links.png)
 
-Use this callback URL:
+Use this callback URL, where `<your-auth-hostname>` is your installation's
+Authentication hostname (`auth.<your-openhands-domain>` by default):
 
 ```text
-https://auth.app.<your-openhands-domain>/realms/allhands/broker/bitbucket_data_center/endpoint
+https://<your-auth-hostname>/realms/allhands/broker/bitbucket_data_center/endpoint
 ```
 
-Replace only `<your-openhands-domain>` in the callback URL. Leave the rest of
-the path unchanged.
-
-Use your actual auth hostname, for example:
+Replace only the hostname. Leave the rest of the path unchanged, for example:
 
 ```text
-https://auth.app.openhands.example.com/realms/allhands/broker/bitbucket_data_center/endpoint
+https://auth.openhands.example.com/realms/allhands/broker/bitbucket_data_center/endpoint
 ```
 
 OpenHands requests the `REPO_ADMIN` OAuth scope so it can list repositories and
@@ -46826,7 +46951,7 @@ when the job starts and when it completes.
 | Symptom | Check |
 | --- | --- |
 | The Bitbucket Data Center login option is not visible | Confirm Bitbucket Data Center Authentication is enabled in the Admin Console and the deployment has been applied. |
-| OAuth redirects fail | Confirm the callback URL exactly matches `https://auth.app.<your-openhands-domain>/realms/allhands/broker/bitbucket_data_center/endpoint`. |
+| OAuth redirects fail | Confirm the callback URL exactly matches `https://<your-auth-hostname>/realms/allhands/broker/bitbucket_data_center/endpoint`. |
 | Login tries to reach an invalid `https://https://...` URL | Remove `https://` from the Bitbucket Data Center Domain field in the Admin Console. |
 | Repository webhook install fails | Confirm the user has repository admin access and the OAuth app grants `REPO_ADMIN`. |
 | Webhook delivery reaches OpenHands but no job starts | Confirm the comment contains `@openhands`, the webhook is installed for that repository, and the mentioning Bitbucket user has signed in to OpenHands. |
@@ -47573,12 +47698,13 @@ OpenHands serves these hostnames, using `openhands.example.com` as the base doma
 | Hostname | Purpose |
 |---|---|
 | `app.openhands.example.com` | Application |
-| `auth.app.openhands.example.com` | Login (Keycloak) |
+| `auth.openhands.example.com` | Login (Keycloak) |
 | `runtime-api.openhands.example.com` | Runtime API |
-| `*.runtime.openhands.example.com` | Per-session sandboxes |
+| `<id>-runtime.openhands.example.com` | Per-session sandboxes |
 
-All of these must resolve to your ingress load balancer. The sandbox entry must be a **wildcard**
-because each session gets its own subdomain.
+All of these must resolve to your ingress load balancer. Every hostname sits one label under the
+base domain, so a single **wildcard** DNS record and certificate for `*.openhands.example.com`
+cover everything, including the dynamically named sandboxes.
 
 ## external-dns
 
@@ -47604,7 +47730,7 @@ With `upsert-only` and a TXT registry, external-dns only ever touches records it
 ## cert-manager
 
 cert-manager issues and renews certificates from Let's Encrypt. Use the **DNS-01** challenge, the
-only one that can issue the **wildcard** certificate the sandbox hostnames need.
+only one that can issue **wildcard** certificates.
 
 <Steps>
   <Step title="Install cert-manager">
@@ -47637,25 +47763,23 @@ only one that can issue the **wildcard** certificate the sandbox hostnames need.
     </Tip>
   </Step>
   <Step title="Request a wildcard certificate">
-    A single wildcard covers every sandbox host. With Traefik, serve it as the default `TLSStore` so
+    A single wildcard covers every hostname. With Traefik, serve it as the default `TLSStore` so
     no per-ingress TLS config is needed.
 
     ```yaml
     apiVersion: cert-manager.io/v1
     kind: Certificate
     metadata:
-      name: runtime-wildcard
+      name: openhands-wildcard
       namespace: openhands
     spec:
-      secretName: runtime-wildcard-tls
+      secretName: openhands-wildcard-tls
       issuerRef:
         name: letsencrypt-prod
         kind: ClusterIssuer
       dnsNames:
-        - "*.runtime.openhands.example.com"
+        - "*.openhands.example.com"
     ```
-
-    Issue certificates for the `app`, `auth`, and `runtime-api` hosts the same way.
   </Step>
 </Steps>
 
@@ -47664,18 +47788,16 @@ only one that can issue the **wildcard** certificate the sandbox hostnames need.
 If you don't run external-dns and cert-manager, provision these by hand and point the ingress
 controller at them.
 
-**DNS**: create a record for each hostname in the table above, all pointing to your ingress load
-balancer (typically a CNAME to the load balancer's hostname, or a cloud DNS alias). The sandbox
-record must be the wildcard `*.runtime.openhands.example.com`.
+**DNS**: create a single wildcard record `*.openhands.example.com` pointing to your ingress load
+balancer (typically a CNAME to the load balancer's hostname, or a cloud DNS alias).
 
-**TLS**: obtain certificates covering those hostnames and load them into the ingress controller as
-Kubernetes TLS secrets. A single wildcard isn't enough, because the hostnames sit at different
-depths. You need:
+**TLS**: obtain a certificate with a `*.openhands.example.com` SAN and load it into the ingress
+controller as a Kubernetes TLS secret.
 
-- `*.runtime.openhands.example.com` for the sandboxes, and
-- certificates for `app.openhands.example.com`, `auth.app.openhands.example.com`, and
-  `runtime-api.openhands.example.com` (for example a `*.openhands.example.com` wildcard, which covers
-  `app` and `runtime-api`, plus a certificate for `auth.app.openhands.example.com`).
+If you can't use a wildcard certificate, obtain one with SANs for the `app`, `auth`, and
+`runtime-api` hostnames plus `runtime.openhands.example.com`, and set
+`runtime-api.env.RUNTIME_ROUTING_MODE: "path"` in your Helm values so sandboxes are served under
+`runtime.openhands.example.com/<id>` instead of their own hostnames.
 
 ## Next Steps
 
@@ -47846,14 +47968,15 @@ license automatically at install time.
   (both provided by our team)
 - **LLM credentials** from your chosen provider, for example an Anthropic API key
   from the [Anthropic Console](https://console.anthropic.com/)
-- DNS records you control, following the `app.<base-domain>` layout used
-  throughout this guide (with `openhands.example.com` as the base):
-  `app.openhands.example.com` (application), `auth.app.openhands.example.com`
-  (login), `runtime-api.openhands.example.com`, and a **wildcard**
-  `*.runtime.openhands.example.com` for runtime sandboxes. These point at your
-  cluster's ingress; see the Quick Start's
-  [DNS checks](/enterprise/quick-start#dns-checks) for the full hostname list.
-- **TLS certificates covering all of the hostnames above**, which you provide.
+- DNS records you control, following the layout used throughout this guide
+  (with `openhands.example.com` as the base domain):
+  `app.openhands.example.com` (application), `auth.openhands.example.com`
+  (login), `runtime-api.openhands.example.com`, and
+  `<id>-runtime.openhands.example.com` for the per-session sandboxes. Every
+  hostname sits one label under the base domain, so a single **wildcard**
+  record `*.openhands.example.com` pointing at your cluster's ingress covers
+  all of them; see [DNS and TLS](/enterprise/k8s-install/dns-and-tls).
+- A **wildcard TLS certificate** for `*.openhands.example.com`, which you provide.
 - An **authentication method** for user login — GitLab, Bitbucket Data Center,
   and more are supported; this guide uses a **GitHub App**. See
   [Creating a GitHub App](/enterprise/quick-start#create-a-github-app).
@@ -47991,22 +48114,22 @@ postgresql:
 databaseMigrations:
   createDatabases: true
 
-# Login is served by the bundled Keycloak at auth.<ingress.host> — both the
-# component and its ingress must be enabled for users to be able to log in
+# Login is served by the bundled Keycloak — both the component and its
+# ingress must be enabled for users to be able to log in
 keycloak:
   enabled: true
   ingress:
     enabled: true
-    hostname: auth.app.openhands.example.com
+    hostname: auth.openhands.example.com
     tls: false
 
 # Where agent sandboxes run. The runtime API needs its own hostname, and each
-# sandbox gets a subdomain under your wildcard DNS record.
+# sandbox gets its own hostname under your wildcard DNS record.
 sandbox:
   apiHostname: https://runtime-api.openhands.example.com
 
 env:
-  RUNTIME_URL_PATTERN: "https://{runtime_id}.runtime.openhands.example.com"
+  RUNTIME_URL_PATTERN: "https://{runtime_id}-runtime.openhands.example.com"
   LITELLM_DEFAULT_MODEL: litellm_proxy/claude-sonnet-4-5
 
 runtime-api:
@@ -48020,10 +48143,11 @@ runtime-api:
   databaseMigrations:
     createDatabases: true
   env:
-    # Base domain for the per-sandbox ingresses ({runtime_id}.<RUNTIME_BASE_URL>);
-    # must match RUNTIME_URL_PATTERN above. RUNTIME_DISABLE_SSL defaults to
-    # "true" — it must be "false" so sandbox URLs are served over https.
+    # Sandbox hostnames are built as {runtime_id}<separator><RUNTIME_BASE_URL>;
+    # together these must match RUNTIME_URL_PATTERN above. RUNTIME_DISABLE_SSL
+    # defaults to "true"; it must be "false" so sandbox URLs are served over https.
     RUNTIME_BASE_URL: runtime.openhands.example.com
+    RUNTIME_URL_SEPARATOR: "-"
     RUNTIME_DISABLE_SSL: "false"
     # Storage class for sandbox volumes. The chart default (standard-rwo) only
     # exists on GKE — set a storage class from `kubectl get storageclass` or
@@ -48536,7 +48660,7 @@ plugins directly at `/plugins` on your application hostname.
 
     ### 1. Open the Admin Console
 
-    Navigate to `https://<your-base-domain>:30000` and log in.
+    Navigate to `https://admin.<your-base-domain>:30000` and log in.
 
     ### 2. Open the configuration page
 
@@ -48610,7 +48734,7 @@ plugins directly at `/plugins` on your application hostname.
 
       oidc:
         # Keycloak issuer URL — must match your Keycloak realm
-        issuerUrl: "https://auth.app.<your-base-domain>"
+        issuerUrl: "https://auth.<your-base-domain>"
         realmSecretName: "keycloak-realm"
     ```
 
@@ -48835,22 +48959,32 @@ You will need a VM to host OpenHands Enterprise. Choose one of the options below
 
     Once your VM is running, configure DNS and TLS before starting the installer.
 
-    **Create DNS A records** pointing to your VM's public IP address:
+    **Create a wildcard DNS A record** pointing to your VM's public IP address:
 
     | Record | Example |
     |--------|---------|
-    | `<your-domain>` | `openhands.example.com` |
-    | `app.<your-domain>` | `app.openhands.example.com` |
-    | `analytics.app.<your-domain>` | `analytics.app.openhands.example.com` |
-    | `auth.app.<your-domain>` | `auth.app.openhands.example.com` |
-    | `llm-proxy.<your-domain>` | `llm-proxy.openhands.example.com` |
-    | `runtime-api.<your-domain>` | `runtime-api.openhands.example.com` |
-    | `*.runtime.<your-domain>` | `*.runtime.openhands.example.com` |
+    | `*.<your-domain>` | `*.openhands.example.com` |
 
-    **Obtain a TLS certificate signed by a well-known certificate authority (CA) such as Let's Encrypt**, with SANs
-    (Subject Alternative Names) for all of the above domains, then copy the certificate
+    **Obtain a wildcard TLS certificate signed by a well-known certificate authority (CA) such as Let's Encrypt**
+    for `*.<your-domain>`, then copy the certificate
     (`.pem` or `.crt`) and private key (`.pem` or `.key`) to the VM. Self-signed certificates
     are not supported for the OpenHands application.
+
+    <Accordion title="Can't use wildcard certificates?">
+      Obtain a certificate with SANs (Subject Alternative Names) for each of these hostnames:
+
+      - `admin.<your-domain>`
+      - `app.<your-domain>`
+      - `auth.<your-domain>`
+      - `analytics.<your-domain>`
+      - `llm-proxy.<your-domain>`
+      - `runtime-api.<your-domain>`
+      - `runtime.<your-domain>`
+
+      By default, each sandbox runtime gets its own dynamic hostname, which only a wildcard
+      certificate can cover. When you configure OpenHands, set **Sandbox Routing Mode** to
+      **Path-based** so all sandboxes are served under `runtime.<your-domain>` instead.
+    </Accordion>
 
     <Warning>
       If you don't provide TLS certificates during installation, the Admin Console will use a
@@ -48886,27 +49020,14 @@ export BASE_DOMAIN="openhands.example.com"
 ```
 Test DNS:
 ```bash
-for h in \
-  "${BASE_DOMAIN}" \
-  "app.${BASE_DOMAIN}" \
-  "analytics.app.${BASE_DOMAIN}" \
-  "auth.app.${BASE_DOMAIN}" \
-  "llm-proxy.${BASE_DOMAIN}" \
-  "runtime-api.${BASE_DOMAIN}"; do
+for h in "admin.${BASE_DOMAIN}" "app.${BASE_DOMAIN}" "test-runtime.${BASE_DOMAIN}"; do
   echo "[DNS] $h"
   getent hosts "$h" || nslookup "$h"
 done
 ```
 
-Expected: each hostname above resolves to your VM's public IP address.
-
-Test that a runtime wildcard hostname resolves:
-
-```bash
-getent hosts "test.runtime.${BASE_DOMAIN}" || nslookup "test.runtime.${BASE_DOMAIN}"
-```
-
-Expected: `test.runtime.${BASE_DOMAIN}` resolves to the same target as `${BASE_DOMAIN}`.
+Expected: each hostname resolves to your VM's public IP address through the
+wildcard record.
 
 ### Outbound connectivity checks
 
@@ -48949,7 +49070,7 @@ If any check fails, stop and resolve before continuing:
 | `443/TCP` inbound | Primary HTTPS entrypoint for users and service hostnames |
 | `30000/TCP` inbound | Replicated/KOTS Admin Console for install and configuration |
 | `80/TCP` inbound | HTTP entrypoint used for ingress/redirect behavior |
-| `*.runtime.<domain>` DNS + cert SAN | Runtime sandboxes are addressed by dynamic runtime-specific hostnames |
+| `*.<domain>` DNS + cert SAN | Application services and sandboxes are addressed by hostnames under the base domain |
 | `replicated.app`, `proxy.replicated.com` | Replicated control-plane/license/install paths |
 | `images.r9...`, `charts.r9...`, `updates.r9...`, `install.r9...` | Vendor distribution image/chart/update/install endpoints |
 | `traefik.github.io` | Embedded cluster ingress chart repository |
@@ -49009,7 +49130,7 @@ If the install command fails after preflight checks pass, run `sudo ./openhands 
 ### 4. Access the Admin Console
 
 Once the install command completes, the Admin Console is available at:
-- `https://<your-base-domain>:30000` (if you provided TLS certificates)
+- `https://admin.<your-base-domain>:30000` (if you provided TLS certificates)
 - `http://<your-vm-ip>:30000` (if you did not use the `--tls-cert` and `--tls-key` flags on the `install` command)
 
 If you did not provide TLS certificates with the `install` command, your browser will display a security warning.
@@ -49020,7 +49141,7 @@ Click **Advanced**, then **Proceed** to continue to the Admin Console.
 ### 5. Upload TLS certificate (if not provided with the install command)
 
 If you did not provide certificates with the `install` command, select **"Upload your own"**,
-enter your base domain under **Hostname**, upload your private key and SSL certificate, then click **Continue**.
+enter `admin.<your-base-domain>` under **Hostname**, upload your private key and SSL certificate, then click **Continue**.
 
 If you upload a private CA certificate, make sure any external webhook or OAuth provider that
 calls OpenHands also trusts that CA.
@@ -49048,7 +49169,7 @@ You should now see the application configuration page.
 
 ### Domain Configuration
 
-- Select **"Derive hostnames from domain (recommended)"**
+- Keep the Hostname Configuration Mode set to **"Simple (default)"**
 - Enter your base domain (e.g., `openhands.example.com`)
 
 ### Certificate Configuration
@@ -49150,9 +49271,183 @@ OpenHands Enterprise is now running. You can open a repository or start a new co
 ### Release Notes
 Source: https://docs.openhands.dev/enterprise/release-notes.md
 
+## 0.36.1
+
+This patch release was focused on stability fixes for the Enterprise Server, including preserving user sessions during transient network failures and giving deployments the ability to disable email changes.
+
+### Enterprise Server
+
+#### Bug Fixes
+* fix(auth): preserve sessions during transient network failures by @ak684 in https://github.com/OpenHands/enterprise/pull/81
+* fix: allow deployments to disable email changes by @ak684 in https://github.com/OpenHands/enterprise/pull/110
+* fix(enterprise): fix broken import in run_budget_maintenance.py by @saurya in https://github.com/OpenHands/enterprise/pull/80
+
+## 0.36.0
+
+This release makes the **Agent Canvas** experience available to users at `your-openhands-instance.acmeco.com/canvas`.  As mentioned in 0.28.0 release notes, Agent Canvas will coexist with the current OpenHands Enterprise conversation interface for the time being. A future release will announce the deprecation date for the current interface, after which Agent Canvas will become the default UI.
+
+Additionally, this release improves security and adds support for Bitbucket Data Center as a supported Git provider for Skills marketplace registrations. Improvements to database-pool resiliency, LLM usage-metrics accuracy, and runtime cleanup performance have also made it into this release.
+
+### Enterprise Server
+
+#### Features
+* feat: Expose app and SDK versions in server info by @malhotra5 in https://github.com/OpenHands/OpenHands/pull/15345
+* feat: surface sandbox start-failure reason in conversation start errors by @ak684 in https://github.com/OpenHands/OpenHands/pull/14885
+* feat(settings): support title generation profile preference by @simonrosenberg in https://github.com/OpenHands/OpenHands/pull/15366
+* feat: Allow disabling redis_rate_limiter via empty RATE_LIMIT_AUTH_WINDOWS by @tofarr in https://github.com/OpenHands/enterprise/pull/97
+* feat: Enforce CSP via middleware (OHE-2815) by @tofarr in https://github.com/OpenHands/enterprise/pull/94
+
+#### Bug Fixes
+* fix(app-server): support Bitbucket Data Center personal repos as marketplace sources by @ak684 in https://github.com/OpenHands/OpenHands/pull/15334
+* fix(frontend): add jittered rate-limit backoff by @aivong-openhands in https://github.com/OpenHands/OpenHands/pull/15236
+* fix: upgraded instances with no superadmin by @tofarr in https://github.com/OpenHands/OpenHands/pull/15349
+* fix: clear member key on managed profile switch by @saurya in https://github.com/OpenHands/OpenHands/pull/15356
+* fix(enterprise): avoid rotating keys on LiteLLM non-auth errors by @saurya in https://github.com/OpenHands/OpenHands/pull/15267
+* fix(app-server): persist combined LLM usage metrics across all usage buckets by @ak684 in https://github.com/OpenHands/OpenHands/pull/15354
+* fix(app-server): prevent webhook callbacks from starving the database pool by @ak684 in https://github.com/OpenHands/OpenHands/pull/15379
+* fix: filter automation event forwarding by requested types by @malhotra5 in https://github.com/OpenHands/OpenHands/pull/15388
+* fix: enforce cloud analytics consent from TOS by @malhotra5 in https://github.com/OpenHands/enterprise/pull/79
+* fix(ci): use private bot PAT for pr-artifacts cleanup job by @jlav in https://github.com/OpenHands/enterprise/pull/88
+* fix(enterprise): atomically migrate legacy empty tool settings by @simonrosenberg in https://github.com/OpenHands/enterprise/pull/12
+* fix(settings): accept legacy detached MCP configs by @neubig in https://github.com/OpenHands/enterprise/pull/93
+
+#### Maintenance
+* test: PLTF-1269 split enterprise test_user_model into focused per-model tests by @aivong-openhands in https://github.com/OpenHands/OpenHands/pull/13997
+* chore: Suppress verbose Laminar info logs by @tofarr in https://github.com/OpenHands/OpenHands/pull/15374
+* chore: Unify release-please into a single semver release line by @mamoodi in https://github.com/OpenHands/enterprise/pull/76
+
+---
+
+### Software Agent SDK
+
+#### Features
+* feat: surface plugin contents in the agent-server plugins API by @hieptl in https://github.com/OpenHands/software-agent-sdk/pull/4103
+* Lazily hydrate persisted conversations by @neubig in https://github.com/OpenHands/software-agent-sdk/pull/4100
+* feat(agent-server): support deployment context on profile launches by @simonrosenberg in https://github.com/OpenHands/software-agent-sdk/pull/4030
+* feat(agent-server): sanitized product-analytics telemetry with split consent policy by @VascoSch92 in https://github.com/OpenHands/software-agent-sdk/pull/4172
+* feat: add opt-in persistent memory across sessions by @hieptl in https://github.com/OpenHands/software-agent-sdk/pull/4178
+* feat(marketplace): auto-load standalone marketplace skills by @ak684 in https://github.com/OpenHands/software-agent-sdk/pull/4176
+* feat(mcp): subscribe to tools/list_changed for progressive-disclosure servers by @neubig in https://github.com/OpenHands/software-agent-sdk/pull/3894
+* feat(agent-server): persist parent/child conversation relationships by @VascoSch92 in https://github.com/OpenHands/software-agent-sdk/pull/4188
+* feat: expose agent_context.load_memory in the agent-settings schema by @hieptl in https://github.com/OpenHands/software-agent-sdk/pull/4205
+* feat: publish typed Agent Server OpenAPI contract by @neubig in https://github.com/OpenHands/software-agent-sdk/pull/4229
+* feat: automate TypeScript client contract handoff by @neubig in https://github.com/OpenHands/software-agent-sdk/pull/4234
+* feat(agent-server): add MCP settings CRUD endpoints by @neubig in https://github.com/OpenHands/software-agent-sdk/pull/4294
+* feat: add MCPServer.enabled to switch a server off without removing it by @hieptl in https://github.com/OpenHands/software-agent-sdk/pull/4307
+
+#### Bug Fixes
+* fix(sdk): rehydrate persisted subscription LLMs by @lufen in https://github.com/OpenHands/software-agent-sdk/pull/4092
+* fix(observability): stamp tool_call_id onto the TOOL span by @simonrosenberg in https://github.com/OpenHands/software-agent-sdk/pull/4010
+* Fix REST API contract summary deduplication by @enyst in https://github.com/OpenHands/software-agent-sdk/pull/3918
+* fix(acp): bound ACP server startup with a timeout by @rsd-darshan in https://github.com/OpenHands/software-agent-sdk/pull/4126
+* fix(visualizer): show per-request token usage alongside cumulative by @luciobaiocchi in https://github.com/OpenHands/software-agent-sdk/pull/4146
+* fix(agent): apply filter_tools_regex to runtime tools by @VascoSch92 in https://github.com/OpenHands/software-agent-sdk/pull/4186
+* fix(sdk): accept boolean JSON Schema nodes in _process_schema_node by @VascoSch92 in https://github.com/OpenHands/software-agent-sdk/pull/4185
+* fix(sdk): mask all registered secrets, not only exported ones by @VascoSch92 in https://github.com/OpenHands/software-agent-sdk/pull/4191
+* fix(acp): persist rotated Codex credentials by @simonrosenberg in https://github.com/OpenHands/software-agent-sdk/pull/4124
+* fix(settings): restore MCP schema migration by @neubig in https://github.com/OpenHands/software-agent-sdk/pull/4013
+* fix(terminal): submit multiline PowerShell commands on Windows by @VascoSch92 in https://github.com/OpenHands/software-agent-sdk/pull/4155
+* fix(agent-server): default bind host to loopback without a session API key by @neubig in https://github.com/OpenHands/software-agent-sdk/pull/4180
+* fix: parallel tool metrics by @luciobaiocchi in https://github.com/OpenHands/software-agent-sdk/pull/4193
+* fix(agent-server): /api/vscode/url without base_url advertises the configured VSCode port by @harish-chandramowli in https://github.com/OpenHands/software-agent-sdk/pull/4181
+* fix(agent-server): require credential reactivation before cold load by @simonrosenberg in https://github.com/OpenHands/software-agent-sdk/pull/4198
+* fix(sdk): reject unknown event parents on append by @hxaxd in https://github.com/OpenHands/software-agent-sdk/pull/4089
+* fix(agent-server): redact LLM & condenser secrets in download-trajectory by @smolpaws in https://github.com/OpenHands/software-agent-sdk/pull/4217
+* fix: honor the stored memory preference on profile launches by @hieptl in https://github.com/OpenHands/software-agent-sdk/pull/4223
+* fix(agent-server): include server_base_path in the advertised VSCode URL by @harish-chandramowli in https://github.com/OpenHands/software-agent-sdk/pull/4222
+* fix(sdk): mark corrective nudge as environment event by @Sehlani042 in https://github.com/OpenHands/software-agent-sdk/pull/3954
+* fix(security): authenticate WebSockets outside URLs by @simonrosenberg in https://github.com/OpenHands/software-agent-sdk/pull/4279
+* fix(llm): generalize model capability resolution by @neubig in https://github.com/OpenHands/software-agent-sdk/pull/4200
+* fix(security): stop logging runtime command contents by @simonrosenberg in https://github.com/OpenHands/software-agent-sdk/pull/4280
+
+#### Maintenance
+* chore(deps): bump starlette from 1.0.1 to 1.3.1 by @dependabot[bot] in https://github.com/OpenHands/software-agent-sdk/pull/4140
+* chore(deps): bump pyjwt from 2.12.0 to 2.13.0 by @dependabot[bot] in https://github.com/OpenHands/software-agent-sdk/pull/4138
+* chore(deps): bump tornado from 6.5.5 to 6.5.7 by @dependabot[bot] in https://github.com/OpenHands/software-agent-sdk/pull/4139
+* chore(deps): bump python-multipart from 0.0.27 to 0.0.31 by @dependabot[bot] in https://github.com/OpenHands/software-agent-sdk/pull/4141
+* chore(deps): bump cryptography from 46.0.7 to 48.0.1 by @dependabot[bot] in https://github.com/OpenHands/software-agent-sdk/pull/4142
+* bump laminar to latest version, fix compat issues by @dinmukhamedm in https://github.com/OpenHands/software-agent-sdk/pull/4179
+* perf(agent-server): index conversation execution status for search/count by @VascoSch92 in https://github.com/OpenHands/software-agent-sdk/pull/4201
+* perf(agent-server): evict idle conversations from memory after a configurable TTL by @VascoSch92 in https://github.com/OpenHands/software-agent-sdk/pull/4202
+* Import SkillInfo from the SDK instead of redefining it in skills_router by @onatozmenn in https://github.com/OpenHands/software-agent-sdk/pull/4277
+* Move duplicated LLM option blocks into common.py by @onatozmenn in https://github.com/OpenHands/software-agent-sdk/pull/4276
+* Share the Gemini edit/write_file diff rendering by @onatozmenn in https://github.com/OpenHands/software-agent-sdk/pull/4278
+
+---
+
+### Runtime API
+
+#### Features
+* feat(cleanup): paginate cleanup_stuck_pvcs PVC list by @tofarr in https://github.com/OpenHands/runtime-api/pull/658
+* feat: surface pod scheduling/image failure reason in sandbox status by @ak684 in https://github.com/OpenHands/runtime-api/pull/615
+
+#### Bug Fixes
+* fix(cleanup): archive with actual conversation IDs by @simonrosenberg in https://github.com/OpenHands/runtime-api/pull/654
+* fix: reap runtimes stuck Pending/unschedulable by @ak684 in https://github.com/OpenHands/runtime-api/pull/655
+* fix: Optimize idle runtime cleanup pod listing by @tofarr in https://github.com/OpenHands/runtime-api/pull/662
+
+#### Maintenance
+* perf(cleanup): page snapshot_and_delete_idle_pvcs over bound PVCs by @tofarr in https://github.com/OpenHands/runtime-api/pull/660
+* build(deps): bump starlette from 0.49.1 to 1.3.1 by @dependabot[bot] in https://github.com/OpenHands/runtime-api/pull/650
+
+---
+
+### Automation
+
+#### Features
+* feat: add automation server info endpoint by @malhotra5 in https://github.com/OpenHands/automation/pull/248
+* feat: capture automation telemetry events by @malhotra5 in https://github.com/OpenHands/automation/pull/254
+* feat: expose requested automation event types by @malhotra5 in https://github.com/OpenHands/automation/pull/260
+* feat: expose automation capabilities and preflight validation by @hieptl in https://github.com/OpenHands/automation/pull/270
+
+#### Bug Fixes
+* fix: add server versions to telemetry by @malhotra5 in https://github.com/OpenHands/automation/pull/256
+* fix: normalize MCP config shapes in automation presets by @malhotra5 in https://github.com/OpenHands/automation/pull/257
+* fix: attribute PostHog events to automation actors by @neubig in https://github.com/OpenHands/automation/pull/265
+* fix(security): keep injected secrets out of commands by @simonrosenberg in https://github.com/OpenHands/automation/pull/267
+
+#### Maintenance
+* chore: Add missing index on automation_runs.automation_id by @aivong-openhands in https://github.com/OpenHands/automation/pull/250
+
+---
+
+### OpenHands Cloud (Helm Chart)
+
+#### Features
+* feat: enable the pending-runtime reaper on OHE installs by @ak684 in https://github.com/OpenHands/OpenHands-Cloud/pull/931
+* feat(charts): add external S3 file store support by @jlav in https://github.com/OpenHands/OpenHands-Cloud/pull/946
+* feat(openhands): PLTF-3258 re-add fail guard for postgresql disabled without external database by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/948
+* feat: add SMTP and budget maintenance deployment wiring by @saurya in https://github.com/OpenHands/OpenHands-Cloud/pull/780
+* feat: wire Agent Canvas through Replicated/Helm installs by @lilagrc in https://github.com/OpenHands/OpenHands-Cloud/pull/954
+* feat(rustfs): PLTF-1250 optional in-cluster object store by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/983
+* feat(charts): adopt kubernetes recommended labels by @jlav in https://github.com/OpenHands/OpenHands-Cloud/pull/960
+* feat(dns): add a simple single-wildcard hostname layout by @jlav in https://github.com/OpenHands/OpenHands-Cloud/pull/985
+
+#### Bug Fixes
+* fix(openhands): namespace-qualify bundled litellm url for sandboxes by @jlav in https://github.com/OpenHands/OpenHands-Cloud/pull/937
+* fix(openhands): validate filestore values and test external S3 env by @jlav in https://github.com/OpenHands/OpenHands-Cloud/pull/947
+* fix(openhands): PLTF-3258 scope render guards to enabled releases by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/950
+* fix: increase Replicated MinIO resource headroom by @ak684 in https://github.com/OpenHands/OpenHands-Cloud/pull/970
+* fix(integrations-hub): default admin.emails to empty by @tofarr in https://github.com/OpenHands/OpenHands-Cloud/pull/976
+* fix(budget-maintenance): disable the budget maintenance cronjob by default by @jlav in https://github.com/OpenHands/OpenHands-Cloud/pull/978
+* fix(minio): PLTF-1250 stop the bundled bucket job purging data on every upgrade by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/981
+* fix(integrations-hub): derive public base URL by @neubig in https://github.com/OpenHands/OpenHands-Cloud/pull/963
+* fix(litellm): PLTF-3363 bump pinned litellm image to 1.93.0 by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/987
+* fix(auth): extend Keycloak identity provider timeout by @ak684 in https://github.com/OpenHands/OpenHands-Cloud/pull/975
+* fix(troubleshoot): PLTF-3264 unblock support bundle exec collectors on Helm installs by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/989
+* fix(replicated): PLTF-3264 include app and license info in support bundles by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/992
+* fix(replicated): PLTF-3264 pass the SDK its pull secret in map form by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/996
+
+#### Maintenance
+* ci: PLTF-3287 sticky comment notify on openhands chart appVersion drift by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/951
+* chore(openhands-secrets): remove no-op config keys by @jlav in https://github.com/OpenHands/OpenHands-Cloud/pull/871
+* chore(openhands): remove no-op values file keys by @jlav in https://github.com/OpenHands/OpenHands-Cloud/pull/869
+* chore(openhands): pin redis master resources to effective values by @jlav in https://github.com/OpenHands/OpenHands-Cloud/pull/868
+* revert: re-enable budget maintenance by default by @saurya in https://github.com/OpenHands/OpenHands-Cloud/pull/982
+
 ## 0.28.0
 
-This release adds the embedded **Agent Canvas** (mounted under `{your-openhands-instance.example.com}/canvas`), which will coexist with the current OpenHands Enterprise conversation interface for the time being. A future release will announce the deprecation date for the existing interface, after which Agent Canvas will become the default UI; in the meantime, teams can begin experimenting with the new Agent Canvas experience and share feedback with the OpenHands product teams.
+This release adds the embedded **Agent Canvas** endpoint (mounted under `your-openhands-instance.acmeco.com/canvas`). Agent Canvas will coexist with the current OpenHands Enterprise conversation interface for the time being. A future release will announce the deprecation date for the current interface, after which Agent Canvas will become the default UI; in the meantime, teams can begin experimenting with the new Agent Canvas experience and share feedback with the OpenHands product teams.
 
 Additionally, this release brings better Helm chart validation and more configuration options to make installs easier to configure and validate. The rest of the release is focused on stability and maintenance fixes.
 
@@ -49617,7 +49912,7 @@ Use the Replicated Admin Console to configure an OpenHands Enterprise deployment
 
 ## Open the Configuration Screen
 
-1. Open `https://<your-base-domain>:30000`.
+1. Open `https://admin.<your-base-domain>:30000`.
 2. Log in with the Admin Console password created during installation.
 3. Select `Config`.
 
@@ -49639,32 +49934,31 @@ Some changes restart one or more OpenHands components. Make changes during a mai
 
 ## Domain Configuration
 
-### Recommended: Derive Hostnames From One Domain
+### Recommended: Simple
 
-Use the default `Derive hostnames from domain (recommended)` mode unless your organization requires a custom hostname for each service.
+Use the default `Simple` mode unless your organization requires a custom hostname for each service.
 
-1. Leave `Hostname Configuration Mode` set to `Derive hostnames from domain (recommended)`.
+1. Leave `Hostname Configuration Mode` set to `Simple (default)`.
 2. Enter your `Base Domain`, such as `openhands.example.com`.
-3. Create DNS records and TLS coverage for the derived hostnames.
 
-For a base domain of `openhands.example.com`, OpenHands uses:
+Every hostname sits one subdomain under the base domain, so a single wildcard DNS record and TLS certificate for `*.openhands.example.com` cover all of them:
 
-| Service | Derived Hostname |
+| Service | Hostname |
 |---|---|
-| Admin Console | `openhands.example.com:30000` |
+| Admin Console | `admin.openhands.example.com:30000` |
 | OpenHands application | `app.openhands.example.com` |
-| Analytics | `analytics.app.openhands.example.com` |
-| Authentication | `auth.app.openhands.example.com` |
+| Analytics | `analytics.openhands.example.com` |
+| Authentication | `auth.openhands.example.com` |
 | LLM proxy | `llm-proxy.openhands.example.com` |
 | Runtime API | `runtime-api.openhands.example.com` |
-| Sandboxes | `*.runtime.openhands.example.com` |
+| Sandboxes | `<id>-runtime.openhands.example.com` |
 
 <Note>
-  The derived mode keeps DNS, certificates, OAuth callbacks, and webhook URLs consistent with the standard OpenHands deployment. It is the recommended path for most installations.
+  Installations created before the Simple layout run in `Legacy` mode, which nests some hostnames deeper (`auth.app.<base>`, `*.runtime.<base>`). Keep existing installs on Legacy; their certificates and OAuth callbacks were issued for those hostnames.
 </Note>
 
 <Accordion title="Customize every hostname">
-  Select `Enter all hostnames manually` only when your DNS or network requirements do not allow the derived layout.
+  Select `Manual` only when your DNS or network requirements do not allow the Simple layout.
 
   | Field | Description |
   |---|---|

--- a/llms.txt
+++ b/llms.txt
@@ -111,7 +111,8 @@ from the OpenHands Software Agent SDK.
 ## OpenHands Web App Server
 
 - [About OpenHands](https://docs.openhands.dev/openhands/usage/about.md)
-- [ACP Agents](https://docs.openhands.dev/openhands/usage/agent-canvas/acp-agents.md): Drive Agent Canvas conversations with an external coding agent — Claude Code, Codex, or Gemini CLI — over the Agent Client Protocol.
+- [ACP Agents](https://docs.openhands.dev/openhands/usage/agent-canvas/acp-agents.md): Run Claude Code, Codex, or Gemini CLI in Agent Canvas through the Agent Client Protocol.
+- [Agent Canvas Architecture](https://docs.openhands.dev/openhands/usage/agent-canvas/architecture.md): Understand how Agent Canvas connects to execution, automation, and sandbox services.
 - [Agent Canvas Overview](https://docs.openhands.dev/openhands/usage/agent-canvas/overview.md): Understand Agent Canvas, how it runs agents, and which setup path to choose.
 - [Agent Profiles](https://docs.openhands.dev/openhands/usage/agent-canvas/agent-profiles.md): Manage reusable agent configurations for Agent Canvas conversations.
 - [API Keys Settings](https://docs.openhands.dev/openhands/usage/settings/api-keys-settings.md): View your OpenHands LLM key and create API keys to work with OpenHands programmatically.
@@ -121,7 +122,6 @@ from the OpenHands Software Agent SDK.
 - [Automations Overview](https://docs.openhands.dev/openhands/usage/automations/overview.md): Create scheduled tasks that run automatically in OpenHands.
 - [AWS Bedrock](https://docs.openhands.dev/openhands/usage/llms/aws-bedrock.md): OpenHands uses LiteLLM to make calls to AWS Bedrock models. You can find their documentation on using Bedrock as a provider [here](https://docs.litellm.ai/docs/providers/bedrock).
 - [Azure](https://docs.openhands.dev/openhands/usage/llms/azure-llms.md): OpenHands uses LiteLLM to make calls to Azure's chat models. You can find their documentation on using Azure as a provider [here](https://docs.litellm.ai/docs/providers/azure).
-- [Backend Architecture](https://docs.openhands.dev/openhands/usage/architecture/backend.md)
 - [Backends](https://docs.openhands.dev/openhands/usage/agent-canvas/backends.md): Understand and manage Agent Canvas backends.
 - [Cloud Backend](https://docs.openhands.dev/openhands/usage/agent-canvas/backend-setup/cloud.md): Connect Agent Canvas to OpenHands Cloud for on-demand sandboxed execution.
 - [COBOL Modernization](https://docs.openhands.dev/openhands/usage/use-cases/cobol-modernization.md): Modernizing legacy COBOL systems with OpenHands
@@ -137,7 +137,6 @@ from the OpenHands Software Agent SDK.
 - [Debugging](https://docs.openhands.dev/openhands/usage/developers/debugging.md)
 - [Dependency Upgrades](https://docs.openhands.dev/openhands/usage/use-cases/dependency-upgrades.md): Automating dependency updates and upgrades with OpenHands
 - [Development Overview](https://docs.openhands.dev/openhands/usage/developers/development-overview.md): This guide provides an overview of the key documentation resources available in the OpenHands repository. Whether you're looking to contribute, understand the architecture, or work on specific components, these resources will help you navigate the codebase effectively.
-- [Docker Backend](https://docs.openhands.dev/openhands/usage/agent-canvas/backend-setup/docker.md): Run Agent Canvas in a Docker container as a sandboxed backend.
 - [Docker Sandbox](https://docs.openhands.dev/openhands/usage/sandboxes/docker.md): The recommended sandbox provider for running OpenHands locally.
 - [Environment Variables Reference](https://docs.openhands.dev/openhands/usage/environment-variables.md): Complete reference of all environment variables supported by OpenHands
 - [Evaluation Harness](https://docs.openhands.dev/openhands/usage/developers/evaluation-harness.md)
@@ -150,16 +149,15 @@ from the OpenHands Software Agent SDK.
 - [Groq](https://docs.openhands.dev/openhands/usage/llms/groq.md): OpenHands uses LiteLLM to make calls to chat models on Groq. You can find their documentation on using Groq as a provider [here](https://docs.litellm.ai/docs/providers/groq).
 - [Hooks](https://docs.openhands.dev/openhands/usage/customization/hooks.md): Use lifecycle hooks to control agent behavior - block dangerous commands, enforce quality checks before stopping, inject context, and more.
 - [Incident Triage](https://docs.openhands.dev/openhands/usage/use-cases/incident-triage.md): Using OpenHands to investigate and resolve production incidents
-- [Install](https://docs.openhands.dev/openhands/usage/agent-canvas/setup.md): Install, run, update, and uninstall Agent Canvas.
+- [Install Agent Canvas](https://docs.openhands.dev/openhands/usage/agent-canvas/setup.md): Install, run, update, or uninstall Agent Canvas.
 - [Integrations Settings](https://docs.openhands.dev/openhands/usage/settings/integrations-settings.md): How to setup and modify the various integrations in OpenHands.
 - [Key Features](https://docs.openhands.dev/openhands/usage/key-features.md)
 - [Kubernetes (Helm)](https://docs.openhands.dev/openhands/usage/agent-canvas/backend-setup/kubernetes.md): Install Agent Canvas into a Kubernetes cluster with the official Helm chart.
 - [Language Model (LLM) Settings](https://docs.openhands.dev/openhands/usage/settings/llm-settings.md): This page goes over how to set the LLM to use in OpenHands, including LLM profiles for switching models during conversations.
 - [LiteLLM Proxy](https://docs.openhands.dev/openhands/usage/llms/litellm-proxy.md): OpenHands supports using the [LiteLLM proxy](https://docs.litellm.ai/docs/proxy/quick_start) to access various LLM providers.
-- [LLM Profiles and Model Configuration](https://docs.openhands.dev/openhands/usage/agent-canvas/llm-profiles.md): Configure models in Agent Canvas and use saved LLM profiles during conversations.
 - [Local Backend](https://docs.openhands.dev/openhands/usage/agent-canvas/backend-setup/local.md): Run one or more local backends and connect to them from the Agent Canvas UI.
-- [Local LLMs](https://docs.openhands.dev/openhands/usage/llms/local-llms.md): When using a Local LLM, OpenHands may have limited functionality. It is highly recommended that you use GPUs to serve local models for optimal experience.
 - [Main Agent and Capabilities](https://docs.openhands.dev/openhands/usage/agents.md)
+- [Manage LLM Profiles](https://docs.openhands.dev/openhands/usage/agent-canvas/llm-profiles.md): Configure models in Agent Canvas and use saved LLM profiles during conversations.
 - [Managing automations](https://docs.openhands.dev/openhands/usage/agent-canvas/managing-automations.md): Browse, export, import, enable, disable, and run automations from the Agent Canvas Automate view.
 - [Managing Automations](https://docs.openhands.dev/openhands/usage/automations/managing-automations.md): List, update, enable, disable, and delete your automations.
 - [Modal Backend](https://docs.openhands.dev/openhands/usage/agent-canvas/backend-setup/modal.md): Deploy the agent server on Modal as a remote backend for Agent Canvas.
@@ -167,7 +165,6 @@ from the OpenHands Software Agent SDK.
 - [Moonshot AI](https://docs.openhands.dev/openhands/usage/llms/moonshot.md): How to use Moonshot AI models with OpenHands
 - [OpenAI](https://docs.openhands.dev/openhands/usage/llms/openai-llms.md): OpenHands uses LiteLLM to make calls to OpenAI's chat models. You can find their documentation on using OpenAI as a provider [here](https://docs.litellm.ai/docs/providers/openai).
 - [OpenHands](https://docs.openhands.dev/openhands/usage/llms/openhands-llms.md): OpenHands LLM provider with access to state-of-the-art (SOTA) agentic coding models.
-- [OpenHands GitHub Action](https://docs.openhands.dev/openhands/usage/run-openhands/github-action.md): This guide explains how to use the OpenHands GitHub Action in your own projects.
 - [OpenHands in Your SDLC](https://docs.openhands.dev/openhands/usage/essential-guidelines/sdlc-integration.md): How OpenHands fits into your software development lifecycle
 - [OpenRouter](https://docs.openhands.dev/openhands/usage/llms/openrouter.md): OpenHands uses LiteLLM to make calls to chat models on OpenRouter. You can find their documentation on using OpenRouter as a provider [here](https://docs.litellm.ai/docs/providers/openrouter).
 - [Overview](https://docs.openhands.dev/openhands/usage/llms/llms.md): OpenHands can connect to any LLM supported by LiteLLM. However, it requires a powerful model to work.
@@ -178,8 +175,8 @@ from the OpenHands Software Agent SDK.
 - [Prompting Best Practices](https://docs.openhands.dev/openhands/usage/tips/prompting-best-practices.md): When working with OpenHands AI software developer, providing clear and effective prompts is key to getting accurate and useful responses. This guide outlines best practices for crafting effective prompts.
 - [Remote Sandbox](https://docs.openhands.dev/openhands/usage/sandboxes/remote.md): Run conversations in a remote sandbox environment.
 - [Repository Customization](https://docs.openhands.dev/openhands/usage/customization/repository.md): You can customize how OpenHands interacts with your repository by creating a `.openhands` directory at the root level.
-- [REST API (V1)](https://docs.openhands.dev/openhands/usage/api/v1.md): Overview of the current V1 REST endpoints used by the Web app.
-- [Runtime Architecture](https://docs.openhands.dev/openhands/usage/architecture/runtime.md)
+- [Run Local LLMs with OpenHands](https://docs.openhands.dev/openhands/usage/llms/local-llms.md): Connect OpenHands to local LLM servers such as LM Studio, Ollama, vLLM, and SGLang.
+- [Sandbox Server REST API (V1)](https://docs.openhands.dev/openhands/usage/api/v1.md): Overview of the Sandbox Server V1 REST endpoints for conversations and sandboxes.
 - [Search Engine Setup](https://docs.openhands.dev/openhands/usage/advanced/search-engine-setup.md): Configure OpenHands to use Tavily as a search engine.
 - [Secrets Management](https://docs.openhands.dev/openhands/usage/settings/secrets-settings.md): How to manage secrets in OpenHands.
 - [Setup](https://docs.openhands.dev/openhands/usage/run-openhands/local-setup.md): Getting started with running OpenHands on your own.
@@ -190,6 +187,7 @@ from the OpenHands Software Agent SDK.
 - [Troubleshooting](https://docs.openhands.dev/openhands/usage/troubleshooting/troubleshooting.md)
 - [Tutorial Library](https://docs.openhands.dev/openhands/usage/get-started/tutorials.md): Centralized hub for OpenHands tutorials and examples
 - [Use Cases Overview](https://docs.openhands.dev/openhands/usage/use-cases/overview.md): Explore how OpenHands can help with common software development challenges
+- [Use Docker with Agent Canvas](https://docs.openhands.dev/openhands/usage/agent-canvas/backend-setup/docker.md): Run Agent Canvas with Docker for a sandboxed backend and mounted project workspace.
 - [VM / Self-Hosted Installation](https://docs.openhands.dev/openhands/usage/agent-canvas/backend-setup/vm.md): Install Agent Canvas on a VM as a backend-only service or full self-hosted Canvas.
 - [Vulnerability Remediation](https://docs.openhands.dev/openhands/usage/use-cases/vulnerability-remediation.md): Using OpenHands to identify and fix security vulnerabilities in your codebase
 - [WebSocket Connection](https://docs.openhands.dev/openhands/usage/developers/websocket-connection.md)
@@ -198,6 +196,7 @@ from the OpenHands Software Agent SDK.
 ## OpenHands Cloud
 
 - [Bitbucket Integration](https://docs.openhands.dev/openhands/usage/cloud/bitbucket-installation.md): This guide walks you through the process of installing OpenHands Cloud for your Bitbucket repositories. Once
+- [Budgets](https://docs.openhands.dev/openhands/usage/cloud/organizations/budgets.md): Set spending limits for your organization and its members to keep AI spend under control.
 - [Cloud API](https://docs.openhands.dev/openhands/usage/cloud/cloud-api.md): OpenHands Cloud provides a REST API that allows you to programmatically interact with OpenHands.
 - [Cloud UI](https://docs.openhands.dev/openhands/usage/cloud/cloud-ui.md): The Cloud UI provides a web interface for interacting with OpenHands. This page provides references on
 - [Getting Started](https://docs.openhands.dev/openhands/usage/cloud/openhands-cloud.md): Getting started with OpenHands Cloud.
@@ -218,7 +217,7 @@ from the OpenHands Software Agent SDK.
 
 - [Adding New Skills](https://docs.openhands.dev/overview/skills/adding.md): Learn how to add existing skills to your OpenHands workspace from the official registry or custom repositories.
 - [Community](https://docs.openhands.dev/overview/community.md): Learn about the OpenHands community, mission, and values
-- [Contributing](https://docs.openhands.dev/overview/contributing.md): Join us in building OpenHands and the future of AI. Learn how to contribute to make a meaningful impact.
+- [Contributing](https://docs.openhands.dev/overview/contributing.md): Find the right OpenHands repository and contribution guide for your change.
 - [Creating New Skills](https://docs.openhands.dev/overview/skills/creating.md): Learn how to create reusable skills instead of repeating prompts, with best practices for structure, triggers, and content organization.
 - [FAQs](https://docs.openhands.dev/overview/faqs.md): Frequently asked questions about OpenHands.
 - [First Projects](https://docs.openhands.dev/overview/first-projects.md): So you've [run OpenHands](/overview/quickstart). Now what?
@@ -229,10 +228,10 @@ from the OpenHands Software Agent SDK.
 - [Model Context Protocol (MCP)](https://docs.openhands.dev/overview/model-context-protocol.md): Model Context Protocol support across OpenHands platforms
 - [Monitoring and Improving Skills](https://docs.openhands.dev/overview/skills/monitoring.md): Monitor skill performance in production using logging, evaluation metrics, dashboarding, and automated feedback aggregation.
 - [Organization and User Skills](https://docs.openhands.dev/overview/skills/org.md): Organizations and users can define skills that apply to all repositories belonging to the organization or user.
-- [Overview](https://docs.openhands.dev/overview/skills.md): Skills are specialized prompts that enhance OpenHands with domain-specific knowledge, expert guidance, and automated task handling.
 - [Path-Triggered Rules](https://docs.openhands.dev/overview/skills/path.md): Path-triggered rules are skills that OpenHands injects deterministically whenever the agent reads, edits, or creates a file whose path matches a glob pattern. They behave like Claude Code "rules" — guaranteed to load for the files they scope, with no reliance on the model choosing them.
 - [Plugins](https://docs.openhands.dev/overview/plugins.md): Plugins bundle multiple agent components together—skills, hooks, MCP servers, agents, and commands—into reusable packages that extend OpenHands capabilities.
 - [Quick Start](https://docs.openhands.dev/overview/quickstart.md): Choose how you want to run OpenHands
+- [Skills Overview](https://docs.openhands.dev/overview/skills.md): Give OpenHands reusable instructions, domain knowledge, workflows, and supporting resources.
 
 ## Other
 

--- a/llms.txt
+++ b/llms.txt
@@ -173,6 +173,7 @@ from the OpenHands Software Agent SDK.
 - [Plugins in Agent Canvas](https://docs.openhands.dev/openhands/usage/agent-canvas/plugins.md): Browse, install, attach, and inspect plugins in Agent Canvas.
 - [Process Sandbox](https://docs.openhands.dev/openhands/usage/sandboxes/process.md): Run the agent server as a local process without container isolation.
 - [Prompting Best Practices](https://docs.openhands.dev/openhands/usage/tips/prompting-best-practices.md): When working with OpenHands AI software developer, providing clear and effective prompts is key to getting accurate and useful responses. This guide outlines best practices for crafting effective prompts.
+- [Remote Backend](https://docs.openhands.dev/openhands/usage/agent-canvas/backend-setup/remote.md): Connect Agent Canvas to an Agent Server backend running on another machine or container.
 - [Remote Sandbox](https://docs.openhands.dev/openhands/usage/sandboxes/remote.md): Run conversations in a remote sandbox environment.
 - [Repository Customization](https://docs.openhands.dev/openhands/usage/customization/repository.md): You can customize how OpenHands interacts with your repository by creating a `.openhands` directory at the root level.
 - [Run Local LLMs with OpenHands](https://docs.openhands.dev/openhands/usage/llms/local-llms.md): Connect OpenHands to local LLM servers such as LM Studio, Ollama, vLLM, and SGLang.

--- a/openhands/usage/agent-canvas/agent-profiles.mdx
+++ b/openhands/usage/agent-canvas/agent-profiles.mdx
@@ -55,7 +55,7 @@ ACP profiles are useful for agents such as:
 - Gemini CLI
 - a custom ACP server
 
-The external ACP agent owns its own model and tool behavior. Agent Canvas starts the agent process and renders the conversation.
+The external ACP agent owns its own model and tool behavior. Agent Server starts and manages the ACP process, while Agent Canvas renders the conversation and profile controls.
 
 ## First-Time Setup
 

--- a/openhands/usage/agent-canvas/architecture.mdx
+++ b/openhands/usage/agent-canvas/architecture.mdx
@@ -3,7 +3,7 @@ title: Agent Canvas Architecture
 description: Understand how Agent Canvas connects to execution, automation, and sandbox services.
 ---
 
-Agent Canvas is the open-source browser client and control center for OpenHands conversations and automations. It presents backend state and sends requests to backend services; it is not an agent runtime or sandbox. Agent Server or an ACP agent process executes tools, and the selected workspace or sandbox provides the execution boundary.
+Agent Canvas is the open-source browser client and control center for OpenHands conversations and automations. It presents backend state and sends requests to backend services; it is not an agent runtime or sandbox. Agent Server or an ACP agent CLI executes tools, and the selected workspace or sandbox provides the execution boundary.
 
 ## Core Components
 

--- a/openhands/usage/agent-canvas/architecture.mdx
+++ b/openhands/usage/agent-canvas/architecture.mdx
@@ -46,11 +46,10 @@ When you send a message, Agent Canvas sends it to the selected backend. Agent Se
 
 The workspace determines the execution boundary:
 
-| Workspace type | Execution and isolation boundary |
-|----------------|----------------------------------|
-| **Local process** | Agent Server and tools run directly on the backend host without container isolation. |
+| Execution environment | Execution and isolation boundary |
+|-----------------------|----------------------------------|
+| **Host process** | Agent Server and tools run directly on the backend host without container isolation. If the backend is remote, that host—not the browser's machine—is the execution boundary. |
 | **Docker or Kubernetes** | Agent Server and tools run inside the configured container or pod with its mounts and network policy. |
-| **Remote Agent Server** | Agent Server runs on another machine or in a separate container, with the workspace boundary configured there. |
 | **OpenHands Cloud or Enterprise** | The managed platform creates and operates the conversation sandbox that hosts Agent Server. |
 
 Connecting Canvas to a remote backend does not grant the browser direct access to that backend's filesystem. Canvas displays files and terminal output returned by Agent Server.
@@ -71,14 +70,14 @@ Switching backends changes which backend-managed conversations, settings, automa
 | Pattern | Relationship |
 |---------|--------------|
 | **Local all-in-one** | The launcher starts Canvas and local backend services on one machine. |
-| **Remote Agent Server** | Canvas connects to an Agent Server running on another machine or in a separate container on the same machine. |
-| **Self-hosted backend services** | You deploy Agent Server, and optionally Automation Server, on a VM, Docker host, Kubernetes cluster, or Modal. |
+| **Self-hosted backend services** | You deploy Agent Server, and optionally Automation Server, in another process, on a VM, in Docker or Kubernetes, or on Modal. Canvas connects to the deployment as a remote backend. |
 | **Managed platform** | Canvas connects to OpenHands Cloud or OpenHands Enterprise, which operate their backend and sandbox infrastructure. |
 
 ## Next Steps
 
 - [Install Agent Canvas](/openhands/usage/agent-canvas/setup)
 - [Connect And Manage Backends](/openhands/usage/agent-canvas/backends)
+- [Connect To A Remote Backend](/openhands/usage/agent-canvas/backend-setup/remote)
 - [Self-Host On A VM](/openhands/usage/agent-canvas/backend-setup/vm)
 - [Use Docker](/openhands/usage/agent-canvas/backend-setup/docker)
 - [Agent Server Overview](/sdk/guides/agent-server/overview)

--- a/openhands/usage/agent-canvas/architecture.mdx
+++ b/openhands/usage/agent-canvas/architecture.mdx
@@ -1,0 +1,114 @@
+---
+title: Agent Canvas Architecture
+description: Understand how Agent Canvas connects to execution, automation, and sandbox services.
+---
+
+Agent Canvas is the open-source browser client and control center for OpenHands conversations and automations. It presents backend state and sends requests to backend services; it is not an agent runtime or sandbox.
+
+<Warning>
+  **Agent Canvas does not execute tools.** Agent Server or an ACP agent process executes tools in the selected workspace.
+
+  **Agent Canvas does not provide sandbox isolation.** Isolation comes from the selected workspace, container, sandbox service, or remote platform.
+</Warning>
+
+## Core Components
+
+| Component | Responsibility | Source |
+|-----------|----------------|--------|
+| **Agent Canvas** | Browser interface for conversations, files, settings, backends, and automations | [`OpenHands/OpenHands`](https://github.com/OpenHands/OpenHands) |
+| **Agent Server** | Runs conversations, agents, tools, and workspace operations; streams events to clients | [`OpenHands/software-agent-sdk`](https://github.com/OpenHands/software-agent-sdk/tree/main/openhands-agent-server) |
+| **Automation Server** | Stores schedules and event triggers, tracks runs, and dispatches conversations | [`OpenHands/automation`](https://github.com/OpenHands/automation) |
+| **Sandbox Server** | Creates and manages sandboxed environments that host Agent Server | [`OpenHands/sandbox-server`](https://github.com/OpenHands/sandbox-server) |
+| **Workspace or sandbox** | Defines which files, processes, credentials, and networks an agent can access | Deployment-specific |
+
+## Service Relationships
+
+```mermaid
+%%{init: {"theme": "default", "flowchart": {"nodeSpacing": 30, "rankSpacing": 45}} }%%
+flowchart TB
+    Browser["Browser"] --> Canvas["Agent Canvas<br/>browser client"]
+
+    Canvas -->|conversations and settings| AgentServer["Agent Server"]
+    Canvas -->|schedules, events, and runs| Automation["Automation Server"]
+    Automation -->|dispatch conversation| AgentServer
+    AgentServer -->|execute agent and tools| Workspace["Workspace or sandbox"]
+
+    Canvas -.->|optional control plane| SandboxServer["Sandbox Server"]
+    SandboxServer -->|create and manage| Sandbox["Sandbox"]
+    Sandbox -->|hosts| SandboxedAgentServer["Agent Server"]
+
+    Canvas -.->|remote backend| Remote["OpenHands Cloud or Enterprise"]
+
+    classDef primary fill:#f3e8ff,stroke:#7c3aed,stroke-width:2px
+    classDef secondary fill:#e8f3ff,stroke:#2b6cb0,stroke-width:2px
+    classDef tertiary fill:#fff4df,stroke:#b7791f,stroke-width:2px
+    classDef service fill:#e9f9ef,stroke:#2f855a,stroke-width:2px
+    class Canvas primary
+    class AgentServer,Automation,SandboxedAgentServer secondary
+    class Workspace,Sandbox tertiary
+    class SandboxServer,Remote service
+```
+
+The normal browser path is **Browser → Agent Canvas → backend services**. Agent Server owns conversation execution. Automation Server owns scheduled and event-driven run lifecycle. A backend distribution can expose both services behind one URL, but they remain separate responsibilities.
+
+Sandbox Server is an optional control plane. It creates sandboxes that host Agent Server, while Agent Canvas remains the client. OpenHands Cloud and OpenHands Enterprise provide remote backend and sandbox infrastructure behind their service endpoints.
+
+## Client And Launcher Boundaries
+
+`Agent Canvas` can refer to two related surfaces:
+
+- **Canvas client** — The React browser application. It renders state and sends requests to backend services.
+- **`agent-canvas` launcher and distributions** — Packaging that can start the Canvas client, Agent Server, Automation Server, and ingress together.
+
+The launcher supports split modes:
+
+| Mode | Services started |
+|------|------------------|
+| `agent-canvas` | Canvas client, Agent Server, Automation Server, and ingress |
+| `agent-canvas --frontend-only` | Canvas client and ingress |
+| `agent-canvas --backend-only` | Agent Server, Automation Server, and ingress |
+
+Docker and Helm packages can also bundle the client and backend services. A bundled deployment changes how services are installed, not which component owns execution or isolation.
+
+## Execution And Isolation
+
+When you send a message, Agent Canvas sends it to the selected backend. Agent Server starts or resumes the conversation, runs the selected agent, invokes tools, updates backend state, and streams events to Canvas.
+
+The workspace determines the execution boundary:
+
+| Workspace type | Execution and isolation boundary |
+|----------------|----------------------------------|
+| **Local process** | Agent Server and tools run directly on the backend host without container isolation. |
+| **Docker or Kubernetes** | Agent Server and tools run inside the configured container or pod with its mounts and network policy. |
+| **Sandbox Server** | The control plane creates a sandbox that hosts Agent Server and applies the configured sandbox boundary. |
+| **OpenHands Cloud or Enterprise** | The remote platform selects and manages the execution environment. |
+
+Connecting Canvas to a remote backend does not grant the browser direct access to that backend's filesystem. Canvas displays files and terminal output returned by Agent Server.
+
+## State Ownership
+
+State belongs to backend services rather than the browser client:
+
+- Agent Server stores conversation history, agent and LLM profiles, secrets, MCP configuration, and related settings.
+- Automation Server stores automation definitions, schedules, events, and run history.
+- The workspace or sandbox stores files produced or changed by the agent.
+- Agent Canvas stores connection information needed to reach configured backends.
+
+Switching backends changes which backend-managed conversations, settings, automations, and workspaces Canvas displays.
+
+## Deployment Patterns
+
+| Pattern | Relationship |
+|---------|--------------|
+| **Local all-in-one** | The launcher starts Canvas and local backend services on one machine. |
+| **Split local or self-hosted** | Canvas runs separately and connects to a backend-only launcher on a workstation, VM, or cluster. |
+| **Sandbox control plane** | Canvas connects through Sandbox Server to Agent Server instances hosted in managed sandboxes. |
+| **Remote platform** | Canvas connects to OpenHands Cloud or OpenHands Enterprise endpoints. |
+
+## Next Steps
+
+- [Install Agent Canvas](/openhands/usage/agent-canvas/setup)
+- [Connect And Manage Backends](/openhands/usage/agent-canvas/backends)
+- [Self-Host On A VM](/openhands/usage/agent-canvas/backend-setup/vm)
+- [Use Docker](/openhands/usage/agent-canvas/backend-setup/docker)
+- [Agent Server Overview](/sdk/guides/agent-server/overview)

--- a/openhands/usage/agent-canvas/architecture.mdx
+++ b/openhands/usage/agent-canvas/architecture.mdx
@@ -3,13 +3,7 @@ title: Agent Canvas Architecture
 description: Understand how Agent Canvas connects to execution, automation, and sandbox services.
 ---
 
-Agent Canvas is the open-source browser client and control center for OpenHands conversations and automations. It presents backend state and sends requests to backend services; it is not an agent runtime or sandbox.
-
-<Warning>
-  **Agent Canvas does not execute tools.** Agent Server or an ACP agent process executes tools in the selected workspace.
-
-  **Agent Canvas does not provide sandbox isolation.** Isolation comes from the selected workspace, container, sandbox service, or remote platform.
-</Warning>
+Agent Canvas is the open-source browser client and control center for OpenHands conversations and automations. It presents backend state and sends requests to backend services; it is not an agent runtime or sandbox. Agent Server or an ACP agent process executes tools, and the selected workspace or sandbox provides the execution boundary.
 
 ## Core Components
 
@@ -18,8 +12,9 @@ Agent Canvas is the open-source browser client and control center for OpenHands 
 | **Agent Canvas** | Browser interface for conversations, files, settings, backends, and automations | [`OpenHands/OpenHands`](https://github.com/OpenHands/OpenHands) |
 | **Agent Server** | Runs conversations, agents, tools, and workspace operations; streams events to clients | [`OpenHands/software-agent-sdk`](https://github.com/OpenHands/software-agent-sdk/tree/main/openhands-agent-server) |
 | **Automation Server** | Stores schedules and event triggers, tracks runs, and dispatches conversations | [`OpenHands/automation`](https://github.com/OpenHands/automation) |
-| **Sandbox Server** | Creates and manages sandboxed environments that host Agent Server | [`OpenHands/sandbox-server`](https://github.com/OpenHands/sandbox-server) |
 | **Workspace or sandbox** | Defines which files, processes, credentials, and networks an agent can access | Deployment-specific |
+
+Sandbox Server is a community-driven standalone API and sandbox control plane. It is not a core Agent Canvas backend or a supported deployment option. [Learn more about Sandbox Server](https://github.com/OpenHands/sandbox-server).
 
 ## Service Relationships
 
@@ -28,30 +23,34 @@ Agent Canvas is the open-source browser client and control center for OpenHands 
 flowchart TB
     Browser["Browser"] --> Canvas["Agent Canvas<br/>browser client"]
 
-    Canvas -->|conversations and settings| AgentServer["Agent Server"]
-    Canvas -->|schedules, events, and runs| Automation["Automation Server"]
-    Automation -->|dispatch conversation| AgentServer
-    AgentServer -->|execute agent and tools| Workspace["Workspace or sandbox"]
+    subgraph Backend["Selected backend"]
+        AgentServer["Agent Server"] -->|execute agent and tools| Workspace["Workspace or sandbox"]
+        Automation["Automation Server"] -->|dispatch conversation| AgentServer
+    end
 
-    Canvas -.->|optional control plane| SandboxServer["Sandbox Server"]
-    SandboxServer -->|create and manage| Sandbox["Sandbox"]
-    Sandbox -->|hosts| SandboxedAgentServer["Agent Server"]
+    Canvas -->|conversations and settings| AgentServer
+    Canvas -->|schedules, events, and runs| Automation
 
-    Canvas -.->|remote backend| Remote["OpenHands Cloud or Enterprise"]
+    subgraph Platform["OpenHands Cloud or Enterprise"]
+        ControlPlane["Platform control plane"] -->|create and manage| Sandbox["Conversation sandbox"]
+        Sandbox -->|hosts| PlatformAgentServer["Agent Server"]
+    end
+
+    Canvas -.->|managed backend| PlatformAgentServer
 
     classDef primary fill:#f3e8ff,stroke:#7c3aed,stroke-width:2px
     classDef secondary fill:#e8f3ff,stroke:#2b6cb0,stroke-width:2px
     classDef tertiary fill:#fff4df,stroke:#b7791f,stroke-width:2px
     classDef service fill:#e9f9ef,stroke:#2f855a,stroke-width:2px
     class Canvas primary
-    class AgentServer,Automation,SandboxedAgentServer secondary
+    class AgentServer,Automation,PlatformAgentServer secondary
     class Workspace,Sandbox tertiary
-    class SandboxServer,Remote service
+    class ControlPlane service
 ```
 
-The normal browser path is **Browser → Agent Canvas → backend services**. Agent Server owns conversation execution. Automation Server owns scheduled and event-driven run lifecycle. A backend distribution can expose both services behind one URL, but they remain separate responsibilities.
+The normal browser path is **Browser → Agent Canvas → selected backend**. Agent Server owns conversation execution. Automation Server owns scheduled and event-driven run lifecycle. A backend distribution can expose both services behind one URL, but they remain separate responsibilities.
 
-Sandbox Server is an optional control plane. It creates sandboxes that host Agent Server, while Agent Canvas remains the client. OpenHands Cloud and OpenHands Enterprise provide remote backend and sandbox infrastructure behind their service endpoints.
+A remote backend uses the same Agent Server API as a local backend. The Agent Server can run on another machine, or in a separate container on the same machine as Canvas. OpenHands Cloud and OpenHands Enterprise are managed backend platforms: their platform control planes create conversation sandboxes that host Agent Server.
 
 ## Client And Launcher Boundaries
 
@@ -80,8 +79,8 @@ The workspace determines the execution boundary:
 |----------------|----------------------------------|
 | **Local process** | Agent Server and tools run directly on the backend host without container isolation. |
 | **Docker or Kubernetes** | Agent Server and tools run inside the configured container or pod with its mounts and network policy. |
-| **Sandbox Server** | The control plane creates a sandbox that hosts Agent Server and applies the configured sandbox boundary. |
-| **OpenHands Cloud or Enterprise** | The remote platform selects and manages the execution environment. |
+| **Remote Agent Server** | Agent Server runs on another machine or in a separate container, with the workspace boundary configured there. |
+| **OpenHands Cloud or Enterprise** | The managed platform creates and operates the conversation sandbox that hosts Agent Server. |
 
 Connecting Canvas to a remote backend does not grant the browser direct access to that backend's filesystem. Canvas displays files and terminal output returned by Agent Server.
 
@@ -101,9 +100,9 @@ Switching backends changes which backend-managed conversations, settings, automa
 | Pattern | Relationship |
 |---------|--------------|
 | **Local all-in-one** | The launcher starts Canvas and local backend services on one machine. |
-| **Split local or self-hosted** | Canvas runs separately and connects to a backend-only launcher on a workstation, VM, or cluster. |
-| **Sandbox control plane** | Canvas connects through Sandbox Server to Agent Server instances hosted in managed sandboxes. |
-| **Remote platform** | Canvas connects to OpenHands Cloud or OpenHands Enterprise endpoints. |
+| **Remote Agent Server** | Canvas connects to an Agent Server running on another machine or in a separate container on the same machine. |
+| **Self-hosted backend services** | You deploy Agent Server, and optionally Automation Server, on a VM, Docker host, Kubernetes cluster, or Modal. |
+| **Managed platform** | Canvas connects to OpenHands Cloud or OpenHands Enterprise, which operate their backend and sandbox infrastructure. |
 
 ## Next Steps
 

--- a/openhands/usage/agent-canvas/architecture.mdx
+++ b/openhands/usage/agent-canvas/architecture.mdx
@@ -14,39 +14,10 @@ Agent Canvas is the open-source browser client and control center for OpenHands 
 | **Automation Server** | Stores schedules and event triggers, tracks runs, and dispatches conversations | [`OpenHands/automation`](https://github.com/OpenHands/automation) |
 | **Workspace or sandbox** | Defines which files, processes, credentials, and networks an agent can access | Deployment-specific |
 
-Sandbox Server is a community-driven standalone API and sandbox control plane. It is not a core Agent Canvas backend or a supported deployment option. [Learn more about Sandbox Server](https://github.com/OpenHands/sandbox-server).
+Sandbox Server is a community-driven standalone API and sandbox control plane. [Learn more about Sandbox Server](https://github.com/OpenHands/sandbox-server).
 
 ## Service Relationships
 
-```mermaid
-%%{init: {"theme": "default", "flowchart": {"nodeSpacing": 30, "rankSpacing": 45}} }%%
-flowchart TB
-    Browser["Browser"] --> Canvas["Agent Canvas<br/>browser client"]
-
-    subgraph Backend["Selected backend"]
-        AgentServer["Agent Server"] -->|execute agent and tools| Workspace["Workspace or sandbox"]
-        Automation["Automation Server"] -->|dispatch conversation| AgentServer
-    end
-
-    Canvas -->|conversations and settings| AgentServer
-    Canvas -->|schedules, events, and runs| Automation
-
-    subgraph Platform["OpenHands Cloud or Enterprise"]
-        ControlPlane["Platform control plane"] -->|create and manage| Sandbox["Conversation sandbox"]
-        Sandbox -->|hosts| PlatformAgentServer["Agent Server"]
-    end
-
-    Canvas -.->|managed backend| PlatformAgentServer
-
-    classDef primary fill:#f3e8ff,stroke:#7c3aed,stroke-width:2px
-    classDef secondary fill:#e8f3ff,stroke:#2b6cb0,stroke-width:2px
-    classDef tertiary fill:#fff4df,stroke:#b7791f,stroke-width:2px
-    classDef service fill:#e9f9ef,stroke:#2f855a,stroke-width:2px
-    class Canvas primary
-    class AgentServer,Automation,PlatformAgentServer secondary
-    class Workspace,Sandbox tertiary
-    class ControlPlane service
-```
 
 The normal browser path is **Browser → Agent Canvas → selected backend**. Agent Server owns conversation execution. Automation Server owns scheduled and event-driven run lifecycle. A backend distribution can expose both services behind one URL, but they remain separate responsibilities.
 
@@ -69,7 +40,7 @@ The launcher supports split modes:
 
 Docker and Helm packages can also bundle the client and backend services. A bundled deployment changes how services are installed, not which component owns execution or isolation.
 
-## Execution And Isolation
+## Execution and Isolation
 
 When you send a message, Agent Canvas sends it to the selected backend. Agent Server starts or resumes the conversation, runs the selected agent, invokes tools, updates backend state, and streams events to Canvas.
 

--- a/openhands/usage/agent-canvas/backend-setup/cloud.mdx
+++ b/openhands/usage/agent-canvas/backend-setup/cloud.mdx
@@ -12,6 +12,7 @@ A Cloud backend is a good fit when you want to:
 - Run agents without tying up local resources
 - Use OpenHands Cloud's managed sandboxes and integrations
 - Keep your local machine for development while offloading agent work
+- Easy Phone & Tablet Access so you can code on the go
 
 ## Prerequisites
 

--- a/openhands/usage/agent-canvas/backend-setup/docker.mdx
+++ b/openhands/usage/agent-canvas/backend-setup/docker.mdx
@@ -3,7 +3,7 @@ title: Use Docker with Agent Canvas
 description: Run Agent Canvas with Docker for a sandboxed backend and mounted project workspace.
 ---
 
-Use Docker when you want Agent Canvas and its agent tools to run in a container rather than directly on your host. The official image packages the full Agent Canvas stack — backend and frontend — in a single container, with access only to the project directories you mount.
+Use Docker when you want the Agent Canvas distribution and its backend services to run in a container rather than directly on your host. The official image packages the Canvas client, Agent Server, Automation Server, and ingress in one container. Agent Server and its tools can access only the project directories and other resources you expose to the container.
 
 ## Prerequisites
 
@@ -43,7 +43,7 @@ Mount a persistence directory for settings, secrets, and conversation history, a
   </Tab>
 </Tabs>
 
-Agent Canvas is now running at `http://localhost:8000`. The agent can access any project under the mounted `/projects` path.
+Agent Canvas is now available at `http://localhost:8000/canvas`. The backend base URL remains `http://localhost:8000`, and the agent can access any project under the mounted `/projects` path.
 
 ### Environment Variables
 

--- a/openhands/usage/agent-canvas/backend-setup/kubernetes.mdx
+++ b/openhands/usage/agent-canvas/backend-setup/kubernetes.mdx
@@ -461,7 +461,7 @@ The chart's default `Service` is `ClusterIP`. Three common ways to reach the UI:
     kubectl -n agent-canvas port-forward svc/agent-canvas 8000:8000
     ```
 
-    Then open `http://localhost:8000`.
+    Then open `http://localhost:8000/canvas`.
 3. **LoadBalancer** — set `service.type: LoadBalancer` if your cloud provisions cloud load balancers for you. Cheaper than ingress for one-off installs, but skips TLS and auth.
 
 <Warning>

--- a/openhands/usage/agent-canvas/backend-setup/modal.mdx
+++ b/openhands/usage/agent-canvas/backend-setup/modal.mdx
@@ -3,7 +3,7 @@ title: Modal Backend
 description: Deploy the agent server on Modal as a remote backend for Agent Canvas.
 ---
 
-Deploy the [OpenHands](https://github.com/OpenHands/OpenHands) agent server on [Modal](https://modal.com) as a remote backend for Agent Canvas. Canvas runs locally on your machine while the agent server runs on Modal and executes code inside the container — same execution model as running `npx @openhands/agent-canvas` locally.
+Deploy [Agent Server](https://github.com/OpenHands/software-agent-sdk/tree/main/openhands-agent-server) on [Modal](https://modal.com) as a remote backend for Agent Canvas. Canvas runs locally on your machine while Agent Server runs on Modal and executes code inside the container—the same execution model as the backend started by `npx @openhands/agent-canvas`.
 
 <Warning>
   The agent server runs with full access to the container's filesystem, environment, and network. Anyone with the API key can execute arbitrary code on your Modal container. Keep the API key secret and rotate it if it's ever exposed.

--- a/openhands/usage/agent-canvas/backend-setup/modal.mdx
+++ b/openhands/usage/agent-canvas/backend-setup/modal.mdx
@@ -3,7 +3,7 @@ title: Modal Backend
 description: Deploy the agent server on Modal as a remote backend for Agent Canvas.
 ---
 
-Deploy [Agent Server](https://github.com/OpenHands/software-agent-sdk/tree/main/openhands-agent-server) on [Modal](https://modal.com) as a remote backend for Agent Canvas. Canvas runs locally on your machine while Agent Server runs on Modal and executes code inside the container—the same execution model as the backend started by `npx @openhands/agent-canvas`.
+Deploy [OpenHands](https://github.com/OpenHands/OpenHands) on [Modal](https://modal.com) as a remote backend for Agent Canvas. Canvas runs locally on your machine while the Agent Canvas Backend runs on Modal and executes code inside the container—the same execution model as the backend started by `npx @openhands/agent-canvas`.
 
 <Warning>
   The agent server runs with full access to the container's filesystem, environment, and network. Anyone with the API key can execute arbitrary code on your Modal container. Keep the API key secret and rotate it if it's ever exposed.

--- a/openhands/usage/agent-canvas/backend-setup/remote.mdx
+++ b/openhands/usage/agent-canvas/backend-setup/remote.mdx
@@ -12,7 +12,7 @@ Agent Canvas does not distinguish a remote backend by where it runs. It connects
 A remote backend must provide:
 
 - An accessible Agent Server URL.
-- An API key when the backend requires authentication.
+- An API key.
 - A workspace or sandbox where Agent Server can execute tools.
 
 To use scheduled or event-driven automations, the backend must also provide an Automation Server.

--- a/openhands/usage/agent-canvas/backend-setup/remote.mdx
+++ b/openhands/usage/agent-canvas/backend-setup/remote.mdx
@@ -1,0 +1,49 @@
+---
+title: Remote Backend
+description: Connect Agent Canvas to an Agent Server backend running on another machine or container.
+---
+
+A remote backend is an Agent Server endpoint that runs somewhere other than the Agent Canvas client. It uses the same Agent Server API as a local backend. The backend can run on another machine, on a VM, or in a separate container on the same machine.
+
+Agent Canvas does not distinguish a remote backend by where it runs. It connects to the endpoint URL and displays the conversations, files, settings, and automations that backend provides.
+
+## What A Remote Backend Needs
+
+A remote backend must provide:
+
+- An accessible Agent Server URL.
+- An API key when the backend requires authentication.
+- A workspace or sandbox where Agent Server can execute tools.
+
+To use scheduled or event-driven automations, the backend must also provide Automation Server.
+
+## Connect To A Remote Backend
+
+1. Start or obtain the URL for the Agent Server backend.
+2. In Agent Canvas, open the backend switcher and choose `Manage Backends`.
+3. Select `Add Backend`.
+4. Enter a display name, the **Host / Base URL**, and the API key when required.
+5. Save the backend and select it.
+
+The selected backend becomes the execution environment for new conversations. Its workspace, settings, profiles, secrets, MCP servers, and automation state remain separate from other backends.
+
+<Warning>
+  Anyone who can reach Agent Server with its API key can request agent execution in that backend's workspace. Use TLS, access controls, and a high-entropy API key before exposing a backend outside a trusted network.
+</Warning>
+
+## Deployment Examples
+
+| Location | Start here |
+|----------|------------|
+| Another local process or container | [Local Backend](/openhands/usage/agent-canvas/backend-setup/local) |
+| A VM or dedicated machine | [VM / Self-Hosted Installation](/openhands/usage/agent-canvas/backend-setup/vm) |
+| Docker | [Use Docker with Agent Canvas](/openhands/usage/agent-canvas/backend-setup/docker) |
+| Kubernetes | [Kubernetes (Helm)](/openhands/usage/agent-canvas/backend-setup/kubernetes) |
+| Modal | [Modal Backend](/openhands/usage/agent-canvas/backend-setup/modal) |
+| A managed OpenHands platform | [Cloud Backend](/openhands/usage/agent-canvas/backend-setup/cloud) |
+
+## Next Steps
+
+- [Connect And Manage Backends](/openhands/usage/agent-canvas/backends)
+- [Agent Canvas Architecture](/openhands/usage/agent-canvas/architecture)
+- [Agent Server Overview](/sdk/guides/agent-server/overview)

--- a/openhands/usage/agent-canvas/backend-setup/remote.mdx
+++ b/openhands/usage/agent-canvas/backend-setup/remote.mdx
@@ -15,7 +15,7 @@ A remote backend must provide:
 - An API key when the backend requires authentication.
 - A workspace or sandbox where Agent Server can execute tools.
 
-To use scheduled or event-driven automations, the backend must also provide Automation Server.
+To use scheduled or event-driven automations, the backend must also provide an Automation Server.
 
 ## Connect To A Remote Backend
 

--- a/openhands/usage/agent-canvas/backends.mdx
+++ b/openhands/usage/agent-canvas/backends.mdx
@@ -11,11 +11,12 @@ Any Agent Canvas frontend can connect to any Agent Canvas backend. Use the backe
 
 Settings, LLM configuration, MCP servers, and automations are all scoped to the active backend — switching backends switches all of these.
 
+"Remote" describes how Canvas connects to a backend, not where that backend runs. A remote backend can be a separate process on the same machine, a self-hosted deployment on a VM or container platform, or a managed Cloud or Enterprise service.
+
 ## Recommended Setups
 
 | Setup | When to use | How |
 |-------|-------------|-----|
 | **Default local** | Quick local work on your machine | Run `agent-canvas`—a local backend is created automatically. |
-| **Remote Agent Server** | An Agent Server on another machine or in a separate local container | Add its host URL and API key in `Manage Backends`. See [Remote Backend](/openhands/usage/agent-canvas/backend-setup/remote). |
-| **Self-hosted VM** | Always-on server, more powerful hardware, team-shared access, or a full self-hosted Canvas | Run `agent-canvas --backend-only --public` for backend-only mode, or `agent-canvas --public` for the full UI and backend. See [VM / Self-Hosted Installation](/openhands/usage/agent-canvas/backend-setup/vm). |
+| **Self-hosted backend** | A separate local process or container, an always-on VM, more powerful hardware, or team-shared access | Deploy the backend services, then add their host URL and API key in `Manage Backends`. See [Remote Backend](/openhands/usage/agent-canvas/backend-setup/remote) and [VM / Self-Hosted Installation](/openhands/usage/agent-canvas/backend-setup/vm). |
 | **Cloud or Enterprise** | Managed backend and sandbox infrastructure | Connect from `Manage Backends`. See [Cloud Backend](/openhands/usage/agent-canvas/backend-setup/cloud). |

--- a/openhands/usage/agent-canvas/backends.mdx
+++ b/openhands/usage/agent-canvas/backends.mdx
@@ -3,7 +3,7 @@ title: Backends
 description: Understand and manage Agent Canvas backends.
 ---
 
-A **backend** provides Agent Server and, when automations are enabled, Automation Server. Agent Server runs conversations and tools in a workspace: the folder, mounted project directory, container, or cloud sandbox where the agent reads and writes files. Automation Server manages schedules, events, and run lifecycle. Agent Canvas connects to these services and displays the state of whichever backend is selected.
+A **backend** provides [Agent Server](/sdk/guides/agent-server/overview#what-is-a-remote-agent-server) and, when automations are enabled, Automation Server. Agent Server runs conversations and tools in a workspace: the folder, mounted project directory, container, or cloud sandbox where the agent reads and writes files. Automation Server manages schedules, events, and run lifecycle. Agent Canvas connects to these services and displays the state of whichever backend is selected.
 
 ## Connecting to a Backend
 

--- a/openhands/usage/agent-canvas/backends.mdx
+++ b/openhands/usage/agent-canvas/backends.mdx
@@ -15,8 +15,7 @@ Settings, LLM configuration, MCP servers, and automations are all scoped to the 
 
 | Setup | When to use | How |
 |-------|-------------|-----|
-| **Default local** | Quick local work on your machine | Run `agent-canvas` — a local backend is created automatically |
-| **Backend-only (local)** | Multiple projects, or separate frontend and backend processes | Run `agent-canvas --backend-only` (optionally on different ports), connect with `--frontend-only`. See [Local Backend](/openhands/usage/agent-canvas/backend-setup/local). |
-| **Self-hosted VM** | Always-on server, more powerful hardware, team-shared access, or a full self-hosted Canvas | Run `agent-canvas --backend-only --public` for backend-only mode, or `agent-canvas --public` for the full UI and backend. Expose it with SSH, ngrok, or a reverse proxy. See [VM / Self-Hosted Installation](/openhands/usage/agent-canvas/backend-setup/vm). |
-| **Cloud** | Managed sandboxes without local resources | Connect to [OpenHands Cloud](/openhands/usage/cloud/openhands-cloud) from **Manage Backends**. See [Cloud Backend](/openhands/usage/agent-canvas/backend-setup/cloud). |
-| **Modal** | Cloud backend with per-second billing, no VM management | Deploy the agent server on [Modal](https://modal.com) with a single command. See [Modal Backend](/openhands/usage/agent-canvas/backend-setup/modal). |
+| **Default local** | Quick local work on your machine | Run `agent-canvas`—a local backend is created automatically. |
+| **Remote Agent Server** | An Agent Server on another machine or in a separate local container | Add its host URL and API key in `Manage Backends`. See [Remote Backend](/openhands/usage/agent-canvas/backend-setup/remote). |
+| **Self-hosted VM** | Always-on server, more powerful hardware, team-shared access, or a full self-hosted Canvas | Run `agent-canvas --backend-only --public` for backend-only mode, or `agent-canvas --public` for the full UI and backend. See [VM / Self-Hosted Installation](/openhands/usage/agent-canvas/backend-setup/vm). |
+| **Cloud or Enterprise** | Managed backend and sandbox infrastructure | Connect from `Manage Backends`. See [Cloud Backend](/openhands/usage/agent-canvas/backend-setup/cloud). |

--- a/openhands/usage/agent-canvas/backends.mdx
+++ b/openhands/usage/agent-canvas/backends.mdx
@@ -3,7 +3,7 @@ title: Backends
 description: Understand and manage Agent Canvas backends.
 ---
 
-A **backend** is an [agent server](/sdk/guides/agent-server/overview#what-is-a-remote-agent-server) and the workspace it operates in. A workspace is the folder, mounted project directory, container, or cloud sandbox where the agent reads and writes files. All conversations, settings, and automations run against whichever backend is currently selected.
+A **backend** provides Agent Server and, when automations are enabled, Automation Server. Agent Server runs conversations and tools in a workspace: the folder, mounted project directory, container, or cloud sandbox where the agent reads and writes files. Automation Server manages schedules, events, and run lifecycle. Agent Canvas connects to these services and displays the state of whichever backend is selected.
 
 ## Connecting to a Backend
 

--- a/openhands/usage/agent-canvas/conversations.mdx
+++ b/openhands/usage/agent-canvas/conversations.mdx
@@ -63,7 +63,7 @@ For example:
 /goal --max 3 add unit tests for the parser and verify they pass
 ```
 
-When you start a goal, Agent Canvas runs the agent and uses a judge LLM to check whether the objective is complete after each round. If the judge finds missing work, Agent Canvas sends that feedback back to the agent and continues until the goal is complete or the maximum number of rounds is reached.
+When you start a goal, Agent Canvas requests a goal run from Agent Server. Agent Server runs the agent and uses a judge LLM to check whether the objective is complete after each round. If the judge finds missing work, Agent Server sends that feedback to the agent and continues until the goal is complete or the maximum number of rounds is reached.
 
 While a goal is running, Agent Canvas shows a status banner with the objective, current round, status, judge score, and any missing work. When the goal finishes, the final status appears inline in the conversation history.
 

--- a/openhands/usage/agent-canvas/customize-and-settings.mdx
+++ b/openhands/usage/agent-canvas/customize-and-settings.mdx
@@ -64,7 +64,7 @@ Use `Settings > Agent` to choose the active Agent Profile for new conversations.
 
 ### Persistent Agent Memory
 
-Open `Settings > Agent Context` to control persistent agent memory. When enabled, new OpenHands and ACP conversations can load saved memory from the workspace and user memory locations into their agent context. 
+Open `Settings > Agent Context` to control persistent agent memory. When enabled, new OpenHands and ACP conversations can load saved memory from the workspace and user memory locations into their agent context.
 
 Disable it when you do not want new conversations to load that persistent memory.
 

--- a/openhands/usage/agent-canvas/overview.mdx
+++ b/openhands/usage/agent-canvas/overview.mdx
@@ -25,16 +25,27 @@ You can also test a preview build of the native desktop app. [Try the desktop pr
 
 Agent Canvas is the browser client. It connects to backend services that own execution and persistent state:
 
-| Component | Responsibility |
-|-----------|----------------|
-| **Agent Canvas** | Displays conversations, files, terminals, settings, backends, and automations. |
-| **Agent Server** | Runs conversations, agents, tools, and workspace operations. |
-| **Automation Server** | Manages schedules, event triggers, dispatch, and run history. |
-| **Workspace or sandbox** | Defines which files, processes, credentials, and networks the agent can access. |
+| Concept | What It Means | Why It Matters |
+|-------|---------------|----------------|
+| **Browser UI** | The web interface you open in your browser. | This is where you chat, inspect files, manage settings, and configure automations. |
+| **Backend** | The agent server that runs conversations, tools, settings, secrets, and automations. | This determines where the agent runs and what machine or sandbox it can access. |
+| **Workspace** | The folder, repository, container mount, or cloud sandbox the agent works in. | This determines which files the agent can read and write. |
+| **Agent and model** | The OpenHands agent or an ACP agent, plus the model credentials it uses. | This determines which LLM or provider receives conversation context and powers the agent. |
 
-<Warning>
-  Agent Canvas does not execute tools or provide sandbox isolation. Agent Server or an ACP process executes tools, and the selected workspace or sandbox provides the execution boundary.
-</Warning>
+```mermaid
+flowchart LR
+    browser["Browser UI"] --> backend["Selected backend"]
+    backend --> conversation["Conversation and agent"]
+    conversation --> model["Model access"]
+    conversation --> workspace["Workspace and tools"]
+
+    classDef primary fill:#f3e8ff,stroke:#7c3aed,stroke-width:2px
+    classDef secondary fill:#e8f3ff,stroke:#2b6cb0,stroke-width:2px
+    classDef tertiary fill:#fff4df,stroke:#b7791f,stroke-width:2px
+    class browser primary
+    class backend,conversation secondary
+    class model,workspace tertiary
+```
 
 The `agent-canvas` launcher can package the client and backend services into one local stack. You can also run the client separately and connect it to services on a VM, in Docker or Kubernetes, or through OpenHands Cloud or OpenHands Enterprise.
 

--- a/openhands/usage/agent-canvas/overview.mdx
+++ b/openhands/usage/agent-canvas/overview.mdx
@@ -23,31 +23,22 @@ You can also test a preview build of the native desktop app. [Try the desktop pr
 
 ## How Agent Canvas Works
 
-Agent Canvas has four pieces to understand:
+Agent Canvas is the browser client. It connects to backend services that own execution and persistent state:
 
-| Concept | What It Means | Why It Matters |
-|-------|---------------|----------------|
-| **Browser UI** | The web interface you open in your browser. | This is where you chat, inspect files, manage settings, and configure automations. |
-| **Backend** | The agent server that runs conversations, tools, settings, secrets, and automations. | This determines where the agent runs and what machine or sandbox it can access. |
-| **Workspace** | The folder, repository, container mount, or cloud sandbox the agent works in. | This determines which files the agent can read and write. |
-| **Agent and model** | The OpenHands agent or an ACP agent, plus the model credentials it uses. | This determines which LLM or provider receives conversation context and powers the agent. |
+| Component | Responsibility |
+|-----------|----------------|
+| **Agent Canvas** | Displays conversations, files, terminals, settings, backends, and automations. |
+| **Agent Server** | Runs conversations, agents, tools, and workspace operations. |
+| **Automation Server** | Manages schedules, event triggers, dispatch, and run history. |
+| **Workspace or sandbox** | Defines which files, processes, credentials, and networks the agent can access. |
 
-```mermaid
-flowchart LR
-    browser["Browser UI"] --> backend["Selected backend"]
-    backend --> conversation["Conversation and agent"]
-    conversation --> model["Model access"]
-    conversation --> workspace["Workspace and tools"]
+<Warning>
+  Agent Canvas does not execute tools or provide sandbox isolation. Agent Server or an ACP process executes tools, and the selected workspace or sandbox provides the execution boundary.
+</Warning>
 
-    classDef primary fill:#f3e8ff,stroke:#7c3aed,stroke-width:2px
-    classDef secondary fill:#e8f3ff,stroke:#2b6cb0,stroke-width:2px
-    classDef tertiary fill:#fff4df,stroke:#b7791f,stroke-width:2px
-    class browser primary
-    class backend,conversation secondary
-    class model,workspace tertiary
-```
+The `agent-canvas` launcher can package the client and backend services into one local stack. You can also run the client separately and connect it to services on a VM, in Docker or Kubernetes, or through OpenHands Cloud or OpenHands Enterprise.
 
-The browser UI is a client of the selected backend. Conversations, settings, secrets, LLM profiles, MCP servers, skills, and automations persist on that backend. The workspace and tools run where that backend runs.
+See [Agent Canvas Architecture](/openhands/usage/agent-canvas/architecture) for the complete service and deployment model.
 
 <Note>
   Switching backends switches the environment the agent is using. For details on how conversations and workspaces remain separate, see [Conversations](/openhands/usage/agent-canvas/conversations) and [Backends](/openhands/usage/agent-canvas/backends).

--- a/openhands/usage/agent-canvas/prebuilt-automations.mdx
+++ b/openhands/usage/agent-canvas/prebuilt-automations.mdx
@@ -15,7 +15,7 @@ Agent Canvas ships with a set of pre-built automations for the most common agent
 
 ---
 
-Every canvas backend includes an automation service, so you can run agents on a schedule or in response to external events.
+Backends created by the `agent-canvas` launcher include Automation Server, so they can run agents on a schedule or in response to external events. Other backends must provide a compatible automation service for these features.
 
 ## What You Can Do
 

--- a/openhands/usage/agent-canvas/prebuilt-automations.mdx
+++ b/openhands/usage/agent-canvas/prebuilt-automations.mdx
@@ -15,7 +15,7 @@ Agent Canvas ships with a set of pre-built automations for the most common agent
 
 ---
 
-Backends created by the `agent-canvas` launcher include Automation Server, so they can run agents on a schedule or in response to external events. Other backends must provide a compatible automation service for these features.
+Backends created by the `agent-canvas` launcher include Automation Server, so they can run agents on a schedule or in response to external events.
 
 ## What You Can Do
 

--- a/openhands/usage/agent-canvas/setup.mdx
+++ b/openhands/usage/agent-canvas/setup.mdx
@@ -6,7 +6,7 @@ description: Install, run, update, or uninstall Agent Canvas.
 The `agent-canvas` launcher can run the Canvas client with Agent Server, Automation Server, and ingress as an all-in-one local stack. Use npm or npx for direct local execution, or Docker for a containerized stack with explicit project mounts. You can also run the client separately and connect it to an existing backend.
 
 <Warning>
-  Agent Server and ACP processes can run shell commands, read files, write files, and use connected tools. Agent Canvas is the client and does not provide isolation. Treat the machine, container, or sandbox where the backend runs as trusted infrastructure. Before exposing backend services to a network you do not control, review [VM / Self-Hosted Installation](/openhands/usage/agent-canvas/backend-setup/vm).
+  Treat agents and ACP processes as untrusted: they can run shell commands, read files, write files, and use connected tools within their execution environment. Agent Canvas is the client and does not provide isolation. If the backend runs directly on your machine, the agent can act with your user account's permissions. Use a container, sandbox, or VM to define a tighter boundary. Before exposing backend services to a network you do not control, review [VM / Self-Hosted Installation](/openhands/usage/agent-canvas/backend-setup/vm).
 </Warning>
 
 ## Choose An Install Method

--- a/openhands/usage/agent-canvas/setup.mdx
+++ b/openhands/usage/agent-canvas/setup.mdx
@@ -3,10 +3,10 @@ title: Install Agent Canvas
 description: Install, run, update, or uninstall Agent Canvas.
 ---
 
-Agent Canvas can run directly on your machine or inside Docker. Use the local npm or npx paths for a direct local backend, or Docker for a sandboxed backend with explicit project mounts. Start with the simplest setup that matches the trust boundary you want.
+The `agent-canvas` launcher can run the Canvas client with Agent Server, Automation Server, and ingress as an all-in-one local stack. Use npm or npx for direct local execution, or Docker for a containerized stack with explicit project mounts. You can also run the client separately and connect it to an existing backend.
 
 <Warning>
-  Agent Canvas starts an agent server that can run shell commands, read files, write files, and use connected tools. Treat the machine or container where the backend runs as trusted infrastructure. Before exposing Agent Canvas to a network you do not control, review [VM / Self-Hosted Installation](/openhands/usage/agent-canvas/backend-setup/vm).
+  Agent Server and ACP processes can run shell commands, read files, write files, and use connected tools. Agent Canvas is the client and does not provide isolation. Treat the machine, container, or sandbox where the backend runs as trusted infrastructure. Before exposing backend services to a network you do not control, review [VM / Self-Hosted Installation](/openhands/usage/agent-canvas/backend-setup/vm).
 </Warning>
 
 ## Choose An Install Method
@@ -115,7 +115,7 @@ Agent Canvas can run directly on your machine or inside Docker. Use the local np
       ghcr.io/openhands/agent-canvas:latest
     ```
 
-    Agent Canvas starts on `http://localhost:8000`. The agent can access project files under the mounted `/projects` directory.
+    The Docker image serves Agent Canvas at `http://localhost:8000/canvas`. The agent can access project files under the mounted `/projects` directory.
 
     <Note>
       PowerShell uses backticks (`` ` ``) for line continuation. If Docker reports that it cannot connect to the daemon, start Docker Desktop and run the command again.

--- a/openhands/usage/api/v1.mdx
+++ b/openhands/usage/api/v1.mdx
@@ -1,5 +1,5 @@
 ---
-title: Sandbox Server REST API (V1)
+title: REST API (V1)
 description: Overview of the Sandbox Server V1 REST endpoints for conversations and sandboxes.
 ---
 
@@ -15,7 +15,7 @@ Sandbox Server V1 REST endpoints are mounted under:
 
 - <code>/api/v1</code>
 
-Use these endpoints to integrate with the Sandbox Server control plane. Agent Canvas is the browser client for compatible deployments; Sandbox Server itself does not include a frontend.
+Use these endpoints to integrate with the Sandbox Server control plane. Sandbox Server itself does not include a frontend.
 
 ## Key resources
 

--- a/openhands/usage/api/v1.mdx
+++ b/openhands/usage/api/v1.mdx
@@ -1,22 +1,21 @@
 ---
-title: REST API (V1)
-description: Overview of the current V1 REST endpoints used by the Web app.
+title: Sandbox Server REST API (V1)
+description: Overview of the Sandbox Server V1 REST endpoints for conversations and sandboxes.
 ---
 
-<Note>
-  OpenHands is in a transition period: legacy (V0) endpoints still exist alongside
-  the new <code>/api/v1</code> endpoints.
+The [OpenHands Sandbox Server](https://github.com/OpenHands/sandbox-server) is the standalone API and sandbox control plane extracted from the former OpenHands monorepo. It exposes conversation and sandbox resources without bundling a frontend.
 
-  If you need the legacy OpenAPI reference, see the <b>Legacy (V0)</b> section in the Web tab.
+<Note>
+  The legacy (V0) API belongs to the archived Local GUI architecture. See the **V0 REST API** section in the Home tab when maintaining an existing V0 integration.
 </Note>
 
 ## Overview
 
-OpenHands V1 REST endpoints are mounted under:
+Sandbox Server V1 REST endpoints are mounted under:
 
 - <code>/api/v1</code>
 
-These endpoints back the current Web UI and are intended for newer integrations.
+Use these endpoints to integrate with the Sandbox Server control plane. Agent Canvas is the browser client for compatible deployments; Sandbox Server itself does not include a frontend.
 
 ## Key resources
 

--- a/overview/contributing.mdx
+++ b/overview/contributing.mdx
@@ -1,58 +1,190 @@
 ---
 title: Contributing
-description: Find the right OpenHands repository and contribution guide for your change.
+description: Join us in building OpenHands and the future of AI. Learn how to contribute to make a meaningful impact.
 ---
 
-# Contributing To OpenHands
+# Contributing to OpenHands
 
-OpenHands is developed across several repositories. Choose the repository that owns the component you want to change, then follow that repository's setup and contribution guidance.
+Welcome to the OpenHands community! We're building the future of AI-powered software development, and we'd love for you to be part of this journey.
 
-## Find The Right Repository
+## Our Vision: Free as in Freedom
 
-| Area | Repository | Guidance | Issues | License |
-|------|------------|----------|--------|---------|
-| **Agent Canvas** | [`OpenHands/OpenHands`](https://github.com/OpenHands/OpenHands) | [README](https://github.com/OpenHands/OpenHands#quickstart) and [development docs](https://github.com/OpenHands/OpenHands/tree/main/docs) | [Issues](https://github.com/OpenHands/OpenHands/issues) | [License](https://github.com/OpenHands/OpenHands/blob/main/LICENSE) |
-| **Software Agent SDK and Agent Server** | [`OpenHands/software-agent-sdk`](https://github.com/OpenHands/software-agent-sdk) | [Development guide](https://github.com/OpenHands/software-agent-sdk/blob/main/DEVELOPMENT.md) and [contribution guide](https://github.com/OpenHands/software-agent-sdk/blob/main/CONTRIBUTING.md) | [Issues](https://github.com/OpenHands/software-agent-sdk/issues) | [License](https://github.com/OpenHands/software-agent-sdk/blob/main/LICENSE) |
-| **Sandbox Server** | [`OpenHands/sandbox-server`](https://github.com/OpenHands/sandbox-server) | [README](https://github.com/OpenHands/sandbox-server#local-development) | [Issues](https://github.com/OpenHands/sandbox-server/issues) | [License](https://github.com/OpenHands/sandbox-server/blob/main/LICENSE) |
-| **OpenHands CLI** | [`OpenHands/OpenHands-CLI`](https://github.com/OpenHands/OpenHands-CLI) | [Contribution guide](https://github.com/OpenHands/OpenHands-CLI/blob/main/CONTRIBUTING.md) | [Issues](https://github.com/OpenHands/OpenHands-CLI/issues) | [License](https://github.com/OpenHands/OpenHands-CLI/blob/main/LICENSE) |
-| **Documentation** | [`OpenHands/docs`](https://github.com/OpenHands/docs) | [Repository guide](https://github.com/OpenHands/docs/blob/main/AGENTS.md) | [Issues](https://github.com/OpenHands/docs/issues) | Check the repository before reuse |
-| **Evaluations and benchmarks** | [`OpenHands/benchmarks`](https://github.com/OpenHands/benchmarks) | [Contribution guide](https://github.com/OpenHands/benchmarks/blob/main/CONTRIBUTING.md) | [Issues](https://github.com/OpenHands/benchmarks/issues) | [License](https://github.com/OpenHands/benchmarks/blob/main/LICENSE) |
+The OpenHands community is built around the belief that **AI and AI agents are going to fundamentally change the way we build software**, and if this is true, we should do everything we can to make sure that the benefits provided by such powerful technology are **accessible to everyone**.
 
-OpenHands Enterprise development is maintained privately. For an Enterprise support request or product question, use your support channel or [contact the OpenHands team](https://openhands.dev/enterprise).
+We believe in the power of open source to democratize access to cutting-edge AI technology. Just as the internet transformed how we share information, we envision a world where AI-powered development tools are available to every developer, regardless of their background or resources.
 
-<Note>
-  The former OpenHands monorepo is preserved in the read-only [`OpenHands/legacy`](https://github.com/OpenHands/legacy) repository. Route active Canvas, SDK, Agent Server, Sandbox Server, CLI, and evaluation work to the repositories above.
-</Note>
+If this resonates with you, we'd love to have you join us in our quest!
 
-## Start Contributing
+## 🚀 Getting Started
 
-1. Open the repository that owns your change.
-2. Read its `README`, `AGENTS.md`, and contribution or development guide when present.
-3. Search the repository's existing issues and pull requests.
-4. For a substantial change, open or join an issue before implementation so maintainers can confirm the direction.
-5. Run the repository's required formatting, linting, and tests before opening a pull request.
+Ready to contribute? Here's your path to making an impact:
 
-Good first issues are labeled per repository. Browse the [OpenHands organization repositories](https://github.com/orgs/OpenHands/repositories), or ask in the [OpenHands Slack community](https://openhands.dev/joinslack) if you are unsure where a change belongs.
+### 1. Quick Wins
+Start with these easy contributions:
+- **Use OpenHands** and [report issues](https://github.com/OpenHands/OpenHands/issues) you encounter
+- **Give feedback** using the thumbs-up/thumbs-down buttons after each session
+- **Star our repository** on [GitHub](https://github.com/OpenHands/OpenHands)
+- **Share OpenHands** with other developers
 
-## Pull Request Guidance
+### 2. Set Up Your Development Environment
+Follow our setup guide:
+- **Requirements**: Node.js 22+, uv
+- **Quick setup**: 
+```
+git clone https://github.com/OpenHands/OpenHands.git
+cd OpenHands
+npm install
+```
+- **Run locally**: `npm run dev` to start the application
 
-Keep pull requests focused on one component and explain:
+*Full details in [Development Guide](https://github.com/OpenHands/OpenHands/blob/main/docs/DEVELOPMENT.md)*
 
-- What changed and why
-- Which issue the change addresses
-- How you tested it
-- Any user-facing behavior or compatibility impact
-- Screenshots for visible Agent Canvas changes
+### 3. Find Your First Issue
+Look for beginner-friendly opportunities:
+- Browse [good first issues](https://github.com/OpenHands/OpenHands/labels/good%20first%20issue)
+- Ask in [Slack](https://openhands.dev/joinslack) what needs help
 
-Follow the target repository's title, changelog, and review requirements. Architecture and agent-behavior changes usually need more design discussion than small bug fixes or documentation corrections.
+### 4. Join the Community
+Connect with other contributors in our [Slack Community](https://openhands.dev/joinslack). You can connect with OpenHands contributors, maintainers, and more!
 
-## Other Ways To Contribute
+## 📋 How to Contribute Code
 
-- Report reproducible issues in the repository that owns the affected component.
-- Improve guides and API documentation in [`OpenHands/docs`](https://github.com/OpenHands/docs).
-- Add or improve evaluations in [`OpenHands/benchmarks`](https://github.com/OpenHands/benchmarks).
-- Answer questions and share feedback in the [OpenHands Slack community](https://openhands.dev/joinslack).
+### Pull Request Process
+We welcome pull requests across our public repositories! Here's how we evaluate them:
 
-## Community Standards
+#### Small Improvements
+- Quick review and approval for obvious improvements
+- Make sure CI tests pass
+- Include clear description of changes
 
-Follow the community and contribution guidance in the repository you are changing. Be respectful, provide enough context for maintainers to reproduce problems, and keep technical discussion focused on the proposed change.
+#### Core Agent Changes
+We're more careful with agent changes since they affect user experience:
+- **Accuracy** - Does it make the agent better at solving problems?
+- **Efficiency** - Does it improve speed or reduce resource usage?
+- **Code Quality** - Is the code maintainable and well-tested?
+
+*Discuss major changes in [GitHub issues](https://github.com/OpenHands/OpenHands/issues) or [Slack](https://openhands.dev/joinslack) first!*
+
+### Pull Request Guidelines
+We recommend the following for smooth reviews but they're not required. Just know that the more you follow these guidelines, the more likely you'll get your PR reviewed faster and reduce the quantity of revisions.
+
+**Title Format:**
+- `feat: Add new agent capability`
+- `fix: Resolve memory leak in runtime`
+- `docs: Update installation guide`
+- `style: Fix code formatting`
+- `refactor: Simplify authentication logic`
+- `test: Add unit tests for parser`
+
+**Description:**
+- Explain what the PR does and why
+- Link to related issues
+- Include screenshots for UI changes
+- Add changelog entry for user-facing changes
+
+## What Can You Build?
+
+There are countless ways to contribute to OpenHands. Whether you're a seasoned developer, a researcher, a designer, or someone just getting started, there's a place for you in our community.
+
+*Small fixes are always welcome! For bigger changes, join our [Slack](https://openhands.dev/joinslack) first.*
+
+### Frontend & UI/UX
+Make OpenHands more beautiful and user-friendly:
+React & TypeScript Development - Improve the web interface
+UI/UX Design - Enhance user experience and accessibility
+Mobile Responsiveness - Make OpenHands work great on all devices
+Component Libraries - Build reusable UI components
+
+*Small fixes are always welcome! For bigger changes, join our `#agent-canvas` channel in [Slack](https://openhands.dev/joinslack) first.
+
+
+### Agent Development
+Help make our AI agents smarter and more capable:
+- **Prompt Engineering** - Improve how agents understand and respond
+- **New Agent Types** - Create specialized agents for different tasks
+- **Agent Evaluation** - Develop better ways to measure agent performance
+- **Multi-Agent Systems** - Enable agents to work together
+
+*We use [SWE-bench](https://www.swebench.com/) to evaluate our agents. Join our  [Slack](https://openhands.dev/joinslack) to learn more.*
+
+### Backend & Infrastructure
+Build the foundation that powers OpenHands:
+- **Python Development** - Core functionality and APIs
+- **Runtime Systems** - Docker containers and sandboxes
+- **Cloud Integrations** - Support for different cloud providers
+- **Performance Optimization** - Make everything faster and more efficient
+
+### Testing & Quality Assurance
+Help us maintain high quality:
+- **Unit Testing** - Write tests for new features
+- **Integration Testing** - Ensure components work together
+- **Bug Hunting** - Find and report issues
+- **Performance Testing** - Identify bottlenecks and optimization opportunities
+
+### Documentation & Education
+Help others learn and contribute:
+- **Technical Documentation** - API docs, guides, and tutorials
+- **Video Tutorials** - Create learning content
+- **Translation** - Make OpenHands accessible in more languages
+- **Community Support** - Help other users and contributors
+
+### Research & Innovation
+Push the boundaries of what's possible:
+- **Academic Research** - Publish papers using OpenHands
+- **Benchmarking** - Develop new evaluation methods
+- **Experimental Features** - Try cutting-edge AI techniques
+- **Data Analysis** - Study how developers use AI tools
+
+## Becoming a Maintainer
+
+For contributors who have made significant and sustained contributions to the project, there is a possibility of joining the maintainer team.
+The process for this is as follows:
+
+1. Any contributor who has made sustained and high-quality contributions to the codebase can be nominated by any maintainer. If you feel that you may qualify you can reach out to any of the maintainers that have reviewed your PRs and ask if you can be nominated.
+2. Once a maintainer nominates a new maintainer, there will be a discussion period among the maintainers for at least 3 days.
+3. If no concerns are raised the nomination will be accepted by acclamation, and if concerns are raised there will be a discussion and possible vote.
+
+Note that just making many PRs does not immediately imply that you will become a maintainer. We will be looking at sustained high-quality contributions over a period of time, as well as good teamwork and adherence to our [Code of Conduct](https://github.com/OpenHands/OpenHands/blob/main/CODE_OF_CONDUCT.md).
+
+## License
+
+OpenHands is released under the **MIT License**, which means:
+
+### You Can:
+- **Use** OpenHands for any purpose, including commercial projects
+- **Modify** the code to fit your needs
+- **Share** your modifications
+- **Distribute** or sell copies of OpenHands
+
+### You Must:
+- **Include** the original copyright notice and license text
+- **Preserve** the license in any substantial portions you use
+
+### No Warranty:
+- OpenHands is provided "as is" without warranty
+- Contributors are not liable for any damages
+
+*Full license text: [LICENSE](https://github.com/OpenHands/OpenHands/blob/main/LICENSE)*
+
+**Special Note:** Content in the `enterprise/` directory has a separate license, and we cannot accept external pull requests for changes to this directory at this time. See `enterprise/LICENSE` for details.
+
+## Ready to make your first contribution?
+
+1. **⭐ Star** our [GitHub repository](https://github.com/OpenHands/OpenHands)
+2. **🔧 Set up** your development environment using our [Development Guide](https://github.com/OpenHands/OpenHands/blob/main/Development.md)
+3. **💬 Join** our [Slack community](https://openhands.dev/joinslack) to meet other contributors
+4. **🎯 Find** a [good first issue](https://github.com/OpenHands/OpenHands/labels/good%20first%20issue) to work on
+5. **📝 Read** our [Code of Conduct](https://github.com/OpenHands/OpenHands/blob/main/CODE_OF_CONDUCT.md)
+
+## Need Help?
+
+Don't hesitate to ask for help:
+- **Slack**: [Join our community](https://openhands.dev/joinslack) for real-time support
+- **GitHub Issues**: [Open an issue](https://github.com/OpenHands/OpenHands/issues) for bugs or feature requests
+- **Email**: Contact us at [contact@openhands.dev](mailto:contact@openhands.dev)
+
+---
+
+Thank you for considering contributing to OpenHands! Together, we're building tools that will democratize AI-powered software development and make it accessible to developers everywhere. Every contribution, no matter how small, helps us move closer to that vision. 
+
+Welcome to the community! 🎉

--- a/overview/contributing.mdx
+++ b/overview/contributing.mdx
@@ -1,196 +1,58 @@
 ---
 title: Contributing
-description: Join us in building OpenHands and the future of AI. Learn how to contribute to make a meaningful impact.
+description: Find the right OpenHands repository and contribution guide for your change.
 ---
 
-# Contributing to OpenHands
+# Contributing To OpenHands
 
-Welcome to the OpenHands community! We're building the future of AI-powered software development, and we'd love for you to be part of this journey.
+OpenHands is developed across several repositories. Choose the repository that owns the component you want to change, then follow that repository's setup and contribution guidance.
 
-## Our Vision: Free as in Freedom
+## Find The Right Repository
 
-The OpenHands community is built around the belief that **AI and AI agents are going to fundamentally change the way we build software**, and if this is true, we should do everything we can to make sure that the benefits provided by such powerful technology are **accessible to everyone**.
+| Area | Repository | Guidance | Issues | License |
+|------|------------|----------|--------|---------|
+| **Agent Canvas** | [`OpenHands/OpenHands`](https://github.com/OpenHands/OpenHands) | [README](https://github.com/OpenHands/OpenHands#quickstart) and [development docs](https://github.com/OpenHands/OpenHands/tree/main/docs) | [Issues](https://github.com/OpenHands/OpenHands/issues) | [License](https://github.com/OpenHands/OpenHands/blob/main/LICENSE) |
+| **Software Agent SDK and Agent Server** | [`OpenHands/software-agent-sdk`](https://github.com/OpenHands/software-agent-sdk) | [Development guide](https://github.com/OpenHands/software-agent-sdk/blob/main/DEVELOPMENT.md) and [contribution guide](https://github.com/OpenHands/software-agent-sdk/blob/main/CONTRIBUTING.md) | [Issues](https://github.com/OpenHands/software-agent-sdk/issues) | [License](https://github.com/OpenHands/software-agent-sdk/blob/main/LICENSE) |
+| **Sandbox Server** | [`OpenHands/sandbox-server`](https://github.com/OpenHands/sandbox-server) | [README](https://github.com/OpenHands/sandbox-server#local-development) | [Issues](https://github.com/OpenHands/sandbox-server/issues) | [License](https://github.com/OpenHands/sandbox-server/blob/main/LICENSE) |
+| **OpenHands CLI** | [`OpenHands/OpenHands-CLI`](https://github.com/OpenHands/OpenHands-CLI) | [Contribution guide](https://github.com/OpenHands/OpenHands-CLI/blob/main/CONTRIBUTING.md) | [Issues](https://github.com/OpenHands/OpenHands-CLI/issues) | [License](https://github.com/OpenHands/OpenHands-CLI/blob/main/LICENSE) |
+| **Documentation** | [`OpenHands/docs`](https://github.com/OpenHands/docs) | [Repository guide](https://github.com/OpenHands/docs/blob/main/AGENTS.md) | [Issues](https://github.com/OpenHands/docs/issues) | Check the repository before reuse |
+| **Evaluations and benchmarks** | [`OpenHands/benchmarks`](https://github.com/OpenHands/benchmarks) | [Contribution guide](https://github.com/OpenHands/benchmarks/blob/main/CONTRIBUTING.md) | [Issues](https://github.com/OpenHands/benchmarks/issues) | [License](https://github.com/OpenHands/benchmarks/blob/main/LICENSE) |
 
-We believe in the power of open source to democratize access to cutting-edge AI technology. Just as the internet transformed how we share information, we envision a world where AI-powered development tools are available to every developer, regardless of their background or resources.
+OpenHands Enterprise development is maintained privately. For an Enterprise support request or product question, use your support channel or [contact the OpenHands team](https://openhands.dev/enterprise).
 
-If this resonates with you, we'd love to have you join us in our quest!
+<Note>
+  The former OpenHands monorepo is preserved in the read-only [`OpenHands/legacy`](https://github.com/OpenHands/legacy) repository. Route active Canvas, SDK, Agent Server, Sandbox Server, CLI, and evaluation work to the repositories above.
+</Note>
 
-## 🚀 Getting Started
+## Start Contributing
 
-Ready to contribute? Here's your path to making an impact:
+1. Open the repository that owns your change.
+2. Read its `README`, `AGENTS.md`, and contribution or development guide when present.
+3. Search the repository's existing issues and pull requests.
+4. For a substantial change, open or join an issue before implementation so maintainers can confirm the direction.
+5. Run the repository's required formatting, linting, and tests before opening a pull request.
 
-### 1. Quick Wins
-Start with these easy contributions:
-- **Use OpenHands** and [report issues](https://github.com/OpenHands/OpenHands/issues) you encounter
-- **Give feedback** using the thumbs-up/thumbs-down buttons after each session
-- **Star our repository** on [GitHub](https://github.com/OpenHands/OpenHands)
-- **Share OpenHands** with other developers
+Good first issues are labeled per repository. Browse the [OpenHands organization repositories](https://github.com/orgs/OpenHands/repositories), or ask in the [OpenHands Slack community](https://openhands.dev/joinslack) if you are unsure where a change belongs.
 
-### 2. Set Up Your Development Environment
-Follow our setup guide:
-- **Requirements**: Linux/Mac/WSL, Docker, Python 3.12, Node.js 22+, Poetry 1.8+
-- **Quick setup**: `make build` to get everything ready
-- **Configuration**: `make setup-config` to configure your LLM
-- **Run locally**: `make run` to start the application
+## Pull Request Guidance
 
-*Full details in our [Development Guide](https://github.com/OpenHands/OpenHands/blob/main/Development.md)*
+Keep pull requests focused on one component and explain:
 
-### 3. Find Your First Issue
-Look for beginner-friendly opportunities:
-- Browse [good first issues](https://github.com/OpenHands/OpenHands/labels/good%20first%20issue)
-- Check our [project boards](https://github.com/OpenHands/OpenHands/projects) for organized tasks
-- Ask in [Slack](https://openhands.dev/joinslack) what needs help
+- What changed and why
+- Which issue the change addresses
+- How you tested it
+- Any user-facing behavior or compatibility impact
+- Screenshots for visible Agent Canvas changes
 
-### 4. Join the Community
-Connect with other contributors in our [Slack Community](https://openhands.dev/joinslack). You can connect with OpenHands contributors, maintainers, and more!
+Follow the target repository's title, changelog, and review requirements. Architecture and agent-behavior changes usually need more design discussion than small bug fixes or documentation corrections.
 
-## 📋 How to Contribute Code
+## Other Ways To Contribute
 
-### Understanding the Codebase
-Get familiar with our architecture:
-- **[Frontend](https://github.com/OpenHands/OpenHands/tree/main/frontend/README.md)** - React application
-- **[Backend](https://github.com/OpenHands/OpenHands/tree/main/openhands/README.md)** - Python core
-- **[Agents](https://github.com/OpenHands/OpenHands/tree/main/openhands/agenthub/README.md)** - AI agent implementations
-- **[Runtime](https://github.com/OpenHands/OpenHands/tree/main/openhands/runtime/README.md)** - Execution environments
-- **[Evaluation](https://github.com/OpenHands/benchmarks)** - Testing and benchmarks
+- Report reproducible issues in the repository that owns the affected component.
+- Improve guides and API documentation in [`OpenHands/docs`](https://github.com/OpenHands/docs).
+- Add or improve evaluations in [`OpenHands/benchmarks`](https://github.com/OpenHands/benchmarks).
+- Answer questions and share feedback in the [OpenHands Slack community](https://openhands.dev/joinslack).
 
-### Pull Request Process
-We welcome pull requests across our public repositories! Here's how we evaluate them:
+## Community Standards
 
-<Warning>
-**Enterprise Directory Restriction:** We cannot accept pull requests for changes in the `enterprise/` directory of the OpenHands repository at this time, as this part of the codebase is commercially licensed. If you have feedback or suggestions for [OpenHands Enterprise](/enterprise/index), please [create an issue](https://github.com/OpenHands/OpenHands/issues) in the OpenHands repository instead.
-</Warning>
-
-#### Small Improvements
-- Quick review and approval for obvious improvements
-- Make sure CI tests pass
-- Include clear description of changes
-
-#### Core Agent Changes
-We're more careful with agent changes since they affect user experience:
-- **Accuracy** - Does it make the agent better at solving problems?
-- **Efficiency** - Does it improve speed or reduce resource usage?
-- **Code Quality** - Is the code maintainable and well-tested?
-
-*Discuss major changes in [GitHub issues](https://github.com/OpenHands/OpenHands/issues) or [Slack](https://openhands.dev/joinslack) first!*
-
-### Pull Request Guidelines
-We recommend the following for smooth reviews but they're not required. Just know that the more you follow these guidelines, the more likely you'll get your PR reviewed faster and reduce the quantity of revisions.
-
-**Title Format:**
-- `feat: Add new agent capability`
-- `fix: Resolve memory leak in runtime`
-- `docs: Update installation guide`
-- `style: Fix code formatting`
-- `refactor: Simplify authentication logic`
-- `test: Add unit tests for parser`
-
-**Description:**
-- Explain what the PR does and why
-- Link to related issues
-- Include screenshots for UI changes
-- Add changelog entry for user-facing changes
-
-## What Can You Build?
-
-There are countless ways to contribute to OpenHands. Whether you're a seasoned developer, a researcher, a designer, or someone just getting started, there's a place for you in our community.
-
-### Frontend & UI/UX
-Make OpenHands more beautiful and user-friendly:
-- **React & TypeScript Development** - Improve the web interface
-- **UI/UX Design** - Enhance user experience and accessibility  
-- **Mobile Responsiveness** - Make OpenHands work great on all devices
-- **Component Libraries** - Build reusable UI components
-
-*Small fixes are always welcome! For bigger changes, join our **#eng-ui-ux** channel in [Slack](https://openhands.dev/joinslack) first.*
-
-### Agent Development
-Help make our AI agents smarter and more capable:
-- **Prompt Engineering** - Improve how agents understand and respond
-- **New Agent Types** - Create specialized agents for different tasks
-- **Agent Evaluation** - Develop better ways to measure agent performance
-- **Multi-Agent Systems** - Enable agents to work together
-
-*We use [SWE-bench](https://www.swebench.com/) to evaluate our agents. Join our  [Slack](https://openhands.dev/joinslack) to learn more.*
-
-### Backend & Infrastructure
-Build the foundation that powers OpenHands:
-- **Python Development** - Core functionality and APIs
-- **Runtime Systems** - Docker containers and sandboxes
-- **Cloud Integrations** - Support for different cloud providers
-- **Performance Optimization** - Make everything faster and more efficient
-
-### Testing & Quality Assurance
-Help us maintain high quality:
-- **Unit Testing** - Write tests for new features
-- **Integration Testing** - Ensure components work together
-- **Bug Hunting** - Find and report issues
-- **Performance Testing** - Identify bottlenecks and optimization opportunities
-
-### Documentation & Education
-Help others learn and contribute:
-- **Technical Documentation** - API docs, guides, and tutorials
-- **Video Tutorials** - Create learning content
-- **Translation** - Make OpenHands accessible in more languages
-- **Community Support** - Help other users and contributors
-
-### Research & Innovation
-Push the boundaries of what's possible:
-- **Academic Research** - Publish papers using OpenHands
-- **Benchmarking** - Develop new evaluation methods
-- **Experimental Features** - Try cutting-edge AI techniques
-- **Data Analysis** - Study how developers use AI tools
-
-## Becoming a Maintainer
-
-For contributors who have made significant and sustained contributions to the project, there is a possibility of joining the maintainer team.
-The process for this is as follows:
-
-1. Any contributor who has made sustained and high-quality contributions to the codebase can be nominated by any maintainer. If you feel that you may qualify you can reach out to any of the maintainers that have reviewed your PRs and ask if you can be nominated.
-2. Once a maintainer nominates a new maintainer, there will be a discussion period among the maintainers for at least 3 days.
-3. If no concerns are raised the nomination will be accepted by acclamation, and if concerns are raised there will be a discussion and possible vote.
-
-Note that just making many PRs does not immediately imply that you will become a maintainer. We will be looking at sustained high-quality contributions over a period of time, as well as good teamwork and adherence to our [Code of Conduct](https://github.com/OpenHands/OpenHands/blob/main/CODE_OF_CONDUCT.md).
-
-## License
-
-OpenHands is released under the **MIT License**, which means:
-
-### You Can:
-- **Use** OpenHands for any purpose, including commercial projects
-- **Modify** the code to fit your needs
-- **Share** your modifications
-- **Distribute** or sell copies of OpenHands
-
-### You Must:
-- **Include** the original copyright notice and license text
-- **Preserve** the license in any substantial portions you use
-
-### No Warranty:
-- OpenHands is provided "as is" without warranty
-- Contributors are not liable for any damages
-
-*Full license text: [LICENSE](https://github.com/OpenHands/OpenHands/blob/main/LICENSE)*
-
-**Special Note:** Content in the `enterprise/` directory has a separate license, and we cannot accept external pull requests for changes to this directory at this time. See `enterprise/LICENSE` for details.
-
-## Ready to make your first contribution?
-
-1. **⭐ Star** our [GitHub repository](https://github.com/OpenHands/OpenHands)
-2. **🔧 Set up** your development environment using our [Development Guide](https://github.com/OpenHands/OpenHands/blob/main/Development.md)
-3. **💬 Join** our [Slack community](https://openhands.dev/joinslack) to meet other contributors
-4. **🎯 Find** a [good first issue](https://github.com/OpenHands/OpenHands/labels/good%20first%20issue) to work on
-5. **📝 Read** our [Code of Conduct](https://github.com/OpenHands/OpenHands/blob/main/CODE_OF_CONDUCT.md)
-
-## Need Help?
-
-Don't hesitate to ask for help:
-- **Slack**: [Join our community](https://openhands.dev/joinslack) for real-time support
-- **GitHub Issues**: [Open an issue](https://github.com/OpenHands/OpenHands/issues) for bugs or feature requests
-- **Email**: Contact us at [contact@openhands.dev](mailto:contact@openhands.dev)
-
----
-
-Thank you for considering contributing to OpenHands! Together, we're building tools that will democratize AI-powered software development and make it accessible to developers everywhere. Every contribution, no matter how small, helps us move closer to that vision. 
-
-Welcome to the community! 🎉
+Follow the community and contribution guidance in the repository you are changing. Be respectful, provide enough context for maintainers to reproduce problems, and keep technical discussion focused on the proposed change.

--- a/overview/faqs.mdx
+++ b/overview/faqs.mdx
@@ -33,23 +33,15 @@ input on our product roadmap.
 
 ### It's doing stuff without asking, is that safe?
 
-**Generally yes, but with important considerations.** OpenHands runs all code in a secure, isolated Docker container
-(called a "sandbox") that is separate from your host system. However, the safety depends on your configuration:
-
-**What's protected:**
-- Your host system files and programs (unless you mount them using [this feature](/openhands/usage/sandboxes/docker#connecting-to-your-filesystem))
-- Host system resources
-- Other containers and processes
+**Safety depends on the backend and workspace you select.** A local process backend runs Agent Server and tools directly on its host. Docker, Kubernetes, Sandbox Server, Cloud, and Enterprise deployments can provide stronger isolation according to their container, sandbox, mount, and network configuration.
 
 **Potential risks to consider:**
-- The agent can access the internet from within the container.
-- If you provide credentials (API keys, tokens), the agent can use them.
-- Mounted files and directories can be modified or deleted.
-- Network requests can be made to external services.
+- The agent can modify any files exposed to its workspace.
+- The agent can use credentials and network access available to its execution environment.
+- A local process backend can access the host with the permissions of the user running Agent Server.
+- Container isolation can be weakened by broad mounts, privileged mode, host networking, or access to the Docker socket.
 
-For detailed security information, see our [Runtime Architecture](/openhands/usage/architecture/runtime),
-[Security Configuration](/openhands/usage/advanced/configuration-options#security-configuration),
-and [Hardened Docker Installation](/openhands/usage/sandboxes/docker#hardened-docker-installation) documentation.
+For current component and trust boundaries, see [Agent Canvas Architecture](/openhands/usage/agent-canvas/architecture), [Security Configuration](/openhands/usage/advanced/configuration-options#security-configuration), and [Hardened Docker Installation](/openhands/usage/sandboxes/docker#hardened-docker-installation).
 
 ## File Storage and Access
 

--- a/overview/introduction.mdx
+++ b/overview/introduction.mdx
@@ -25,31 +25,31 @@ The [Software Agent SDK](/sdk) is a composable Python library for building agent
 
 [OpenHands Cloud](/openhands/usage/cloud/openhands-cloud) is the managed commercial service for running OpenHands without operating your own backend and sandbox infrastructure. It provides hosted execution, integrations, collaboration, access controls, usage reporting, and budget management.
 
-[Sign in with your GitHub account](https://app.all-hands.dev) to try it.
+[Open Agent Canvas](https://app.all-hands.dev/canvas) to sign in and try it.
 
 ## OpenHands Enterprise
 
-[OpenHands Enterprise](/enterprise) provides commercial capabilities and support for organizations that need licensed self-hosting or managed deployment options. Enterprise development lives in a private repository rather than a public `enterprise/` directory.
+[OpenHands Enterprise](/enterprise) provides commercial capabilities and support for organizations that need licensed self-hosting or managed deployment options.
 
 Learn more at [openhands.dev/enterprise](https://openhands.dev/enterprise).
 
 ## Sandbox Server
 
-[Sandbox Server](https://github.com/OpenHands/sandbox-server) is the community supported standalone OpenHands API and sandbox control plane. It creates and manages sandboxed environments that host Agent Server. It does not bundle a frontend but can be configured to use Agent Canvas as its browser client.
-
+[Sandbox Server](https://github.com/OpenHands/sandbox-server) is the community-supported standalone OpenHands API and sandbox control plane. It creates and manages sandboxed environments that host Agent Server. It can be configured to use Agent Canvas as its browser client.
 
 ## Component And Repository Map
 
 | Component | Responsibility | Source |
 |-----------|----------------|--------|
 | **Agent Canvas** | Browser client and control center | [`OpenHands/OpenHands`](https://github.com/OpenHands/OpenHands) |
-| **Software Agent SDK and Agent Server** | Agent framework and remote execution API | [`OpenHands/software-agent-sdk`](https://github.com/OpenHands/software-agent-sdk) |
+| **Software Agent SDK** | Agent framework, tools, conversations, and workspaces | [`OpenHands/software-agent-sdk`](https://github.com/OpenHands/software-agent-sdk) |
+| **Agent Server** | Remote agent execution API | [`OpenHands/software-agent-sdk`](https://github.com/OpenHands/software-agent-sdk/tree/main/openhands-agent-server) |
 | **Automation Server** | Scheduled and event-driven automation lifecycle | [`OpenHands/automation`](https://github.com/OpenHands/automation) |
+| **Sandbox Server** | Standalone API and sandbox control plane | [`OpenHands/sandbox-server`](https://github.com/OpenHands/sandbox-server) |
 | **Documentation** | Documentation for the OpenHands ecosystem | [`OpenHands/docs`](https://github.com/OpenHands/docs) |
 | **Evaluations** | Benchmark and evaluation infrastructure | [`OpenHands/benchmarks`](https://github.com/OpenHands/benchmarks) |
 
 Each public repository includes its own license. Check the repository you use or modify instead of assuming one license applies to the entire ecosystem.
-
 
 ## Legacy
 

--- a/overview/introduction.mdx
+++ b/overview/introduction.mdx
@@ -8,64 +8,67 @@ description: Welcome to OpenHands, a community focused on AI-driven development
 There are a few ways to work with OpenHands:
 
 ## Agent Canvas
-Agent Canvas is a browser-based UI and backend server for running agents and automations. A single `agent-canvas` command starts the full stack locally. Self-host on a VM, or connect to OpenHands Cloud.
 
-[Get started with Agent Canvas](/openhands/usage/agent-canvas/overview) or [view the source](https://github.com/OpenHands/OpenHands)
+[Agent Canvas](/openhands/usage/agent-canvas/overview) is the open-source browser client and control center for agent conversations and automations. It connects to one or more Agent Server backends.
+
+The `agent-canvas` launcher can start Canvas with local backend services as an all-in-one stack. You can also run the client separately and connect it to a local, self-hosted, Cloud, or Enterprise backend.
+
+[Get started with Agent Canvas](/openhands/usage/agent-canvas/overview) or [view the source](https://github.com/OpenHands/OpenHands).
+
+## OpenHands Software Agent SDK and Agent Server
+
+The [Software Agent SDK](/sdk) is a composable Python library for building agents that work with code. The same repository contains Agent Server, which exposes agent execution, conversations, tools, and workspaces through REST and WebSocket APIs.
+
+[Get started with the SDK](/sdk/getting-started) or [view the source](https://github.com/OpenHands/software-agent-sdk).
 
 ## OpenHands Cloud
-A fully managed version of OpenHands with source-available features and integrations:
-- Deeper integrations with GitHub, GitLab, and Bitbucket
-- Integrations with Slack, Jira, and Linear
-- Multi-user support
-- RBAC and permissions
-- Collaboration features (e.g., conversation sharing)
-- Usage reporting
-- Budgeting enforcement
 
-Try it free by [signing in with your GitHub account](https://app.all-hands.dev).
+[OpenHands Cloud](/openhands/usage/cloud/openhands-cloud) is the managed commercial service for running OpenHands without operating your own backend and sandbox infrastructure. It provides hosted execution, integrations, collaboration, access controls, usage reporting, and budget management.
+
+[Sign in with your GitHub account](https://app.all-hands.dev) to try it.
 
 ## OpenHands Enterprise
-Large enterprises can work with us to self-host OpenHands Cloud in their own VPC, via Kubernetes.
-OpenHands Enterprise can also work with the CLI and SDK above.
 
-OpenHands Enterprise is source-available--you can see all the source code here in the enterprise/ directory,
-but you'll need to purchase a license if you want to run it for more than one month.
+[OpenHands Enterprise](/enterprise) provides commercial capabilities and support for organizations that need licensed self-hosting or managed deployment options. Enterprise development lives in a private repository rather than a public `enterprise/` directory.
 
-Enterprise contracts also come with extended support and access to our research team.
+Learn more at [openhands.dev/enterprise](https://openhands.dev/enterprise).
 
-Learn more at [openhands.dev/enterprise](https://openhands.dev/enterprise)
+## Sandbox Server
 
-## OpenHands Software Agent SDK
-The SDK is a composable Python library that contains all of our agentic tech. It's the engine that powers everything else.
+[Sandbox Server](https://github.com/OpenHands/sandbox-server) is the community supported standalone OpenHands API and sandbox control plane. It creates and manages sandboxed environments that host Agent Server. It does not bundle a frontend but can be configured to use Agent Canvas as its browser client.
 
-Define agents in code, then run them locally, or scale to 1000s of agents in the cloud.
 
-[Check out the docs](https://docs.openhands.dev/sdk) or [view the source](https://github.com/OpenHands/software-agent-sdk)
+## Component And Repository Map
+
+| Component | Responsibility | Source |
+|-----------|----------------|--------|
+| **Agent Canvas** | Browser client and control center | [`OpenHands/OpenHands`](https://github.com/OpenHands/OpenHands) |
+| **Software Agent SDK and Agent Server** | Agent framework and remote execution API | [`OpenHands/software-agent-sdk`](https://github.com/OpenHands/software-agent-sdk) |
+| **Automation Server** | Scheduled and event-driven automation lifecycle | [`OpenHands/automation`](https://github.com/OpenHands/automation) |
+| **Documentation** | Documentation for the OpenHands ecosystem | [`OpenHands/docs`](https://github.com/OpenHands/docs) |
+| **Evaluations** | Benchmark and evaluation infrastructure | [`OpenHands/benchmarks`](https://github.com/OpenHands/benchmarks) |
+
+Each public repository includes its own license. Check the repository you use or modify instead of assuming one license applies to the entire ecosystem.
+
 
 ## Legacy
+
+The archived [`OpenHands/legacy`](https://github.com/OpenHands/legacy) snapshot also preserves the previous backend and runtime architecture for historical reference.
 
 <Accordion title="OpenHands CLI and Local GUI">
   **OpenHands CLI**
 
-  The CLI is a terminal-based interface for running OpenHands agents. You can power it with Claude, GPT, or any other LLM.
+  The CLI is a terminal-based interface powered by the Software Agent SDK. It is feature-complete and primarily maintained for stability.
 
-  [Check out the docs](https://docs.openhands.dev/openhands/usage/run-openhands/cli-mode) or [view the source](https://github.com/OpenHands/OpenHands-CLI)
+  [Check out the docs](/openhands/usage/cli/installation) or [view the source](https://github.com/OpenHands/OpenHands-CLI).
 
-  **OpenHands Local GUI**
+  **OpenHands Legacy Local GUI**
 
-  A legacy UI requiring Docker for running agents on your laptop. It comes with a REST API and a single-page React application.
+  The Local GUI is the deprecated Docker-based browser application from the former OpenHands monorepo. Use Agent Canvas for active browser-client development.
 
-  [Check out the docs](https://docs.openhands.dev/openhands/usage/run-openhands/local-setup) or view the source in this repo.
+  [View the pinned source](https://github.com/OpenHands/legacy).
 </Accordion>
 
-## Everything Else
+## Community
 
-Check out our [Product Roadmap](https://github.com/orgs/openhands/projects/1), and feel free to
-[open up an issue](https://github.com/OpenHands/OpenHands/issues) if there's something you'd like to see!
-
-You might also be interested in our [evaluation infrastructure](https://github.com/OpenHands/benchmarks), our [chrome extension](https://github.com/OpenHands/openhands-chrome-extension/), or our [Theory-of-Mind module](https://github.com/OpenHands/ToM-SWE).
-
-All our work is available under the MIT license, except for the `enterprise/` directory in this repository (see the [enterprise license](https://github.com/OpenHands/OpenHands/blob/main/enterprise/LICENSE) for details).
-The core `openhands` and `agent-server` Docker images are fully MIT-licensed as well.
-
-If you need help with anything, or just want to chat, [come find us on Slack](https://openhands.dev/joinslack).
+Explore all [OpenHands repositories](https://github.com/orgs/OpenHands/repositories) and [join us on Slack](https://openhands.dev/joinslack).

--- a/scripts/generate-llms-files.py
+++ b/scripts/generate-llms-files.py
@@ -7,12 +7,13 @@ Why this exists
 Mintlify automatically generates and hosts `/llms.txt` and `/llms-full.txt` for
 Mintlify-backed documentation sites.
 
-For OpenHands, we want those files to provide **V1-only** context to LLMs while we
-still keep some legacy V0 pages available for humans. In particular, we want to
-exclude:
+For OpenHands, we want those files to provide **current architecture** context
+to LLMs while we still keep legacy pages available for humans. In particular,
+we want to exclude:
 
 - The legacy docs subtree under `openhands/usage/v0/`
 - Any page whose filename starts with `V0*`
+- Orphaned architecture pages for the former monorepo backend and runtime
 
 Mintlify supports overriding the auto-generated files by committing `llms.txt`
 (and/or `llms-full.txt`) to the repository root.
@@ -51,6 +52,10 @@ ROOT = Path(__file__).resolve().parents[1]
 BASE_URL = "https://docs.openhands.dev"
 
 EXCLUDED_DIRS = {".git", ".github", ".agents", "tests", "openapi", "logo"}
+EXCLUDED_PAGES = {
+    Path("openhands/usage/architecture/backend.mdx"),
+    Path("openhands/usage/architecture/runtime.mdx"),
+}
 
 
 @dataclass(frozen=True)
@@ -127,7 +132,7 @@ def iter_doc_pages() -> list[DocPage]:
 
         if any(part in EXCLUDED_DIRS for part in rel_path.parts):
             continue
-        if is_v0_page(rel_path):
+        if rel_path in EXCLUDED_PAGES or is_v0_page(rel_path):
             continue
 
         raw = mdx_path.read_text(encoding="utf-8")

--- a/sdk/arch/overview.mdx
+++ b/sdk/arch/overview.mdx
@@ -7,43 +7,46 @@ The **OpenHands Software Agent SDK** provides a unified, type-safe framework for
 
 Check [this document](/sdk/arch/design) for the core design principles that guided its architecture.
 
-## Relationship with OpenHands Applications
+## Relationship With OpenHands Applications
 
-The Software Agent SDK serves as the **source of truth for agents** in OpenHands. The [OpenHands repository](https://github.com/OpenHands/OpenHands) provides interfaces—web app, CLI, and cloud—that consume the SDK APIs. This architecture ensures consistency and enables flexible integration patterns.
-- **Software Agent SDK = foundation.** The SDK defines all core components: agents, LLMs, conversations, tools, workspaces, events, and security policies.
-- **Interfaces reuse SDK objects.** The OpenHands GUI or CLI hydrate SDK components from persisted settings and orchestrate execution through SDK APIs.
-- **Consistent configuration.** Whether you launch an agent programmatically or via the OpenHands GUI, the supported parameters and defaults come from the SDK.
+The Software Agent SDK is the source of truth for agents in OpenHands. Its repository also contains Agent Server, which exposes SDK conversations and workspaces to remote clients through REST and WebSocket APIs. OpenHands applications live in separate repositories and consume these SDK interfaces.
+
+- **The SDK defines agent behavior.** It provides agents, LLMs, conversations, tools, workspaces, events, and security policies.
+- **Agent Server exposes remote execution.** Clients use its APIs to run conversations and tools in the selected workspace or sandbox.
+- **Applications remain separate.** [Agent Canvas](https://github.com/OpenHands/OpenHands), the [OpenHands CLI](https://github.com/OpenHands/OpenHands-CLI), and custom clients integrate with the SDK or Agent Server without sharing one application repository.
 
 ```mermaid
 %%{init: {"theme": "default", "flowchart": {"nodeSpacing": 30, "rankSpacing": 50}} }%%
 graph TB
-    subgraph Interfaces["OpenHands Interfaces"]
-        UI[OpenHands GUI<br><i>React frontend</i>]
-        CLI[OpenHands CLI<br><i>Command-line interface</i>]
-        Custom[Your Custom Client<br><i>Automations & workflows</i>]
+    subgraph Clients["Clients"]
+        Canvas[Agent Canvas<br><i>Browser client</i>]
+        CLI[OpenHands CLI<br><i>Command-line client</i>]
+        Custom[Custom Client<br><i>Applications and workflows</i>]
     end
 
-    SDK[Software Agent SDK<br><i>openhands.sdk + tools + workspace</i>]
-    
+    Server[Agent Server<br><i>REST and WebSocket API</i>]
+    SDK[Software Agent SDK<br><i>Agents, tools, and workspaces</i>]
+
     subgraph External["External Services"]
-        LLM[LLM Providers<br><i>OpenAI, Anthropic, etc.</i>]
-        Runtime[Runtime Services<br><i>Docker, Remote API, etc.</i>]
+        LLM[LLM Providers]
+        Workspace[Workspace or Sandbox]
     end
 
-    UI --> SDK
+    Canvas --> Server
     CLI --> SDK
+    Custom --> Server
     Custom --> SDK
-    
+    Server --> SDK
     SDK --> LLM
-    SDK --> Runtime
-    
+    SDK --> Workspace
+
     classDef interface fill:#e8f3ff,stroke:#2b6cb0,stroke-width:2px
     classDef sdk fill:#f3e8ff,stroke:#7c3aed,stroke-width:2px
     classDef external fill:#fff4df,stroke:#b7791f,stroke-width:2px
-    
-    class UI,CLI,Custom interface
-    class SDK sdk
-    class LLM,Runtime external
+
+    class Canvas,CLI,Custom interface
+    class Server,SDK sdk
+    class LLM,Workspace external
 ```
 
 

--- a/tests/test_generate_llms_files.py
+++ b/tests/test_generate_llms_files.py
@@ -1,0 +1,19 @@
+import importlib.util
+from pathlib import Path
+import sys
+
+
+SCRIPT_PATH = Path(__file__).parents[1] / "scripts" / "generate-llms-files.py"
+SPEC = importlib.util.spec_from_file_location("generate_llms_files", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def test_iter_doc_pages_excludes_former_monorepo_architecture() -> None:
+    paths = {page.rel_path for page in MODULE.iter_doc_pages()}
+
+    assert Path("openhands/usage/architecture/backend.mdx") not in paths
+    assert Path("openhands/usage/architecture/runtime.mdx") not in paths
+    assert Path("openhands/usage/agent-canvas/architecture.mdx") in paths


### PR DESCRIPTION
## Summary

- update product and repository ownership boundaries after the repository migration
- add a canonical Agent Canvas architecture page and clarify Agent Server, Automation Server, managed Cloud/Enterprise control-plane, and community Sandbox Server boundaries
- add generic Remote Backend documentation, reorganize Agent Canvas navigation, and move Modal under self-hosted backend services
- correct Docker/Helm UI paths and reassign the V1 API documentation to Sandbox Server
- exclude obsolete monorepo architecture pages from generated LLM context

## Review status

This is a **first pass** over the broad scope in #686. It still needs a full human review, preferably page by page, for product language, information architecture, technical accuracy, and the remaining decisions listed in the issue. Please keep this PR in draft until that review is complete.

The latest pass clarifies that Sandbox Server is community-driven and not a core or supported Agent Canvas backend. It also distinguishes a generic remote Agent Server from the managed Cloud and Enterprise platforms, whose control planes create the sandboxes that host Agent Server.

## Validation

- local Mintlify preview renders the revised architecture page and navigation
- 31 affected tests pass
- `docs.json` parses successfully
- `git diff --check` passes
- regenerated `llms.txt` and `llms-full.txt` omit the obsolete backend/runtime architecture pages

## Known unrelated issue

The complete pricing test suite has two pre-existing errors because it fetches the removed `OpenHands/OpenHands/main/openhands/utils/llm.py` path. That separate pricing-source migration is not included here.

Closes #686

_This draft pull request was created by an AI agent (OpenHands) on behalf of the user._