### PR TITLE
Add Enterprise 0.41.0 release notes

### DIFF
--- a/enterprise/release-notes.mdx
+++ b/enterprise/release-notes.mdx
@@ -4,6 +4,76 @@ description: Release notes for OpenHands Enterprise
 icon: clipboard-list
 ---
 
+## 0.41.0
+
+This release advances the **Agent Canvas** rollout with a new homepage banner and an updated Canvas build, and sets GLM 5.2 as the default model for SaaS deployments. It expands infrastructure flexibility with an opt-in Valkey cache backend, FUSE/device passthrough support for runtimes, and durable automation package storage. The remainder of the release focuses on Codex authentication handling, secrets and settings reliability, and a range of stability fixes across the Enterprise Server and Helm charts.
+
+### Enterprise Server
+
+#### Features
+* feat: set SaaS default model to GLM 5.2 by @juanmichelini in https://github.com/OpenHands/enterprise/pull/89
+* feat: Add Agent Canvas homepage banner by @malhotra5 in https://github.com/OpenHands/enterprise/pull/124
+* feat: expose observability fields on app conversations by @juanmichelini in https://github.com/OpenHands/enterprise/pull/130
+
+#### Bug Fixes
+* fix(frontend): wire Export CSV buttons on Usage & Monitoring Overview and Models tabs by @saurya in https://github.com/OpenHands/enterprise/pull/78
+* fix: Pass pod security context from runtime-api warm configs to sandbox start by @tofarr in https://github.com/OpenHands/enterprise/pull/108
+* fix: skip default CSP on FastAPI docs paths (OHE-2815) by @tofarr in https://github.com/OpenHands/enterprise/pull/118
+* fix(settings): keep active LLM profile selected during updates by @saurya in https://github.com/OpenHands/enterprise/pull/107
+* fix(enterprise): Fix 405 error when uploading files before conversation is ready by @jpelletier1 in https://github.com/OpenHands/enterprise/pull/134
+* fix: propagate registered marketplaces to conversations by @tofarr in https://github.com/OpenHands/enterprise/pull/126
+* fix(app-server): serialize secrets writes to fix lost-write race (OHE-3052) by @tofarr in https://github.com/OpenHands/enterprise/pull/133
+* fix: load_settings should show meta for secrets by @tofarr in https://github.com/OpenHands/enterprise/pull/138
+* fix(enterprise): make POST /api/organizations/provision-user idempotent (OHE-2980) by @tofarr in https://github.com/OpenHands/enterprise/pull/117
+* fix: validate Codex auth secrets on save by @simonrosenberg in https://github.com/OpenHands/enterprise/pull/141
+* fix(app-server): pre-flight Codex credentials by @simonrosenberg in https://github.com/OpenHands/enterprise/pull/139
+
+#### Maintenance
+* chore(enterprise): enforce PostgreSQL-only migrations by @simonrosenberg in https://github.com/OpenHands/enterprise/pull/95
+
+---
+
+### Runtime API
+
+#### Features
+* feat(helm): add generic-device-plugin DaemonSet for FUSE support by @tofarr in https://github.com/OpenHands/runtime-api/pull/685
+
+#### Bug Fixes
+* fix: resolve real service-account email for GCS URL signing by @jlav in https://github.com/OpenHands/runtime-api/pull/686
+
+#### Maintenance
+* chore: PLTF-3242 Emit cleanup backlog/throughput counts as a structured log summary by @aivong-openhands in https://github.com/OpenHands/runtime-api/pull/665
+* build(deps): bump aiohttp from 3.13.4 to 3.14.1 by @dependabot[bot] in https://github.com/OpenHands/runtime-api/pull/680
+* build(deps): bump ddtrace from 3.5.1 to 4.8.2 by @dependabot[bot] in https://github.com/OpenHands/runtime-api/pull/687
+* build(deps): bump awscli from 1.44.38 to 1.44.78 by @dependabot[bot] in https://github.com/OpenHands/runtime-api/pull/689
+* build(deps): bump pyasn1 from 0.6.3 to 0.6.4 by @dependabot[bot] in https://github.com/OpenHands/runtime-api/pull/688
+
+---
+
+### OpenHands Cloud (Helm Chart)
+
+#### Features
+* feat(charts): device-plugin subchart for kvm/fuse passthrough by @jlav in https://github.com/OpenHands/OpenHands-Cloud/pull/1006
+* feat(openhands): PLTF-1247 offer Valkey as an opt-in cache backend by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/1007
+* feat(agent-canvas): bump chart image tag to 1.10.0 by @hieptl in https://github.com/OpenHands/OpenHands-Cloud/pull/1024
+
+#### Bug Fixes
+* fix(budget-maintenance): disable cronjob until fixed image ships by @saurya in https://github.com/OpenHands/OpenHands-Cloud/pull/999
+* fix(replicated): preserve Keycloak identity provider timeout by @ak684 in https://github.com/OpenHands/OpenHands-Cloud/pull/1001
+* fix: disable email changes for Replicated installs by @ak684 in https://github.com/OpenHands/OpenHands-Cloud/pull/1002
+* fix(rustfs): PLTF-1250 make the bundled store deployable when enabled by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/1010
+* fix(charts): pass fuse_s3_mount through warm-runtimes configmap by @jlav in https://github.com/OpenHands/OpenHands-Cloud/pull/1011
+* fix(build): PLTF-1250 stop shipping Chart.yaml.bak in released charts by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/1013
+* fix(build): PLTF-1250 restore Chart.lock after packaging by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/1014
+* fix(charts)!: OHE-3033 durable automation package storage by @jlav in https://github.com/OpenHands/OpenHands-Cloud/pull/1015
+* fix(charts): restore the nested sandbox hostname default by @jlav in https://github.com/OpenHands/OpenHands-Cloud/pull/1021
+* fix(litellm-helm): bump default image tag to 1.94.1 for memory fix by @aivong-openhands in https://github.com/OpenHands/OpenHands-Cloud/pull/1023
+* fix(budget-maintenance): re-enable cronjob with 1.49.1 by @saurya in https://github.com/OpenHands/OpenHands-Cloud/pull/1018
+
+#### Maintenance
+* chore: bump Agent Canvas chart image to 1.9.0 by @malhotra5 in https://github.com/OpenHands/OpenHands-Cloud/pull/1009
+* chore: add storage-lifetime and naming checks to the code-review skill by @jlav in https://github.com/OpenHands/OpenHands-Cloud/pull/1016
+
 ## 0.36.1
 
 This patch release was focused on stability fixes for the Enterprise Server, including preserving user sessions during transient network failures and giving deployments the ability to disable email changes.

--- a/enterprise/release-notes.mdx
+++ b/enterprise/release-notes.mdx
@@ -6,7 +6,7 @@ icon: clipboard-list
 
 ## 0.41.0
 
-This release advances the **Agent Canvas** rollout with a new homepage banner and an updated Canvas build, and sets GLM 5.2 as the default model for SaaS deployments. It expands infrastructure flexibility with an opt-in Valkey cache backend, FUSE/device passthrough support for runtimes, and durable automation package storage. The remainder of the release focuses on Codex authentication handling, secrets and settings reliability, and a range of stability fixes across the Enterprise Server and Helm charts.
+This release advances the **Agent Canvas** rollout with a new homepage banner and an updated Canvas build, and sets GLM 5.2 as the default model for SaaS deployments. The remainder of the release focuses on Codex authentication handling, secrets and settings reliability, and a range of stability fixes across the Enterprise Server and Helm charts.
 
 ### Enterprise Server
 


### PR DESCRIPTION
## Summary

Adds OpenHands Enterprise **0.41.0** release notes (new Stable channel release), diffed against the previously documented **0.36.1**.

Component versions were derived from the Replicated release charts:

| Component | Previous (0.36.1) | New (0.41.0) |
|-----------|-------------------|--------------|
| OpenHands-Cloud (Helm chart) | 0.36.1 | 0.41.0 |
| Enterprise Server | 1.49.x (hotfix) | 1.51.0 |
| Software Agent SDK | 1.39.1 | 1.39.1 (no change) |
| Runtime API | 0.7.0 | 0.8.0 |
| Automation | 1.5.0 | 1.5.0 (no change) |

### Notes on ranges
- **Enterprise Server**: includes releases `1.49.1`, `1.50.0`, `1.51.0`. The `1.49.1` fixes already shipped in the 0.36.1 hotfix (PRs #81, #80, #110) were excluded to avoid duplication.
- **Runtime API**: `v0.8.0`.
- **OpenHands Cloud (Helm Chart)**: `0.37.0`-`0.41.0`, with automated openhands/runtime-api image-tag bump PRs filtered out as noise.
- **Software Agent SDK** and **Automation** are omitted - versions were unchanged between 0.36.1 and 0.41.0.

`docs.json` already lists `enterprise/release-notes`, so no navigation change was needed.

---
_This pull request was created by an AI agent (OpenHands) on behalf of the user._
