### PR TITLE
Add OpenHands Enterprise sizing guide [PLTF-3389]

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -486,6 +486,7 @@
             "pages": [
               "enterprise/index",
               "enterprise/enterprise-vs-oss",
+              "enterprise/sizing-guide",
               "enterprise/quick-start",
               "enterprise/custom-sandbox-image",
               "enterprise/docker-in-sandbox",

--- a/enterprise/index.mdx
+++ b/enterprise/index.mdx
@@ -116,6 +116,7 @@ Enterprise customers receive:
 
 ## Additional Resources
 
+- [Sizing Guide](/enterprise/sizing-guide) — Size a deployment from peak concurrent sandboxes
 - [OpenHands Documentation](/overview/introduction) — Learn how to use OpenHands
 - [SDK Documentation](/sdk/index) — Build custom agents with the OpenHands SDK
 - [Pricing](https://openhands.dev/pricing) — Compare all OpenHands plans

--- a/enterprise/k8s-install/index.mdx
+++ b/enterprise/k8s-install/index.mdx
@@ -50,6 +50,10 @@ OpenHands Enterprise consists of several components deployed as Kubernetes workl
 
 ## Guides
 
+<Card title="Sizing Guide" icon="ruler" href="/enterprise/sizing-guide">
+  Size your node pools, volume storage, and database from peak concurrent sandboxes.
+</Card>
+
 <Card title="Install with Helm" icon="ship" href="/enterprise/k8s-install/installation">
   End-to-end installation instructions using your OpenHands Enterprise license.
 </Card>

--- a/enterprise/k8s-install/resource-limits.mdx
+++ b/enterprise/k8s-install/resource-limits.mdx
@@ -268,6 +268,9 @@ For production deployments, we recommend integrating with a monitoring solution
 ## Next Steps
 
 <CardGroup cols={2}>
+  <Card title="Sizing Guide" icon="ruler" href="/enterprise/sizing-guide">
+    Translate peak concurrent sandboxes into node pools, storage, and database size.
+  </Card>
   <Card title="K8s Install Overview" icon="dharmachakra" href="/enterprise/k8s-install/index">
     Return to the Kubernetes installation overview.
   </Card>

--- a/enterprise/quick-start.mdx
+++ b/enterprise/quick-start.mdx
@@ -35,6 +35,10 @@ Before you begin, make sure you have the following ready:
 
 You will need a VM to host OpenHands Enterprise. Choose one of the options below to provision your infrastructure.
 
+<Note>
+  The requirements below are the trial baseline, which comfortably supports about 15 concurrent sandboxes. For a larger rollout, pick your VM from the [Sizing Guide](/enterprise/sizing-guide) before provisioning.
+</Note>
+
 <Tabs>
   <Tab title="AWS with Terraform (Recommended)">
     We provide a [Terraform module](https://github.com/All-Hands-AI/OpenHands-Cloud/tree/main/terraform/aws) that provisions a properly configured environment

--- a/enterprise/sizing-guide.mdx
+++ b/enterprise/sizing-guide.mdx
@@ -1,0 +1,103 @@
+---
+title: Sizing Guide
+description: Recommended VM or Cluster sizing for an OpenHands Enterprise deployment
+icon: ruler
+---
+
+OpenHands Enterprise deployments are sized primarily based on expected **peak concurrent sandboxes** — the largest number of sandboxes you expect to be running at the same time. Keep in mind that one user can have multiple sandboxes running at one time.
+
+<Note>
+  The **Users** column in the tables below is a rough translation of peak sandboxes into headcount, not an input. Size on peak sandboxes; the user estimate is a very rough guide
+</Note>
+
+## Planning Unit
+
+Both tables below are built from the same per-sandbox allocation:
+
+| Resource | Per sandbox |
+|----------|-------------|
+| CPU | 0.5 vCPU |
+| Memory | 4 GiB |
+| Node disk | 10 GiB |
+| Volume storage | 10 GiB |
+
+If you raise the sandbox defaults (for large monorepos or memory-hungry builds), scale the totals in the tables by the same factor. See [Resource Limits](/enterprise/k8s-install/resource-limits) for how to change these values.
+
+## Installation Modes
+
+This guide covers the two supported installation modes:
+
+<CardGroup cols={2}>
+  <Card title="Embedded Cluster (Single VM)" icon="server" href="/enterprise/quick-start">
+    The installer builds a single-node k0s cluster on a VM you provide. Fixed capacity, configured through the Admin Console, everything bundled on one machine.
+  </Card>
+  <Card title="Helm (Existing Kubernetes)" icon="dharmachakra" href="/enterprise/k8s-install/index">
+    Install into a cluster you already run, with standard Kubernetes elasticity and autoscaling.
+  </Card>
+</CardGroup>
+
+## Replicated Embedded Cluster — Single VM
+
+Machine sizes below are based on the peak sandboxes, so feel free to size up or down based on expected usage.
+
+| Peak sandboxes | Users (estimate) | VM | Example machine types | Data disk (starting recommendation) |
+|----------------|------------------|----|-----------------------|-------------------------------------|
+| **5** | ~25 | 8 vCPU / 32 GiB | `e2-standard-8`, `m6i.2xlarge`, `D8s_v5` | 500 GiB SSD |
+| **15** | ~60 | 16 vCPU / 64 GiB | `n2-standard-16`, `m6i.4xlarge`, `D16s_v5` | 1 TiB SSD |
+| **30** | ~125 | 32 vCPU / 128 GiB | `n2-standard-32`, `m6i.8xlarge`, `D32s_v5` | 1.5 TiB SSD |
+| **50** | ~250 | 64 vCPU / 256 GiB | `n2-standard-64`, `m6i.16xlarge`, `D64s_v5` | 3 TiB SSD |
+| **100** | ~400 | 96 vCPU / 384 GiB | `n2-standard-96`, `m6i.24xlarge`, `D96s_v5` | 4 TiB SSD |
+| **Above 100** | — | Use a Kubernetes install, or contact us for a sizing consultation | — | — |
+
+The 16 vCPU / 64 GiB row matches the minimum VM in the [Quick Start](/enterprise/quick-start) system requirements. Trials that stay below roughly 15 concurrent sandboxes are well served by that baseline.
+
+<Warning>
+  **Put the data disk on a separate expandable volume, not the boot disk.** Sandbox volumes on a single VM are host directories that consume actual bytes rather than preallocating, so the disk grows with real usage and is meant to be resized in place as demand increases.
+</Warning>
+
+## Replicated Helm Installation
+
+Use two node pools: a tainted pool that runs **only** sandboxes, and an untainted pool that runs everything else. This keeps a burst of sandboxes from evicting platform components.
+
+Recommended node pools:
+
+- **Sandbox pool**: 16 vCPU / 64 GiB / 400 GiB SSD
+- **Platform pool**: 8 vCPU / 32 GiB / 100 GiB
+
+| Peak sandboxes | Users (estimate) | Sandbox nodes (min–max) | Platform nodes | Volume storage (start) | PostgreSQL (in-cluster by default) |
+|----------------|------------------|-------------------------|----------------|------------------------|------------------------------------|
+| **10** | ~50 | 1–1 | 2 | 1 TiB | 2 vCPU / 8 GiB — fits the platform pool |
+| **25** | ~125 | 1–3 | 2 | 2.5 TiB | 2 vCPU / 8 GiB — fits the platform pool |
+| **50** | ~250 | 1–5 | 2 | 5 TiB | 2 vCPU / 8 GiB — fits the platform pool |
+| **100** | ~500 | 1–10 | 3 | 10 TiB | 4 vCPU / 16 GiB — fits the platform pool |
+| **200** | ~1,000 | 2–20 | 3 | 20 TiB | 4 vCPU / 16 GiB — fits the platform pool |
+| **500** | ~2,500 | 3–48 | 4 | 50 TiB | 8 vCPU / 32 GiB — **needs a dedicated node** |
+| **1,000** | ~5,000 | 5–96 | 5 | 100 TiB | 16 vCPU / 64 GiB — **needs a dedicated node** |
+
+Notes on the table:
+
+- **Minimum node counts assume autoscaling.** If your cluster cannot scale up quickly, raise the minimum toward your typical daily peak so users don't wait on node provisioning.
+- **PostgreSQL** is deployed in-cluster by default. At 500 peak sandboxes and above, give it a dedicated node — or use [External PostgreSQL](/enterprise/external-postgres) and size it with your database team.
+
+## Adjusting After Rollout
+
+- Track sandbox pod count over time and size to the observed peak, plus headroom.
+- Watch memory usage against limits to catch OOMKills, and usage against requests to catch evictions. See [Resource Limits](/enterprise/k8s-install/resource-limits) for the metrics and the settings to change.
+- Grow volume storage before it fills. Sandbox workspaces are deleted with their sandbox, but their usage and retention may outstrip initial storage numbers
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Quick Start" icon="rocket" href="/enterprise/quick-start">
+    Provision a VM and install OpenHands Enterprise.
+  </Card>
+  <Card title="Kubernetes Installation" icon="dharmachakra" href="/enterprise/k8s-install/index">
+    Deploy into an existing cluster with Helm.
+  </Card>
+  <Card title="Resource Limits" icon="gauge-high" href="/enterprise/k8s-install/resource-limits">
+    Tune CPU, memory, and storage for the application server and sandboxes.
+  </Card>
+  <Card title="Conversations and Sandboxes" icon="boxes-stacked" href="/enterprise/conversations-and-sandboxes">
+    Understand how conversations map onto sandboxes and how placement affects capacity.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [x] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

"How big a box do I need?" is the first question on every Enterprise deployment call, and we had no answer in the docs — just a single trial-baseline VM spec buried in Quick Start, which says nothing about what happens at 50 or 500 concurrent users. This ports the internal sizing guide to the docsite so customers and CEs can size a deployment without a call.

The guide sizes on **peak concurrent sandboxes** rather than headcount, since sandboxes are the bulk of the footprint and one user can run several at once. Everything derives from one planning unit (0.5 vCPU / 4 GiB / 10 GiB node disk / 10 GiB volume per sandbox), with a table per install mode: Replicated embedded cluster on a single VM, and Replicated Helm into an existing cluster.

- `enterprise/sizing-guide.mdx` — new page. Planning unit, VM sizing table (5–100 peak sandboxes with example GCP/AWS/Azure machine types and data disks), Helm sizing table (10–1,000 peak sandboxes with node pool min/max, platform nodes, volume storage, PostgreSQL sizing), and post-rollout adjustment guidance.
- `docs.json` — nav entry under Enterprise → OpenHands Enterprise, between `enterprise-vs-oss` and `quick-start`. It sits above both install paths because it applies to both and is a pre-install decision; nesting it under VM Install or K8s Install would hide it from half its audience.
- `enterprise/quick-start.mdx` — note framing the 16 vCPU / 64 GiB requirement as the trial baseline (~15 concurrent sandboxes), pointing here for larger rollouts.
- `enterprise/k8s-install/index.mdx`, `enterprise/k8s-install/resource-limits.mdx`, `enterprise/index.mdx` — cross-links from the places where sizing decisions actually get made.

Verified with `mint dev` locally: page and nav render, tables lay out correctly. `mint broken-links` passes clean.

Note: `llms.txt` / `llms-full.txt` are intentionally not regenerated here. They're already stale on `main`, so running the generator pulls ~1,650 lines of unrelated drift into this diff. The weekly `check-llms-files` workflow will pick this page up.