### PR TITLE
docs: add cluster scaling guide for VM installs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -555,7 +555,8 @@
             "group": "VM Install",
             "pages": [
               "enterprise/vm-install/admin-console-configuration",
-              "enterprise/vm-install/log-collection"
+              "enterprise/vm-install/log-collection",
+              "enterprise/vm-install/scaling"
             ]
           },
           {

--- a/enterprise/vm-install/admin-console-configuration.mdx
+++ b/enterprise/vm-install/admin-console-configuration.mdx
@@ -220,6 +220,7 @@ See [External PostgreSQL](/enterprise/external-postgres) for version, encoding, 
 | `Warm Runtime Count` | Number of ready sandboxes kept for faster conversation startup. Set to `0` for cold starts only. |
 | `Additional Host Path Mounts` | Host paths mounted into every sandbox, one per line as `host_path:container_path[:ro\|rw]`. |
 | `Enable /dev/kvm passthrough (QEMU/KVM)` | Makes host KVM acceleration available inside sandboxes. The node must expose `/dev/kvm`. |
+| `Run sandboxes on dedicated nodes` | Confines sandboxes to machines added with the `sandbox` role, and keeps the application off those machines. Requires at least one `sandbox` machine already joined. See [Scaling the Cluster](/enterprise/vm-install/scaling). |
 
 <Note>
   `Idle Time` and `Deletion Time` control when idle and paused conversations are

--- a/enterprise/vm-install/scaling.mdx
+++ b/enterprise/vm-install/scaling.mdx
@@ -41,7 +41,7 @@ Dedicated sandbox machines also give you a dial for conversation capacity.
 
   A joining machine also needs to reach `30000/TCP` and `50000/TCP` on the existing machines.
 
-  Note that `4789` is UDP. Opening the whole set as TCP leaves the machines unable to exchange traffic.
+  Note that `4789` is UDP.
 </Warning>
 
 ## Add a Machine

--- a/enterprise/vm-install/scaling.mdx
+++ b/enterprise/vm-install/scaling.mdx
@@ -1,0 +1,89 @@
+---
+title: Scaling the Cluster
+description: Add machines to an OpenHands Enterprise VM deployment to increase capacity, and run sandboxes on dedicated machines.
+icon: server
+---
+
+An OpenHands Enterprise VM deployment starts as a single machine that runs everything: the OpenHands application, its supporting services, and the sandboxes where conversations execute. Add machines when you need more capacity.
+
+## Machine Roles
+
+When you add a machine, you choose the role it takes. The role determines what runs on it and cannot be changed afterward.
+
+| Role | Runs |
+|---|---|
+| `app` | The OpenHands application and its supporting services. |
+| `sandbox` | Sandboxes only. |
+
+## Recommended: Dedicated Sandbox Machines
+
+For production, run sandboxes on dedicated `sandbox` machines.
+
+Sandboxes are the most variable workload in a deployment. Each conversation gets one, their number rises and falls with user activity, and the code that runs inside them is arbitrary. When sandboxes share a machine with the OpenHands application, a burst of conversations competes for the same CPU and memory the application needs to serve requests. Separating them means sandbox demand cannot degrade or take down the application.
+
+Dedicated sandbox machines also give you a single dial for conversation capacity. When users need more concurrent conversations, add sandbox machines without touching the machines running the application.
+
+## Before You Begin
+
+<Warning>
+  New machines must be able to reach the existing machines over your private network. Cluster traffic uses a specific set of ports, and some of it is UDP. If your environment restricts traffic between machines, open those ports first — a machine that cannot reach the others will appear to join successfully and then fail to run workloads. See [Replicated's port requirements](https://docs.replicated.com/enterprise/installing-embedded-requirements) for the list.
+</Warning>
+
+Adding machines requires the multi-node entitlement on your license. If `Add node` does not appear in the Admin Console, contact OpenHands Support.
+
+## Add a Machine
+
+<Steps>
+  <Step title="Start the process">
+    In the Admin Console, select `Cluster Management`, then `Add node`.
+  </Step>
+  <Step title="Choose the role">
+    Select `app` or `sandbox`. The role cannot be changed after the machine is added.
+  </Step>
+  <Step title="Run the commands on the new machine">
+    The Admin Console displays download, extraction, and join commands for the role you selected. Connect to the new machine and run them in order. Keep the Admin Console page open while you do this.
+  </Step>
+  <Step title="Confirm it joined">
+    Return to `Cluster Management` and wait for the new machine's status to become `Ready`.
+  </Step>
+</Steps>
+
+## Add Sandbox Capacity
+
+Add one or more machines with the `sandbox` role, then confine sandboxes to them.
+
+<Steps>
+  <Step title="Add a sandbox machine">
+    Follow [Add a Machine](#add-a-machine) and select the `sandbox` role. Wait for its status to become `Ready`.
+  </Step>
+  <Step title="Turn on dedicated sandboxes">
+    Open `Config`, find `Sandbox Configuration`, and enable `Run sandboxes on dedicated nodes`. Save and deploy the change.
+  </Step>
+</Steps>
+
+<Note>
+  Enable `Run sandboxes on dedicated nodes` only after at least one `sandbox` machine is `Ready`. Turn it on first and new conversations will have nowhere to run. A configuration check warns you if the setting is enabled while no sandbox machine exists.
+</Note>
+
+Conversations that were already running stay on their original machine and are cleaned up normally as they go idle. Only new conversations move to the sandbox machines, so the transition needs no downtime.
+
+To add more conversation capacity later, add another `sandbox` machine. No configuration change is needed — the setting already routes sandboxes to every machine with that role.
+
+## Add Application Capacity
+
+Add machines with the `app` role to increase capacity for the OpenHands application itself.
+
+Machines with the `app` role also run the services that coordinate the cluster, which makes resilience step rather than climb:
+
+| `app` machines | Machine failures tolerated |
+|---|---|
+| 1 | 0 |
+| 2 | 0 |
+| 3 | 1 |
+
+Two `app` machines double capacity but tolerate no more failure than one, because the coordination services need more than half of them available. Three is the first count that survives losing a machine. If your goal is resilience rather than raw capacity, plan for three.
+
+## Related Guides
+
+- [Admin Console Configuration](/enterprise/vm-install/admin-console-configuration)
+- [Conversations and Sandboxes](/enterprise/conversations-and-sandboxes)

--- a/enterprise/vm-install/scaling.mdx
+++ b/enterprise/vm-install/scaling.mdx
@@ -26,10 +26,12 @@ Dedicated sandbox machines also give you a dial for conversation capacity.
 ## Before You Begin
 
 <Warning>
-  New machines must be able to reach the existing machines over your private network. Cluster traffic uses a specific set of ports, and some of it is UDP. If your environment restricts traffic between machines, open those ports first — a machine that cannot reach the others will appear to join successfully and then fail to run workloads. See [Replicated's port requirements](https://docs.replicated.com/enterprise/installing-embedded-requirements) for the list.
-</Warning>
+  New machines must be able to reach the existing machines over your private network. If your environment restricts traffic between machines, open these ports first. A machine that cannot reach the others will appear to join successfully and then fail to run workloads.
 
-Adding machines requires the multi-node entitlement on your license. If `Add node` does not appear in the Admin Console, contact OpenHands Support.
+  Open in both directions between all machines: `2380/TCP`, `4789/UDP`, `6443/TCP`, `9091/TCP`, `9443/TCP`, `10249/TCP`, `10250/TCP`, and `10256/TCP`. A joining machine also needs to reach `30000/TCP` and `50000/TCP` on the existing machines.
+
+  Note that `4789` is UDP. Opening the whole set as TCP leaves the machines unable to exchange traffic.
+</Warning>
 
 ## Add a Machine
 
@@ -62,7 +64,7 @@ Add one or more machines with the `sandbox` role, then confine sandboxes to them
 </Steps>
 
 <Note>
-  Enable `Run sandboxes on dedicated nodes` only after at least one `sandbox` machine is `Ready`. Turn it on first and new conversations will have nowhere to run. A configuration check warns you if the setting is enabled while no sandbox machine exists.
+  You can enable `Run sandboxes on dedicated nodes` before adding a `sandbox` machine, but new conversations cannot start until one is `Ready`. A configuration check warns you if the setting is enabled while no sandbox machine exists.
 </Note>
 
 Conversations that were already running stay on their original machine and are cleaned up normally as they go idle. Only new conversations move to the sandbox machines, so the transition needs no downtime.

--- a/enterprise/vm-install/scaling.mdx
+++ b/enterprise/vm-install/scaling.mdx
@@ -69,21 +69,11 @@ Add one or more machines with the `sandbox` role, then confine sandboxes to them
 
 Conversations that were already running stay on their original machine and are cleaned up normally as they go idle. Only new conversations move to the sandbox machines, so the transition needs no downtime.
 
-To add more conversation capacity later, add another `sandbox` machine. No configuration change is needed — the setting already routes sandboxes to every machine with that role.
+To add more conversation capacity later, add another `sandbox` machine.
 
 ## Add Application Capacity
 
 Add machines with the `app` role to increase capacity for the OpenHands application itself.
-
-Machines with the `app` role also run the services that coordinate the cluster, which makes resilience step rather than climb:
-
-| `app` machines | Machine failures tolerated |
-|---|---|
-| 1 | 0 |
-| 2 | 0 |
-| 3 | 1 |
-
-Two `app` machines double capacity but tolerate no more failure than one, because the coordination services need more than half of them available. Three is the first count that survives losing a machine. If your goal is resilience rather than raw capacity, plan for three.
 
 ## Related Guides
 

--- a/enterprise/vm-install/scaling.mdx
+++ b/enterprise/vm-install/scaling.mdx
@@ -61,6 +61,10 @@ Dedicated sandbox machines also give you a dial for conversation capacity.
   </Step>
 </Steps>
 
+<Note>
+  You can select both `app` and `sandbox`, but this is not recommended. A machine with both roles runs the application and sandboxes together, which gives up the separation you are adding the machine for. When adding a sandbox machine, make sure `app` is unchecked.
+</Note>
+
 ## Add Sandbox Capacity
 
 Add one or more machines with the `sandbox` role, then confine sandboxes to them.

--- a/enterprise/vm-install/scaling.mdx
+++ b/enterprise/vm-install/scaling.mdx
@@ -28,7 +28,18 @@ Dedicated sandbox machines also give you a dial for conversation capacity.
 <Warning>
   New machines must be able to reach the existing machines over your private network. If your environment restricts traffic between machines, open these ports first. A machine that cannot reach the others will appear to join successfully and then fail to run workloads.
 
-  Open in both directions between all machines: `2380/TCP`, `4789/UDP`, `6443/TCP`, `9091/TCP`, `9443/TCP`, `10249/TCP`, `10250/TCP`, and `10256/TCP`. A joining machine also needs to reach `30000/TCP` and `50000/TCP` on the existing machines.
+  Open in both directions between all machines:
+
+  - `2380/TCP`
+  - `4789/UDP`
+  - `6443/TCP`
+  - `9091/TCP`
+  - `9443/TCP`
+  - `10249/TCP`
+  - `10250/TCP`
+  - `10256/TCP`
+
+  A joining machine also needs to reach `30000/TCP` and `50000/TCP` on the existing machines.
 
   Note that `4789` is UDP. Opening the whole set as TCP leaves the machines unable to exchange traffic.
 </Warning>

--- a/enterprise/vm-install/scaling.mdx
+++ b/enterprise/vm-install/scaling.mdx
@@ -19,9 +19,9 @@ When you add a machine, you choose the role it takes. The role determines what r
 
 For production, run sandboxes on dedicated `sandbox` machines.
 
-Sandboxes are the most variable workload in a deployment. Each conversation gets one, their number rises and falls with user activity, and the code that runs inside them is arbitrary. When sandboxes share a machine with the OpenHands application, a burst of conversations competes for the same CPU and memory the application needs to serve requests. Separating them means sandbox demand cannot degrade or take down the application.
+Sandboxes are the most variable workload in a deployment. When sandboxes share a machine with the OpenHands application, a burst of conversations competes for the same CPU and memory the application needs to serve requests. Separating them means sandbox demand cannot degrade or take down the application.
 
-Dedicated sandbox machines also give you a single dial for conversation capacity. When users need more concurrent conversations, add sandbox machines without touching the machines running the application.
+Dedicated sandbox machines also give you a dial for conversation capacity.
 
 ## Before You Begin
 
@@ -41,7 +41,7 @@ Adding machines requires the multi-node entitlement on your license. If `Add nod
     Select `app` or `sandbox`. The role cannot be changed after the machine is added.
   </Step>
   <Step title="Run the commands on the new machine">
-    The Admin Console displays download, extraction, and join commands for the role you selected. Connect to the new machine and run them in order. Keep the Admin Console page open while you do this.
+    The Admin Console displays download, extraction, and join commands for the role you selected. Connect to the new machine and run them in order.
   </Step>
   <Step title="Confirm it joined">
     Return to `Cluster Management` and wait for the new machine's status to become `Ready`.


### PR DESCRIPTION
- [ ] I have read and reviewed the documentation changes to the best of my ability.
- [ ] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

Customers on the VM install want to scale past a single machine, mainly for sandbox capacity. Nothing in the docs tells them how, so this adds a `Scaling the Cluster` page under VM Install.

It's written in terms of machines and roles rather than nodes and scheduling, since that's the layer replicated presents to customers. The main thing it recommends is running sandboxes on dedicated machines in production, so sandbox load can't eat capacity the application needs.

Two smaller points I made deliberate calls on:

- There's a warning about network reachability between machines. It's the one semi-technical bit I kept, because a machine that can't reach the others joins fine and then silently fails to run anything.
- The app-machine section spells out that going from one machine to two buys capacity but no extra resilience, and three is the first count that survives a failure. Framed without k8s terms.

Also adds the new `Run sandboxes on dedicated nodes` setting to the Sandbox Configuration table on the Admin Console page.

That setting ships in OpenHands/OpenHands-Cloud#1133 through OpenHands/OpenHands-Cloud#1136.