### PR TITLE
docs: inline dangling structured-output example (#723)

### DIFF
--- a/sdk/guides/structured-output.mdx
+++ b/sdk/guides/structured-output.mdx
@@ -45,7 +45,118 @@ facts = cast(ProjectFacts | None, finish_tool.parse_last_response(conversation.s
 ## Ready-to-run Example
 
 ```python icon="python" expandable examples/01_standalone_sdk/56_structured_output.py
-# content is auto-synced
+"""Structured output via ``response_schema``.
+
+Attach a Pydantic model to *any* tool spec and the agent must populate those
+fields when calling that tool. The schema is sent to the LLM as the tool's
+JSON-schema parameters and validated on receipt.
+
+Demonstrated here on two tools:
+  - ``TerminalTool`` (existing SDK tool) — every command must come with a
+    ``purpose`` and ``expected_outcome``, on top of the tool's own ``command``
+    field. No subclassing required: the schema is merged in via the spec.
+  - ``FinishTool`` (built-in) — the final answer comes back as a typed object.
+"""
+
+import os
+from typing import cast
+
+from pydantic import BaseModel, Field
+
+from openhands.sdk import LLM, Agent, Conversation
+from openhands.sdk.event import ActionEvent
+from openhands.sdk.tool import Tool, register_tool
+from openhands.sdk.tool.builtins.finish import FinishTool
+from openhands.tools.file_editor import FileEditorTool
+from openhands.tools.terminal import TerminalTool
+
+
+# --- Structured-output schemas ------------------------------------------------
+
+
+class CommandRationale(BaseModel):
+    """Forced-annotation schema attached to TerminalTool."""
+
+    purpose: str = Field(description="Why this command is being run, in one line.")
+    expected_outcome: str = Field(
+        description="What the assistant expects to observe from running it."
+    )
+
+
+class ProjectFacts(BaseModel):
+    # NOTE: ``kind``, ``security_risk``, ``structured_output`` and ``summary``
+    # are reserved, as are the tool's own field names; using one raises at
+    # resolution time.
+    description: str = Field(description="One-paragraph description of the project.")
+    facts: list[str] = Field(description="Three concise, distinct facts.")
+
+
+# Register FinishTool so we can attach a response_schema via Tool spec.
+register_tool("FinishTool", FinishTool)
+
+
+# --- Agent setup --------------------------------------------------------------
+
+
+llm = LLM(
+    model=os.getenv("LLM_MODEL", "anthropic/claude-sonnet-4-5-20250929"),
+    api_key=os.getenv("LLM_API_KEY"),
+    base_url=os.getenv("LLM_BASE_URL", None),
+)
+
+agent = Agent(
+    llm=llm,
+    tools=[
+        # Existing tool, augmented with a forced-annotation schema:
+        Tool(name=TerminalTool.name, params={"response_schema": CommandRationale}),
+        Tool(name=FileEditorTool.name),
+        Tool(name="FinishTool", params={"response_schema": ProjectFacts}),
+    ],
+    # Skip the auto-injected default FinishTool so our schema-bound one is used.
+    include_default_tools=["ThinkTool"],
+)
+
+conversation = Conversation(agent=agent, workspace=os.getcwd())
+conversation.send_message(
+    "Inspect the repo using terminal commands, then finish with three facts "
+    "about the project."
+)
+conversation.run()
+
+
+# --- Recover typed outputs from any tool with a response_schema ---------------
+
+events = conversation.state.events
+terminal_tool = agent.tools_map[TerminalTool.name]
+finish_tool = agent.tools_map["finish"]
+
+# Every TerminalTool call now carries our annotation fields. Walk all events to
+# show that the LLM populated them on every invocation.
+print("\n[Terminal commands with rationale]")
+
+for event in events:
+    if (
+        isinstance(event, ActionEvent)
+        and event.tool_name == TerminalTool.name
+        and event.action is not None
+    ):
+        rationale = cast(CommandRationale, terminal_tool.parse_response(event.action))
+        # action.command is the tool's own field; rationale.* came from the schema.
+        print(f"  $ {getattr(event.action, 'command', '?')}")
+        print(f"    purpose:          {rationale.purpose}")
+        print(f"    expected_outcome: {rationale.expected_outcome}")
+
+# And the typed final answer:
+facts = cast(ProjectFacts | None, finish_tool.parse_last_response(events))
+if facts:
+    print("\n[Finish]")
+    print(f"  description: {facts.description}")
+    for fact in facts.facts:
+        print(f"  - {fact}")
+
+# Report cost
+cost = conversation.conversation_stats.get_combined_metrics().accumulated_cost
+print(f"\nEXAMPLE_COST: {cost}")
 ```
 
 <RunExampleCode path_to_script="examples/01_standalone_sdk/56_structured_output.py"/>


### PR DESCRIPTION
## What

Fixes #723.

The **Structured Output** guide (`/sdk/guides/structured-output`) never rendered its ready-to-run example — the "Ready-to-run Example" section showed only the literal placeholder `# content is auto-synced` and the code block displayed "See all 1 lines".

## Root cause

In `sdk/guides/structured-output.mdx` the example block was:

````mdx
```python icon="python" expandable examples/01_standalone_sdk/56_structured_output.py
# content is auto-synced
```
````

In this repo the `icon="python" expandable examples/...` fence is **just a label** — the example code must be **inlined manually** between the fences. There is no build-time sync step that injects the file contents (`.github/scripts/check_documented_examples.py` in `software-agent-sdk` only verifies a *reference string* exists, not that the code is present). The author left `# content is auto-synced` as a placeholder that was never filled in.

Every other guide inlines its example code this way and renders correctly (e.g. `custom-tools.mdx` → "See all 224 lines", `hello-world.mdx`).

## Fix

Inline the exact contents of `examples/01_standalone_sdk/56_structured_output.py` (from `OpenHands/software-agent-sdk`) between the fences, so the guide renders the ready-to-run example like every other guide. Verified the inlined content is byte-for-byte identical to the source example.

## Verification

- `diff` between the inlined fence content and the raw example file from `software-agent-sdk@main` → identical.
- Pattern now matches the working guides (`custom-tools`, `hello-world`, etc.).

## Follow-up (not in this PR)

Issue #723 also notes that nothing currently catches a "dangling" example block (reference present, body is a placeholder). A lightweight lint could be added separately to prevent regressions.

---

_This PR was created by an AI agent (OpenHands) on behalf of @luciobaiocchi._

@luciobaiocchi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3761d5c1-983f-45d3-8dd7-ee3aea52ddef)