### PR TITLE
docs(sdk): document AgentSettingsBase.from_persisted()

### DIFF
--- a/sdk/guides/agent-settings.mdx
+++ b/sdk/guides/agent-settings.mdx
@@ -57,6 +57,39 @@ This is useful when:
 - Letting users edit agent configuration in a form-based UI
 - Rehydrating the same agent setup in another process
 
+## Load Persisted Settings
+
+`model_validate` only accepts payloads that already match the current schema. Use `from_persisted` for data written by an older SDK version: it applies the registered schema migrations first, then validates the migrated payload against the class you call it on.
+
+```python icon="python" focus={1}
+restored = OpenHandsAgentSettings.from_persisted(payload)
+```
+
+`from_persisted` is defined on `AgentSettingsBase`, so it is a concrete-variant loader: `OpenHandsAgentSettings.from_persisted()` returns an `OpenHandsAgentSettings` and `ACPAgentSettings.from_persisted()` returns an `ACPAgentSettings`. When you do not know which variant a payload holds, use `validate_agent_settings` (also in `openhands.sdk.settings`) instead — it dispatches across the settings union.
+
+Passing an already-validated instance of that variant returns it unchanged, so its secrets are preserved without a lossy serialization round trip.
+
+<Note>
+The deprecated `agent_kind="llm"` discriminator is only rewritten while migrating between schema versions. A payload that is already at the current schema version but still carries `agent_kind="llm"` is therefore rejected by `OpenHandsAgentSettings.from_persisted`. Load those payloads with `validate_agent_settings`, which canonicalizes the discriminator unconditionally.
+</Note>
+
+### Encrypted Payloads
+
+Secret-bearing fields only decrypt when you pass the same validation context that was used to write them.
+
+```python icon="python" focus={2}
+persisted = settings.model_dump(mode="json", context={"cipher": cipher})
+restored = OpenHandsAgentSettings.from_persisted(persisted, context={"cipher": cipher})
+```
+
+### Errors
+
+| Exception | Raised when |
+|-----------|-------------|
+| `TypeError` | The payload is not a mapping or `BaseModel`, or its `schema_version` is not an integer. |
+| `ValueError` | `schema_version` is negative, newer than the supported version, or has no registered migration. |
+| `pydantic.ValidationError` | The migrated payload is invalid for the class you called `from_persisted` on. |
+
 ## Create an Agent from Settings
 
 Once validated, create a working agent directly from the settings object.


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [x] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

Documents the new public `AgentSettingsBase.from_persisted()` entry point added in https://github.com/OpenHands/software-agent-sdk/pull/3503, which `openhands-sdk/openhands/sdk/AGENTS.md` requires to ship with a corresponding docs change.

Adds a `Load Persisted Settings` section to `sdk/guides/agent-settings.mdx`, placed between the existing `Serialize and Restore Settings` and `Create an Agent from Settings` sections. It covers the contract rather than repeating the tutorial:

- `from_persisted` applies registered schema migrations and then validates against the class it is called on, so it is a concrete-variant loader (`OpenHandsAgentSettings` in, `OpenHandsAgentSettings` out).
- Callers that need union dispatch across settings variants should use `validate_agent_settings` instead.
- A current-schema payload still carrying the deprecated `agent_kind="llm"` discriminator is rejected by `OpenHandsAgentSettings.from_persisted`, because that rewrite only happens while migrating between schema versions.
- Encrypted persisted mappings need the same validation context used to write them (for example `{"cipher": cipher}`) so secret-bearing fields decrypt.
- Passing an already-validated instance of that variant returns it unchanged, preserving secrets without a lossy serialization round trip.
- The error taxonomy from the docstring (`TypeError`, `ValueError`, `pydantic.ValidationError`).

**Related**

Documents the SDK API added in https://github.com/OpenHands/software-agent-sdk/pull/3503 (which closes OpenHands/software-agent-sdk#3084). The two PRs cross-reference each other, per the SDK's `AGENTS.md` docs requirement.

**Verification**

- `mint broken-links` — no broken links.
- `mint dev` — confirmed the new section renders: both code blocks, the `<Note>` callout, and the errors table.

`llms.txt` / `llms-full.txt` are intentionally untouched: regenerating them locally pulls in a large amount of unrelated pre-existing drift, and the weekly `sync-llms-files` workflow already owns keeping them current.
