### PR TITLE
docs(sdk): document AgentContext.disabled_agents deny-list

### DIFF
--- a/sdk/guides/agent-file-based.mdx
+++ b/sdk/guides/agent-file-based.mdx
@@ -268,6 +268,27 @@ conversation = Conversation(
 
 To learn more about agent delegation, follow our [comprehensive guide](/sdk/guides/task-tool-set).
 
+## Disabling Sub-Agents per Conversation
+
+`AgentContext.disabled_agents` is a per-conversation deny-list of sub-agent names, mirroring the `disabled_skills` model for skills. When the task tool or the delegate tool is asked to spawn a listed agent, the spawn is refused and the calling LLM receives a tool error naming the disabled agent, so it can pick another type or do the work itself.
+
+```python icon="python"
+from openhands.sdk import Agent, AgentContext, Tool
+from openhands.tools.task import TaskToolSet
+
+main_agent = Agent(
+    llm=llm,
+    tools=[Tool(name=TaskToolSet.name)],
+    agent_context=AgentContext(disabled_agents=["code-explorer"]),
+)
+```
+
+Enforcement happens at spawn time, not registration time: the sub-agent registry is process-global and shared across conversations on the agent server, so unregistering an agent would remove it for every conversation in the process. A listed name that is not registered is a harmless no-op, and the default empty list disables nothing.
+
+<Note>
+`disabled_agents` rides the standard `AgentContext` plumbing, so server and frontend integrations can set it per conversation through the start-conversation settings payload (`agent_settings.agent_context.disabled_agents`).
+</Note>
+
 ## Example Agent Files
 
 ### Code Reviewer


### PR DESCRIPTION
Companion to OpenHands/software-agent-sdk#4557 (feature) and OpenHands/software-agent-sdk#4556 (issue).

Adds a "Disabling Sub-Agents per Conversation" section to the file-based agents guide, covering:

- the `AgentContext.disabled_agents` deny-list (mirrors `disabled_skills`)
- spawn-time enforcement in the task and delegate tools, and why it is not registration-time (process-global registry)
- a minimal usage example
- a note that the field rides the start-conversation settings payload for server/frontend integrations

Docs-only change; the feature lands with the SDK PR.
