### PR TITLE
docs: document custom title generation prompts

### DIFF
--- a/sdk/arch/agent-server.mdx
+++ b/sdk/arch/agent-server.mdx
@@ -123,6 +123,27 @@ conversation.close()
 
 If the server was started without `OH_SESSION_API_KEYS_0`, remove the `api_key=...` argument.
 
+## Customize Conversation Title Generation
+
+When creating a conversation through `POST /api/conversations`, set
+`title_generation_prompt` to replace the default user prompt used for automatic
+title generation. The value can contain these placeholders:
+
+- `{conversation_content}` - The first user message, truncated to 1,000 characters.
+- `{max_length}` - The maximum generated title length.
+
+```json
+{
+  "autotitle": true,
+  "title_generation_prompt": "Create a title under {max_length} characters for: {conversation_content}"
+}
+```
+
+If `{conversation_content}` is not present, the Agent Server appends the first
+user message to the custom prompt. Empty or omitted values keep the default
+title-generation behavior. Prompts can contain up to 2,000 characters and are
+stored with the conversation in `meta.json`.
+
 ## Expose It Safely
 
 If another service runs on the same machine, keep the server bound to `127.0.0.1` and let that service connect locally.

--- a/sdk/arch/agent-server.mdx
+++ b/sdk/arch/agent-server.mdx
@@ -126,7 +126,7 @@ If the server was started without `OH_SESSION_API_KEYS_0`, remove the `api_key=.
 ## Customize Conversation Title Generation
 
 When creating a conversation through `POST /api/conversations`, set
-`title_generation_prompt` to replace the default user prompt used for automatic
+`prompt` to replace the default user prompt used for automatic
 title generation. The value can contain these placeholders:
 
 - `{conversation_content}` - The first user message, truncated to 1,000 characters.
@@ -135,7 +135,7 @@ title generation. The value can contain these placeholders:
 ```json
 {
   "autotitle": true,
-  "title_generation_prompt": "Create a title under {max_length} characters for: {conversation_content}"
+  "prompt": "Create a title under {max_length} characters for: {conversation_content}"
 }
 ```
 


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [ ] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

Documents the new Agent Server `prompt` conversation setting introduced by [OpenHands/software-agent-sdk#4564](https://github.com/OpenHands/software-agent-sdk/pull/4564), including its placeholders, automatic conversation-content fallback, 2,000-character limit, default behavior, and `meta.json` persistence.

Validation: `git diff --check` passed. I did not run the documentation site locally; this is a focused addition to the existing Agent Server architecture page.
