### PR TITLE
docs(k8s-install): OHE-3033 fix the bundled object store values

### DIFF
--- a/enterprise/k8s-install/eks.mdx
+++ b/enterprise/k8s-install/eks.mdx
@@ -82,7 +82,6 @@ Then point the file store at the bucket in your values:
 
 ```yaml
 filestore:
-  ephemeral: false
   type: s3
   bucket: <your-bucket>
   region: <your-region>

--- a/enterprise/k8s-install/installation.mdx
+++ b/enterprise/k8s-install/installation.mdx
@@ -210,10 +210,13 @@ runtime-api:
     # sandboxes will never start.
     STORAGE_CLASS: <your-storage-class>
 
-# Store conversation data in the bundled MinIO, persisted to a volume
+# Store conversation data in the bundled MinIO, persisted to a volume.
+# minio.enabled is what deploys it, and it defaults to false. With type: s3 and
+# no endpoint or credentials set, the app targets the bundled instance.
 filestore:
-  ephemeral: true
+  type: s3
 minio:
+  enabled: true
   persistence:
     enabled: true
 


### PR DESCRIPTION
## Why

The Step 3 values tell operators to configure the bundled object store with `filestore.ephemeral: true`, and the chart has no such key. It was removed on 2026-08-04 by OpenHands/OpenHands-Cloud#1015, a breaking chart change that replaced it with `minio.enabled` and a flat filestore config; the docs update did not travel with it, so the published page has been wrong since. Following the page as written leaves an install with **no object store at all**: `ephemeral` is silently ignored because unknown values are accepted without warning, `minio.persistence.enabled` configures a subchart that `minio.enabled` never deploys since it defaults to `false`, and `filestore.type` falls back to its `gcs` default. Nothing errors, and the app comes up with an empty `FILE_STORE`. The bundled store needs `minio.enabled: true` together with `filestore.type: s3`, which is what the chart's own values comment says, so this sets both and explains why `enabled` is the load-bearing one.

The external-S3 example on the EKS page sets the same non-existent key to `false`. Harmless there, since the rest of that block is correct and an ignored key changes nothing, but it implies the key exists and is worth removing while it is in hand.

## Validation

- **Rendered the published values against the shipped chart, and they produce no object store** — zero MinIO resources, no `AWS_S3_ENDPOINT`, and `FILE_STORE` resolving to `google_cloud`. So an operator following the page today is silently configured for GCS on a cluster with no GCS credentials, which is worse than an obvious failure.
- **Rendered the corrected values, which produce the store the page describes** — a MinIO Deployment, its bucket Job, a bound-on-install PersistentVolumeClaim, two Services, and the app receiving `FILE_STORE=s3` with `AWS_S3_ENDPOINT=http://<release>-minio:9000`.
- **Confirmed on a running install, not only by rendering** — a Kubernetes cluster running exactly these three values has MinIO 1/1 with its claim bound, the app pointed at it, and several thousand conversation objects written and read back through it.
- **Swept the rest of the enterprise docs** — the only remaining `ephemeral` mentions are sandbox ephemeral-storage sizing, which is a different and correct setting.

_This PR was drafted by an AI agent on behalf of the user._
