### PR TITLE
docs: add currently supported features page to Enterprise tab

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -509,6 +509,7 @@
             "pages": [
               "enterprise/index",
               "enterprise/enterprise-vs-oss",
+              "enterprise/supported-features",
               "enterprise/sizing-guide",
               "enterprise/quick-start",
               "enterprise/custom-sandbox-image",

--- a/enterprise/supported-features.mdx
+++ b/enterprise/supported-features.mdx
@@ -1,0 +1,65 @@
+---
+title: Currently Supported Features
+description: Which features are supported across OpenHands SaaS, Self-Hosted Charts, and Replicated VM-based deployments
+icon: list-check
+---
+
+This page lists what is currently supported in OpenHands across the SaaS,
+Self-Hosted Charts, and Replicated VM-based deployment options.
+
+## Authentication
+
+| Integration | SaaS | Self-Hosted Charts | Replicated VM-based |
+|-------------|:---:|:---:|:---:|
+| GitHub (github.com) | ✅ | ✅ | ✅ |
+| GitHub Enterprise (self-hosted) | ❌ | ❌ | ❌ |
+| GitLab (gitlab.com) | ✅ | ✅ | ✅ |
+| GitLab Self-Hosted | ❌ | ✅ | ✅ |
+| BitBucket Cloud | ✅ | ❌ | ❌ |
+| BitBucket Data Center | ❌ | ✅ | ✅ |
+| Azure DevOps | ❌ | ✅ | ✅ |
+| SAML Authentication | ❌ | ✅ | ❌ |
+
+## Integrations (Resolver)
+
+| Integration | SaaS | Self-Hosted Charts | Replicated VM-based |
+|-------------|:---:|:---:|:---:|
+| GitHub (github.com) | ✅ | ✅ | ✅ |
+| GitHub Enterprise (self-hosted) | ❌ | ❌ | ❌ |
+| GitLab (gitlab.com) | ✅ | ✅ | ✅ |
+| GitLab Self-Hosted | ❌ | ❌ | ❌ |
+| BitBucket Cloud | ❌ | ❌ | ❌ |
+| BitBucket Data Center | ❌ | ✅ | ✅ |
+| Jira Cloud | ✅ | ❌ | ❌ |
+| Jira Data Center | ❌ | ✅ | ✅ |
+| Azure DevOps | ❌ | ❌ | ❌ |
+| Linear | ❌ | ❌ | ❌ |
+| Slack | ✅ | ✅ | ✅ |
+
+## LLM Provider
+
+| Integration | SaaS | Self-Hosted Charts | Replicated VM-based |
+|-------------|:---:|:---:|:---:|
+| Anthropic | ✅ | ✅ | ✅ |
+| Azure OpenAI | ❌ | ✅ | ✅ |
+| Google Vertex AI | ❌ | ✅ | ✅ |
+| Amazon Bedrock | ❌ | ✅ | ✅ |
+| Custom LLM Endpoint | ❌ | ✅ | ✅ |
+
+## Analytics (Laminar)
+
+| SaaS | Self-Hosted Charts | Replicated VM-based |
+|:---:|:---:|:---:|
+| ✅ | ✅ | ✅ |
+
+## Automations
+
+| SaaS | Self-Hosted Charts | Replicated VM-based |
+|:---:|:---:|:---:|
+| ✅ | ✅ | ✅ |
+
+## Plugin Directory
+
+| SaaS | Self-Hosted Charts | Replicated VM-based |
+|:---:|:---:|:---:|
+| ❌ | ✅ | ✅ |


### PR DESCRIPTION
## Summary

Adds a new **Currently Supported Features** page to the Enterprise tab, mirroring the official internal Notion source of truth for what is currently supported in OpenHands.

The page documents feature support across the three deployment options — **SaaS**, **Self-Hosted Charts**, and **Replicated VM-based** — in six sections:

- **Authentication** (GitHub, GitHub Enterprise, GitLab, GitLab Self-Hosted, BitBucket Cloud / Data Center, Azure DevOps, SAML)
- **Integrations (Resolver)** (GitHub, GitLab, BitBucket, Jira Cloud / Data Center, Azure DevOps, Linear, Slack)
- **LLM Provider** (Anthropic, Azure OpenAI, Google Vertex AI, Amazon Bedrock, Custom LLM Endpoint)
- **Analytics (Laminar)**
- **Automations**
- **Plugin Directory**

## Changes

- `enterprise/supported-features.mdx` — new page with the six support matrices
- `docs.json` — registered `enterprise/supported-features` in the "OpenHands Enterprise" navigation group, after `enterprise-vs-oss`

## Notes

- Content was pulled directly from the internal "Currently Supported Features" Notion page.
- `llms.txt` / `llms-full.txt` were intentionally not regenerated here — regeneration produced unrelated drift (title renames and other pages), and the scheduled `sync-llms-files` workflow handles that sync automatically.
- Verified: `docs.json` is valid JSON and all repo tests pass (the 2 `test_pricing_documentation.py` errors are pre-existing network-fetch failures on clean `main`).

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@jpelletier1 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/547996bc-07f7-47c7-af9a-15768a2514eb)