### PR TITLE
docs(enterprise): document conversation lifecycle limits and 12h session cap

### DIFF
--- a/enterprise/conversations-and-sandboxes.mdx
+++ b/enterprise/conversations-and-sandboxes.mdx
@@ -309,6 +309,32 @@ is `RUNNING`:
 | `ERROR` | Task encountered an error |
 | `STUCK` | Agent appears to be stuck |
 
+## Conversation Lifecycle Limits
+
+Running conversations are subject to time-based limits that free up cluster
+resources. Two of these are configurable in the admin console under
+**Sandbox Configuration** (see
+[Admin Console Configuration](/enterprise/vm-install/admin-console-configuration)):
+
+- **Idle Time (seconds)** — After a conversation has been idle (no agent or user
+  activity) for this long, its sandbox is **paused**, releasing CPU and memory.
+  Activity resets the idle timer, so an actively-working agent is not paused for
+  idleness. A paused conversation is resumed automatically on next access.
+- **Deletion Time (seconds)** — After a conversation has been **paused** for this
+  long, it and its storage are permanently deleted and can no longer be resumed.
+
+<Note>
+  Separately from the idle timeout, a single running session is capped at a
+  maximum of **12 hours**. This cap applies even to a continuously-active
+  conversation: once a session has been running for 12 hours it is force-paused.
+  Resuming the conversation starts a new 12-hour window. This maximum session
+  duration is not currently configurable.
+</Note>
+
+Because these limits are deployment-wide, they cannot be set per conversation or
+per Agent Profile. Agent Profiles configure the agent's model, tools, and
+behavior, not sandbox lifetime.
+
 ## Read-Only Conversations
 
 When `sandbox_status` is `ERROR` or `MISSING`, the conversation becomes

--- a/enterprise/vm-install/admin-console-configuration.mdx
+++ b/enterprise/vm-install/admin-console-configuration.mdx
@@ -221,6 +221,14 @@ See [External PostgreSQL](/enterprise/external-postgres) for version, encoding, 
 | `Additional Host Path Mounts` | Host paths mounted into every sandbox, one per line as `host_path:container_path[:ro\|rw]`. |
 | `Enable /dev/kvm passthrough (QEMU/KVM)` | Makes host KVM acceleration available inside sandboxes. The node must expose `/dev/kvm`. |
 
+<Note>
+  `Idle Time` and `Deletion Time` control when idle and paused conversations are
+  reclaimed. A single running session is additionally capped at 12 hours
+  regardless of these values; this maximum is not currently configurable. See
+  [Conversations and Sandboxes](/enterprise/conversations-and-sandboxes) for the
+  full conversation lifecycle.
+</Note>
+
 Resource requests are scheduling reservations. Multiply per-sandbox requests by the expected concurrent sandbox count and leave capacity for the platform services.
 
 ### Custom Sandbox Image


### PR DESCRIPTION
## Summary

Documents the time-based limits that govern conversation/sandbox lifetime in OpenHands Enterprise, prompted by customer questions about running conversations indefinitely and whether the idle timeout is configurable globally or per Agent Profile.

The docs previously mentioned "cleaned up due to idle timeout" but did not explain the timers or the hard maximum session duration. This clarifies the behavior without exposing any new configuration.

## Changes

- **`enterprise/conversations-and-sandboxes.mdx`** — new **Conversation Lifecycle Limits** section explaining:
  - **Idle Time (seconds)** — pauses idle conversations; activity resets the timer; paused conversations resume on next access.
  - **Deletion Time (seconds)** — permanently deletes paused conversations after the configured period.
  - A `<Note>` documenting the **12-hour hard cap on a single running session**, which applies even to a continuously-active conversation and is **not currently configurable**.
  - A statement that these limits are deployment-wide and cannot be set per conversation or per Agent Profile.
- **`enterprise/vm-install/admin-console-configuration.mdx`** — a `<Note>` under the Sandbox Configuration table cross-referencing the lifecycle page and calling out the non-configurable 12-hour cap.

## Notes

- No new configuration is exposed. The 12-hour maximum session duration (`RUNTIME_MAX_SESSION_SECONDS`, default 43200) remains a code/chart default and is intentionally **not** surfaced as an admin-console/Helm option in this change — this PR only documents existing behavior.
- Verified against the source of truth: the idle/deletion settings map to `sandbox_idle_seconds` / `sandbox_dead_seconds` in `OpenHands/OpenHands-Cloud` (`replicated/config.yaml` → chart `RUNTIME_IDLE_SECONDS` / `RUNTIME_DEAD_SECONDS`), and the 12-hour cap is enforced in `OpenHands/runtime-api` `cleanup.py`. Agent Profile models in the SDK/enterprise expose no lifetime/session fields.

---
_This PR was created by an AI agent (OpenHands) on behalf of the requesting user._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/877bc481-1316-460b-bf67-cea5030afb1d)