### PR TITLE
docs: recommend Ubuntu 24.04 LTS for Enterprise manual VM installs

### DIFF
--- a/enterprise/quick-start.mdx
+++ b/enterprise/quick-start.mdx
@@ -66,6 +66,17 @@ You will need a VM to host OpenHands Enterprise. Choose one of the options below
       | **OS** | Linux (x86-64 architecture) |
       | **Init system** | systemd |
       | **Access** | Root access (sudo) required |
+
+      <Note>
+        We recommend **Ubuntu 24.04 LTS**. The default **Sandbox Isolation** runtime
+        (Sysbox) is best supported on Ubuntu and requires **Linux kernel 6.3 or newer**,
+        which Ubuntu 24.04 provides. Very new, non-LTS releases (for example, Ubuntu 25.10
+        or later) may ship kernels that are not yet supported by Sysbox and can cause
+        sandbox containers to fail during startup. If you do not need Docker inside the
+        sandbox, you can instead select the standard runtime under **Sandbox Isolation** in
+        the installer, which does not require a Sysbox-compatible kernel. See
+        [Docker in Sandbox](/enterprise/docker-in-sandbox) for details.
+      </Note>
     </Accordion>
 
     <Accordion title="Network requirements">


### PR DESCRIPTION
## Summary

The Enterprise quick start's **Manual VM Setup** currently lists only a generic OS requirement (`Linux (x86-64 architecture)`) and does not recommend a specific distribution. This gap can lead operators to provision very new, non-LTS releases whose kernels are not yet supported by Sysbox — the default **Sandbox Isolation** runtime — causing sandbox containers to fail during startup.

This PR adds a `<Note>` callout to the **System requirements** accordion recommending **Ubuntu 24.04 LTS**, and explaining the underlying kernel/Sysbox constraint and the runc/standard-runtime alternative.

## Why

- Docs already state (in `enterprise/docker-in-sandbox.mdx`) that the default isolation runtime requires **Linux kernel 6.3 or newer** (e.g. Ubuntu 24.04).
- Docs already state (in `enterprise/k8s-install/sysbox.mdx`) that **Ubuntu** is the most common and best-supported Sysbox distribution.
- That guidance previously lived only in the Docker-in-sandbox and k8s-install pages, which a VM installer may never read. This surfaces it where operators actually choose a VM image.

This mirrors a real support finding: an install on Ubuntu 26.04 (kernel 7.0) hit a known upstream Sysbox compatibility issue ([nestybox/sysbox#1005](https://github.com/nestybox/sysbox/issues/1005)); the fix was to deploy on Ubuntu 24.04 LTS (or switch Sandbox Isolation to the standard runtime if Docker-in-sandbox isn't needed).

## Change

- `enterprise/quick-start.mdx`: added a `<Note>` after the System requirements table in the Manual VM Setup tab.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c3c51366-53b5-46ef-9e84-b3ec4811c2f7)