### PR TITLE
docs: Add OpenHands Enterprise release notes for 0.45.0

### DIFF
--- a/.agents/skills/ohe-release-notes.md
+++ b/.agents/skills/ohe-release-notes.md
@@ -173,20 +173,22 @@ Within each section, sort items into:
 
 ### 5. Filter out noise
 
-Remove these automated/housekeeping lines that don't add value to customer-facing release notes:
+Apply these exclusions before categorizing entries:
 
-| Pattern                                     | Reason                                                     |
-|---------------------------------------------|------------------------------------------------------------|
-| `chore(main): release X.X.X`                | Automated release PRs                                      |
-| `chore: bump SDK packages to vX.X.X`        | Automated dependency bumps                                 |
-| `chore: bump SDK and agent-server to X.X.X` | Automated dependency bumps                                 |
-| `fix(backport): ...`                        | Backport cherry-picks (the original fix is already listed) |
-| `feat: bump agent-server to ...`            | Version bump PRs, not user-facing features                 |
-| `feat: bump image tag to ...`               | Version bump PRs, not user-facing features                 |
-| `feat(openhands): bump image tag to ...`    | Version bump PRs, not user-facing features                 |
-| `feat(runtime-api): bump image tag to ...`  | Version bump PRs, not user-facing features                 |
-| `Release vX.Y.Z`                            | Automated release PRs in software-agent-sdk                |
-| `Verify ... model`                          | Model verification entries in software-agent-sdk           |
+- Exclude every entry whose linked PR was authored by `dependabot[bot]`, regardless of its title or
+  category. Use the release-note attribution or linked PR metadata to identify the author.
+- Exclude every version-only bump entry, regardless of its conventional commit prefix, scope, or
+  author. This includes forms such as `bump X from A to B`, `bump X to B`, and `bump from A to B`,
+  plus dependency, package, SDK, agent-server, image, and image-tag bumps.
+
+Also remove these automated/housekeeping lines that don't add value to customer-facing release notes:
+
+| Pattern                      | Reason                                                     |
+|------------------------------|------------------------------------------------------------|
+| `chore(main): release X.X.X` | Automated release PRs                                      |
+| `fix(backport): ...`         | Backport cherry-picks (the original fix is already listed) |
+| `Release vX.Y.Z`             | Automated release PRs in software-agent-sdk                |
+| `Verify ... model`           | Model verification entries in software-agent-sdk           |
 
 ### 6. Write the page
 

--- a/enterprise/release-notes.mdx
+++ b/enterprise/release-notes.mdx
@@ -21,9 +21,6 @@ This release introduces **Canvas Extensions**, a major new capability that enabl
 * fix(s3 file store): OHE-3079 : paginate list_objects_v2 to avoid silent truncation at 1000 keys by @tofarr in https://github.com/OpenHands/enterprise/pull/157
 * fix: redirect Automations sidebar icon to /canvas/automations by @hieptl in https://github.com/OpenHands/enterprise/pull/162
 
-#### Maintenance
-* chore: bump openhands-sdk, openhands-agent-server, and openhands-tools to 1.41.0 by @tofarr in https://github.com/OpenHands/enterprise/pull/161
-
 ---
 
 ### Software Agent SDK
@@ -51,13 +48,10 @@ This release introduces **Canvas Extensions**, a major new capability that enabl
 * fix(observability): keep the conversation object out of TOOL span input by @simonrosenberg in https://github.com/OpenHands/software-agent-sdk/pull/4379
 
 #### Maintenance
-* chore(deps): bump joserfc from 1.6.4 to 1.6.8 by @dependabot[bot] in https://github.com/OpenHands/software-agent-sdk/pull/4306
 * chore(ci): remove QA Changes workflows by @VascoSch92 in https://github.com/OpenHands/software-agent-sdk/pull/4299
 * refactor(llm): add LiteLLM-backed provider abstraction by @enyst in https://github.com/OpenHands/software-agent-sdk/pull/2363
 * chore(sdk): deprecate AgentBase.model_dump_succint by @AzeelSajjad in https://github.com/OpenHands/software-agent-sdk/pull/4328
-* chore(deps): bump pypdf from 6.10.2 to 6.14.2 by @dependabot[bot] in https://github.com/OpenHands/software-agent-sdk/pull/4345
 * refactor(observability): stop depending on lmnr to propagate trace context into tool workers by @simonrosenberg in https://github.com/OpenHands/software-agent-sdk/pull/4360
-* chore(deps): bump aiohttp from 3.13.4 to 3.14.3 by @dependabot[bot] in https://github.com/OpenHands/software-agent-sdk/pull/4312
 * test: stop ambient LMNR env vars deciding what the tracing tests measure by @simonrosenberg in https://github.com/OpenHands/software-agent-sdk/pull/4390
 * chore: remove deprecated features past their 1.41.0 removal deadline by @VascoSch92 in https://github.com/OpenHands/software-agent-sdk/pull/4394
 
@@ -77,18 +71,12 @@ This release introduces **Canvas Extensions**, a major new capability that enabl
 * fix: normalize SQLite telemetry timestamps by @Linxiushen in https://github.com/OpenHands/automation/pull/301
 * fix: default FILE_STORE to local instead of gcs by @neubig in https://github.com/OpenHands/automation/pull/314
 
-#### Maintenance
-* chore: bump SDK to 1.40.1 by @all-hands-bot in https://github.com/OpenHands/automation/pull/309
-* chore: bump SDK to 1.41.0 by @all-hands-bot in https://github.com/OpenHands/automation/pull/315
-
 ---
 
 ### OpenHands Cloud (Helm Chart)
 
 #### Features
-* feat(agent-canvas): bump image tag to 1.12.0 by @juanmichelini in https://github.com/OpenHands/OpenHands-Cloud/pull/1036
 * feat(chart): OHE-3021 : expose OH_SANDBOX_MAX_NUM_SANDBOXES as a ConfigOption by @tofarr in https://github.com/OpenHands/OpenHands-Cloud/pull/1035
-* feat(automation): bump image tag to 1.7.0 by @openhands-release-bot[bot] in https://github.com/OpenHands/OpenHands-Cloud/pull/1020
 
 ---
 

--- a/enterprise/release-notes.mdx
+++ b/enterprise/release-notes.mdx
@@ -4,6 +4,94 @@ description: Release notes for OpenHands Enterprise
 icon: clipboard-list
 ---
 
+## 0.45.0
+
+This release introduces **Canvas Extensions**, a major new capability that enables installing, managing, and refreshing extensions with manifest support and persistent storage. The Agent SDK saw significant improvements with conversation error classification, accumulated LLM cost tracking, and observability enhancements including detached traces for delegate conversations. The Automation component was modernized with the retirement of the standalone frontend, enhanced preset metadata, and LLM cost tracking. Critical stability fixes addressed S3/MinIO silent truncation issues, improved CSP compatibility for the Monaco diff viewer, and enhanced secrets handling across the platform.
+
+### Enterprise Server
+
+#### Features
+* feat: migrate existing managed MiniMax M2.7 settings to the GLM 5.2 default by @juanmichelini in https://github.com/OpenHands/enterprise/pull/140
+
+#### Bug Fixes
+* fix(sandbox): OHE-3021 : honor OH_SANDBOX_MAX_NUM_SANDBOXES in RemoteSandboxServiceInjector fallback by @tofarr in https://github.com/OpenHands/enterprise/pull/153
+* fix: self-host Monaco so the diff viewer works under CSP by @hieptl in https://github.com/OpenHands/enterprise/pull/155
+* fix: stop silent truncation of archived and shared conversations on S3/MinIO by @hieptl in https://github.com/OpenHands/enterprise/pull/158
+* fix: stop surfacing Git provider token required errors for SSO-only users by @hieptl in https://github.com/OpenHands/enterprise/pull/159
+* fix(s3 file store): OHE-3079 : paginate list_objects_v2 to avoid silent truncation at 1000 keys by @tofarr in https://github.com/OpenHands/enterprise/pull/157
+* fix: redirect Automations sidebar icon to /canvas/automations by @hieptl in https://github.com/OpenHands/enterprise/pull/162
+
+#### Maintenance
+* chore: bump openhands-sdk, openhands-agent-server, and openhands-tools to 1.41.0 by @tofarr in https://github.com/OpenHands/enterprise/pull/161
+
+---
+
+### Software Agent SDK
+
+#### Features
+* feat(llm): verify kimi-for-coding (Kimi Code membership) by @georgeglarson in https://github.com/OpenHands/software-agent-sdk/pull/4150
+* feat(sdk): classify conversation errors by @neubig in https://github.com/OpenHands/software-agent-sdk/pull/4316
+* feat: report accumulated LLM cost in the automation completion callback by @hieptl in https://github.com/OpenHands/software-agent-sdk/pull/4311
+* feat(agent-server): Canvas Extensions manifest and containment [1/4] by @VascoSch92 in https://github.com/OpenHands/software-agent-sdk/pull/4361
+* feat(sdk): track requested_ref alongside resolved_ref in InstallationInfo [2/4] by @VascoSch92 in https://github.com/OpenHands/software-agent-sdk/pull/4375
+* feat(agent-server): Canvas Extensions installation persistence [3/4] by @VascoSch92 in https://github.com/OpenHands/software-agent-sdk/pull/4364
+* feat(agent-server): Canvas Extensions staged refresh (check/apply) [4/4] by @VascoSch92 in https://github.com/OpenHands/software-agent-sdk/pull/4374
+
+#### Bug Fixes
+* fix(sdk): respect subscription validator composition by @Sehlani042 in https://github.com/OpenHands/software-agent-sdk/pull/3953
+* fix(agent-server): keep secrets out of workspace persistence by @enyst in https://github.com/OpenHands/software-agent-sdk/pull/3990
+* fix(acp): surface Claude Opus 5 in Claude Code model picker by @nicolasdmolina in https://github.com/OpenHands/software-agent-sdk/pull/4326
+* fix: PATCH /api/settings loads the profile's LLM when setting active_profile by @emmanuel-adu in https://github.com/OpenHands/software-agent-sdk/pull/4319
+* fix(git): demote expected command failures to debug by @neubig in https://github.com/OpenHands/software-agent-sdk/pull/4341
+* fix(sdk): nudge before hard-terminating on a repeating action-error pattern by @VascoSch92 in https://github.com/OpenHands/software-agent-sdk/pull/4332
+* fix(mcp): reconcile live agent tool snapshots by @Shimada666 in https://github.com/OpenHands/software-agent-sdk/pull/4367
+* fix(observability): mark utility LLM spans (title generation, ask_agent) by @simonrosenberg in https://github.com/OpenHands/software-agent-sdk/pull/4359
+* fix(observability): give delegate conversations their own detached Laminar trace by @simonrosenberg in https://github.com/OpenHands/software-agent-sdk/pull/4378
+* fix(browser): a browser tool that cannot start should not fail the conversation by @onatozmenn in https://github.com/OpenHands/software-agent-sdk/pull/4342
+* fix(observability): keep the conversation object out of TOOL span input by @simonrosenberg in https://github.com/OpenHands/software-agent-sdk/pull/4379
+
+#### Maintenance
+* chore(deps): bump joserfc from 1.6.4 to 1.6.8 by @dependabot[bot] in https://github.com/OpenHands/software-agent-sdk/pull/4306
+* chore(ci): remove QA Changes workflows by @VascoSch92 in https://github.com/OpenHands/software-agent-sdk/pull/4299
+* refactor(llm): add LiteLLM-backed provider abstraction by @enyst in https://github.com/OpenHands/software-agent-sdk/pull/2363
+* chore(sdk): deprecate AgentBase.model_dump_succint by @AzeelSajjad in https://github.com/OpenHands/software-agent-sdk/pull/4328
+* chore(deps): bump pypdf from 6.10.2 to 6.14.2 by @dependabot[bot] in https://github.com/OpenHands/software-agent-sdk/pull/4345
+* refactor(observability): stop depending on lmnr to propagate trace context into tool workers by @simonrosenberg in https://github.com/OpenHands/software-agent-sdk/pull/4360
+* chore(deps): bump aiohttp from 3.13.4 to 3.14.3 by @dependabot[bot] in https://github.com/OpenHands/software-agent-sdk/pull/4312
+* test: stop ambient LMNR env vars deciding what the tracing tests measure by @simonrosenberg in https://github.com/OpenHands/software-agent-sdk/pull/4390
+* chore: remove deprecated features past their 1.41.0 removal deadline by @VascoSch92 in https://github.com/OpenHands/software-agent-sdk/pull/4394
+
+---
+
+### Automation
+
+#### Features
+* feat: retire the standalone automation frontend by @hieptl in https://github.com/OpenHands/automation/pull/284
+* feat: report the configured automation timeout cap by @neubig in https://github.com/OpenHands/automation/pull/296
+* feat: record accumulated LLM cost per automation run by @hieptl in https://github.com/OpenHands/automation/pull/280
+* feat: set descriptive titles on automation-born conversations by @hieptl in https://github.com/OpenHands/automation/pull/312
+* feat: add generic preset metadata field to Automation model by @hieptl in https://github.com/OpenHands/automation/pull/313
+* feat: add template provenance, idempotent enablement, and first-run outcome to presets by @hieptl in https://github.com/OpenHands/automation/pull/322
+
+#### Bug Fixes
+* fix: normalize SQLite telemetry timestamps by @Linxiushen in https://github.com/OpenHands/automation/pull/301
+* fix: default FILE_STORE to local instead of gcs by @neubig in https://github.com/OpenHands/automation/pull/314
+
+#### Maintenance
+* chore: bump SDK to 1.40.1 by @all-hands-bot in https://github.com/OpenHands/automation/pull/309
+* chore: bump SDK to 1.41.0 by @all-hands-bot in https://github.com/OpenHands/automation/pull/315
+
+---
+
+### OpenHands Cloud (Helm Chart)
+
+#### Features
+* feat(agent-canvas): bump image tag to 1.12.0 by @juanmichelini in https://github.com/OpenHands/OpenHands-Cloud/pull/1036
+* feat(chart): OHE-3021 : expose OH_SANDBOX_MAX_NUM_SANDBOXES as a ConfigOption by @tofarr in https://github.com/OpenHands/OpenHands-Cloud/pull/1035
+* feat(automation): bump image tag to 1.7.0 by @openhands-release-bot[bot] in https://github.com/OpenHands/OpenHands-Cloud/pull/1020
+
+---
+
 ## 0.41.0
 
 This release advances the **Agent Canvas** rollout with a new homepage banner and an updated Canvas build, and sets GLM 5.2 as the default model for SaaS deployments. The remainder of the release focuses on Codex authentication handling, secrets and settings reliability, and a range of stability fixes across the Enterprise Server and Helm charts.


### PR DESCRIPTION
This PR adds release notes for the latest OpenHands Enterprise release promoted to stable.

## Changes
- Added comprehensive release notes for version 0.45.0
- Includes changes from Enterprise Server (1.51.0 → 1.52.2), Software Agent SDK (1.39.1 → 1.41.0), Automation (1.5.0 → 1.7.0), and OpenHands Cloud Helm Chart (0.41.0 → 0.45.0)

## Component Version Changes
| Component                    | Previous (0.41.0) | New (0.45.0) |
|------------------------------|-------------------|--------------|
| OpenHands-Cloud (Helm chart) | 0.41.0            | 0.45.0       |
| Enterprise Server            | 1.51.0            | 1.52.2       |
| Software Agent SDK           | 1.39.1            | 1.41.0       |
| Runtime API                  | 0.8.0             | 0.8.0        |
| Automation                   | 1.5.0             | 1.7.0        |

## Highlights
- 🎨 **Canvas Extensions**: Major new capability for installing, managing, and refreshing extensions
- 📊 **LLM Cost Tracking**: Accumulated cost reporting across Automation and SDK
- 🔒 **Security Improvements**: Enhanced secrets handling and CSP compatibility
- 🐛 **Critical Fixes**: Resolved S3/MinIO silent truncation issues and observability enhancements