### PR TITLE
Add Agent Canvas release notes for v1.10.0–v1.14.0

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -308,6 +308,16 @@
               "openhands/usage/agent-canvas/development",
               "openhands/usage/agent-canvas/troubleshooting"
             ]
+          },
+          {
+            "group": "Release Notes",
+            "pages": [
+              "openhands/usage/agent-canvas/release-notes/v1.14.0",
+              "openhands/usage/agent-canvas/release-notes/v1.13.0",
+              "openhands/usage/agent-canvas/release-notes/v1.12.0",
+              "openhands/usage/agent-canvas/release-notes/v1.11.0",
+              "openhands/usage/agent-canvas/release-notes/v1.10.0"
+            ]
           }
         ]
       },

--- a/openhands/usage/agent-canvas/release-notes/v1.10.0.mdx
+++ b/openhands/usage/agent-canvas/release-notes/v1.10.0.mdx
@@ -1,0 +1,31 @@
+---
+title: Agent Canvas 1.10.0
+description: Release notes for Agent Canvas version 1.10.0
+---
+
+# Agent Canvas 1.10.0
+
+Released August 5, 2026.
+
+[View the full release on GitHub](https://github.com/OpenHands/OpenHands/releases/tag/v1.10.0).
+
+## Highlights
+
+- **Canvas default model set to GLM 5.2** — New conversations now use GLM 5.2 as the default model, providing a better out-of-the-box experience without requiring manual model selection.
+- **Activity Log export** — Users can export the full Activity Log for a conversation, making it easier to share agent trajectories and audit work outside of Canvas.
+- **Featured Automations dashboard** — A new landing dashboard surfaces featured automations, helping users discover and set up prebuilt workflows directly from the home screen.
+- **Faceted skills filter** — The skills page now includes a faceted filter rail, letting users quickly narrow down skills by category, source, or status.
+- **Manifest-driven automation sub-pages** — Automations can now define their own sub-pages via a manifest, enabling richer configuration UIs without custom frontend code.
+
+## Improvements and fixes
+
+- Automation timeout cap is now derived from the deployment configuration, preventing runs from being silently capped by stale defaults.
+- Sidebar conversation links are pinned to the correct backend identity, fixing broken navigation when multiple backends are connected.
+- Local proxy targets now use IPv4 loopback addresses, resolving connection failures on systems where IPv6 loopback is not configured.
+- Resolved all npm audit vulnerabilities reported in the frontend dependency tree.
+- MCP server credentials are preserved during Canvas settings mutations, preventing credential loss when toggling or editing other settings.
+
+## Full changelog
+
+- [GitHub release notes](https://github.com/OpenHands/OpenHands/releases/tag/v1.10.0)
+- [Compare v1.9.0 to v1.10.0](https://github.com/OpenHands/OpenHands/compare/v1.9.0...v1.10.0)

--- a/openhands/usage/agent-canvas/release-notes/v1.11.0.mdx
+++ b/openhands/usage/agent-canvas/release-notes/v1.11.0.mdx
@@ -1,0 +1,31 @@
+---
+title: Agent Canvas 1.11.0
+description: Release notes for Agent Canvas version 1.11.0
+---
+
+# Agent Canvas 1.11.0
+
+Released August 7, 2026.
+
+[View the full release on GitHub](https://github.com/OpenHands/OpenHands/releases/tag/v1.11.0).
+
+## Highlights
+
+- **Per-run LLM cost in Activity Log** — Each Activity Log entry and CSV export now includes the LLM cost for that run, giving users visibility into spending at the conversation level.
+- **Typed agent action for child conversations** — A new typed action lets agents programmatically launch local or Cloud child conversations, enabling structured delegation workflows.
+- **Automation tag filter and recognition** — Automations can now be tagged, and the UI supports filtering by tags so users can organize and find automations faster.
+- **Conversation tag chips** — Conversations display tag chips with overflow and hovercard labels, making it easier to identify and group conversations by category.
+- **Customize navigation reordered** — The Customize page navigation has been reorganized for a more logical flow between settings sections.
+- **Version update UI polished** — The Agent Canvas version update experience has been refined with clearer status indicators and smoother transitions.
+- **Automations pane always visible** — The home screen Automations pane now stays visible even when no automations are installed, guiding users toward setup.
+
+## Improvements and fixes
+
+- Multi-size application icons are now shipped for both Windows and macOS, eliminating blurry or missing icons in taskbars and docks.
+- The desktop app has been renamed to "OpenHands Agent Canvas" for consistency across platforms.
+- Runtime metrics now fetch the conversation directly instead of going through a removed cloud-proxy endpoint, fixing a broken metrics path.
+
+## Full changelog
+
+- [GitHub release notes](https://github.com/OpenHands/OpenHands/releases/tag/v1.11.0)
+- [Compare v1.10.0 to v1.11.0](https://github.com/OpenHands/OpenHands/compare/v1.10.0...v1.11.0)

--- a/openhands/usage/agent-canvas/release-notes/v1.12.0.mdx
+++ b/openhands/usage/agent-canvas/release-notes/v1.12.0.mdx
@@ -1,0 +1,19 @@
+---
+title: Agent Canvas 1.12.0
+description: Release notes for Agent Canvas version 1.12.0
+---
+
+# Agent Canvas 1.12.0
+
+Released August 7, 2026.
+
+[View the full release on GitHub](https://github.com/OpenHands/OpenHands/releases/tag/v1.12.0).
+
+## Highlights
+
+- **Clarified free OpenHands model endpoints** — The free OpenHands model offerings now have clearer endpoint labeling, helping users understand which models are available at no cost and how to select them.
+
+## Full changelog
+
+- [GitHub release notes](https://github.com/OpenHands/OpenHands/releases/tag/v1.12.0)
+- [Compare v1.11.0 to v1.12.0](https://github.com/OpenHands/OpenHands/compare/v1.11.0...v1.12.0)

--- a/openhands/usage/agent-canvas/release-notes/v1.13.0.mdx
+++ b/openhands/usage/agent-canvas/release-notes/v1.13.0.mdx
@@ -1,0 +1,36 @@
+---
+title: Agent Canvas 1.13.0
+description: Release notes for Agent Canvas version 1.13.0
+---
+
+# Agent Canvas 1.13.0
+
+Released August 13, 2026.
+
+[View the full release on GitHub](https://github.com/OpenHands/OpenHands/releases/tag/v1.13.0).
+
+## Highlights
+
+- **Context window usage meter and manual compaction** — A new context-window usage meter, usage drawer, and manual compaction control let users monitor and manage token consumption in real time, preventing unexpected context overflow.
+- **Client-side conversation archive** — Users can archive conversations directly from the sidebar, keeping the active conversation list clean without permanently deleting work.
+- **Inline markdown artifact previews** — Markdown artifacts rendered in chat now show inline previews, reducing the need to open a separate viewer for common output formats.
+- **Ready-for-dev issue readiness gate** — A new readiness gate enforces type-specific criteria before issues are marked ready for development, improving workflow discipline.
+
+## Improvements and fixes
+
+- A postinstall message now explains how to start Agent Canvas after installation.
+- Agent-server telemetry is now correctly configured when launched from Canvas.
+- Overflow menus are now usable on touch devices, fixing a long-standing mobile interaction issue.
+- The sidebar "Load more" button now correctly discovers folders rather than expanding folder contents prematurely.
+- Chat input drag-resize is disabled when the input is not bottom-anchored, preventing unexpected layout shifts.
+- Non-MCP-installable automation integrations are now surfaced instead of being silently dropped.
+- A flaky `ProgressEvent` unhandled rejection in CI has been resolved.
+- Launcher services are spawned without an implicit shell, improving reliability across environments.
+- The Basic LLM provider list no longer truncates at 100 entries, ensuring all available providers are visible.
+- The context meter ring track is now drawn from the foreground color instead of a border token, fixing visual inconsistency.
+- Pending MSW callbacks are drained before jsdom teardown, eliminating a `ProgressEvent` `ReferenceError` in tests.
+
+## Full changelog
+
+- [GitHub release notes](https://github.com/OpenHands/OpenHands/releases/tag/v1.13.0)
+- [Compare v1.12.0 to v1.13.0](https://github.com/OpenHands/OpenHands/compare/v1.12.0...v1.13.0)

--- a/openhands/usage/agent-canvas/release-notes/v1.14.0.mdx
+++ b/openhands/usage/agent-canvas/release-notes/v1.14.0.mdx
@@ -1,0 +1,30 @@
+---
+title: Agent Canvas 1.14.0
+description: Release notes for Agent Canvas version 1.14.0
+---
+
+# Agent Canvas 1.14.0
+
+Released August 17, 2026.
+
+[View the full release on GitHub](https://github.com/OpenHands/OpenHands/releases/tag/v1.14.0).
+
+## Highlights
+
+- **Structured error outcomes** — Agent errors are now presented as structured outcomes in the UI, making it easier to understand what went wrong and what action to take next.
+- **LLM pre-flight validation** — A pre-flight check validates LLM configuration before saving a profile, preventing misconfigured profiles from being saved and causing failures at run time.
+- **Git Sync page for automations** — A new Git Sync page lets automation authors manage how their automation repositories stay in sync, streamlining the automation development lifecycle.
+- **Canvas default model set to Kimi K3** — New conversations now default to Kimi K3, which is tagged as free, lowering the barrier to entry for new users.
+
+## Improvements and fixes
+
+- Onboarding now preselects the OpenHands LLM provider after picking the OpenHands agent, reducing friction during first-time setup.
+- Backend scope is preserved in conversation links, fixing broken navigation when switching between multiple backends.
+- The `VITE_BACKEND_BASE_URL` is no longer baked at build time during `npm run dev`, allowing developers to point at different backends without rebuilding.
+- Automation local responder URLs are now set from the browser origin, fixing webhook delivery in behind-proxy deployments.
+- The full workspace file tree is now shown in the Files tab on cloud backends, restoring visibility into nested directories.
+
+## Full changelog
+
+- [GitHub release notes](https://github.com/OpenHands/OpenHands/releases/tag/v1.14.0)
+- [Compare v1.13.0 to v1.14.0](https://github.com/OpenHands/OpenHands/compare/v1.13.0...v1.14.0)


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [x] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

Add a new **Release Notes** section under the Agent Canvas tab, covering versions 1.10.0 through 1.14.0. Each release note page mirrors the corresponding GitHub release and follows a consistent format:

- Version header with release date
- Link to the full GitHub release
- **Highlights** — key features with bold names and factual explanations
- **Improvements and fixes** — user-visible bug fixes and enhancements
- **Full changelog** — links to the GitHub release and tag comparison

**Files added:**
- `openhands/usage/agent-canvas/release-notes/v1.10.0.mdx`
- `openhands/usage/agent-canvas/release-notes/v1.11.0.mdx`
- `openhands/usage/agent-canvas/release-notes/v1.12.0.mdx`
- `openhands/usage/agent-canvas/release-notes/v1.13.0.mdx`
- `openhands/usage/agent-canvas/release-notes/v1.14.0.mdx`

**Files modified:**
- `docs.json` — added a "Release Notes" group to the Agent Canvas tab navigation, listing all five versions in descending order (newest first).

All pages were verified to render correctly in the local Mintlify dev server.