### PR TITLE
Adding doc links to Introduction page

### DIFF
--- a/overview/introduction.mdx
+++ b/overview/introduction.mdx
@@ -22,7 +22,7 @@ A fully managed version of OpenHands with source-available features and integrat
 - Usage reporting
 - Budgeting enforcement
 
-Try it free by [signing in with your GitHub account](https://app.all-hands.dev).
+[Check out the docs](/openhands/usage/cloud/openhands-cloud) or try it free by [signing in with your GitHub account](https://app.all-hands.dev).
 
 ## OpenHands Enterprise
 Large enterprises can work with us to self-host OpenHands Cloud in their own VPC, via Kubernetes.
@@ -33,7 +33,7 @@ but you'll need to purchase a license if you want to run it for more than one mo
 
 Enterprise contracts also come with extended support and access to our research team.
 
-Learn more at [openhands.dev/enterprise](https://openhands.dev/enterprise)
+[Check out the docs](/enterprise) or learn more at [openhands.dev/enterprise](https://openhands.dev/enterprise)
 
 ## OpenHands Software Agent SDK
 The SDK is a composable Python library that contains all of our agentic tech. It's the engine that powers everything else.

--- a/overview/introduction.mdx
+++ b/overview/introduction.mdx
@@ -22,7 +22,7 @@ A fully managed version of OpenHands with source-available features and integrat
 - Usage reporting
 - Budgeting enforcement
 
-[Check out the docs](/openhands/usage/cloud/openhands-cloud) or try it free by [signing in with your GitHub account](https://app.all-hands.dev).
+Try it free by [signing in with your GitHub account](https://app.all-hands.dev) or [Check out the docs](/openhands/usage/cloud/openhands-cloud)
 
 ## OpenHands Enterprise
 Large enterprises can work with us to self-host OpenHands Cloud in their own VPC, via Kubernetes.
@@ -33,7 +33,7 @@ but you'll need to purchase a license if you want to run it for more than one mo
 
 Enterprise contracts also come with extended support and access to our research team.
 
-[Check out the docs](/enterprise) or learn more at [openhands.dev/enterprise](https://openhands.dev/enterprise)
+Learn more at [openhands.dev/enterprise](https://openhands.dev/enterprise) or [Check out the docs](/enterprise)
 
 ## OpenHands Software Agent SDK
 The SDK is a composable Python library that contains all of our agentic tech. It's the engine that powers everything else.


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [x] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

The intro page sections didn't have a clear way to stay on the docs site if that's what i wanted. For Enterprise, i expected the "Learn more" link to take me to more documentation but that was not the case.

Just adding some "Check out the docs" links to a two sections that didn't have them. Enterprise and OpenHands Cloud
