### PR TITLE
docs: document OpenHands repository boundaries

### DIFF
--- a/.agents/skills/code-review.md
+++ b/.agents/skills/code-review.md
@@ -94,7 +94,6 @@ Include a "Source Verification" section that lists the key claims verified and t
 | Legacy skills with `trigger=None` are included in the initial system prompt and remain in LLM context for subsequent turns | ✅ | [agent.py#L150](permalink) |
 | `load_skills_from_dir()` returns tuple of (skills, repo_skills) | ✅ | [context.py#L85](permalink) |
 | AgentSkills format uses progressive disclosure | ❌ Incorrect | [agent.py#L200](permalink) shows... |
-```
 
 If you cannot find source code to verify a documentation claim, explicitly flag it:
 
@@ -102,6 +101,12 @@ If you cannot find source code to verify a documentation claim, explicitly flag 
 ⚠️ Unverified: Could not find source code for the claimed behavior of "X".
 This should be verified before merging.
 ```
+
+## Repository boundaries
+
+Verify that documentation changes belong in this repository rather than a source repository. `OpenHands/OpenHands` owns Agent Canvas, `OpenHands/software-agent-sdk` owns the SDK/Agent Server and canonical API, `OpenHands/typescript-client` owns typed browser API access, `OpenHands/automation` owns scheduling and dispatch, and `OpenHands/extensions` owns reusable skills, plugins, automations, and integrations.
+
+If a PR is opened in the wrong repository, explicitly recommend that it may need to be closed and moved to the repository that owns the change rather than merged here. Every PR must follow this repository's review guidance.
 
 ## Review Decisions
 

--- a/.agents/skills/code-review.md
+++ b/.agents/skills/code-review.md
@@ -94,6 +94,7 @@ Include a "Source Verification" section that lists the key claims verified and t
 | Legacy skills with `trigger=None` are included in the initial system prompt and remain in LLM context for subsequent turns | ✅ | [agent.py#L150](permalink) |
 | `load_skills_from_dir()` returns tuple of (skills, repo_skills) | ✅ | [context.py#L85](permalink) |
 | AgentSkills format uses progressive disclosure | ❌ Incorrect | [agent.py#L200](permalink) shows... |
+```
 
 If you cannot find source code to verify a documentation claim, explicitly flag it:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,19 @@ The site is built with **Mintlify** and deployed automatically by Mintlify on pu
 - `.agents/skills/` — prompt extensions for agents editing this repo (legacy: `.openhands/skills/`; formerly `microagents`)
 - `tests/` — pytest checks for docs consistency (notably LLM pricing docs)
 
+## Cross-Repository Boundaries
+
+This repository owns the unified documentation site and documentation-specific tooling. The documented source repositories have distinct responsibilities:
+
+- [`OpenHands/OpenHands`](https://github.com/OpenHands/OpenHands) owns Agent Canvas UI and local-stack orchestration.
+- [`OpenHands/software-agent-sdk`](https://github.com/OpenHands/software-agent-sdk) owns the Python SDK, Agent Server, agent/tool behavior, conversations, workspaces, events, and canonical API.
+- [`OpenHands/typescript-client`](https://github.com/OpenHands/typescript-client) owns the browser-compatible typed Agent Server client.
+- [`OpenHands/automation`](https://github.com/OpenHands/automation) owns scheduling, webhooks, run history, dispatch, and sandbox lifecycle orchestration.
+- [`OpenHands/extensions`](https://github.com/OpenHands/extensions) owns reusable skills, plugins, automations, and integrations.
+
+Documentation should describe these boundaries accurately. If a documentation PR is opened in the wrong source repository, explicitly recommend closing and moving it to the repository that owns the change. PRs must follow this repository's applicable code-review guidance.
+
+
 
 ## llms.txt / llms-full.txt (V1-only)
 

--- a/README.md
+++ b/README.md
@@ -26,3 +26,9 @@ mint dev
 ## Deployment
 
 The documentation site is automatically deployed via Mintlify when changes are pushed to the main branch.
+
+## Repository boundaries
+
+This site documents a multi-repository OpenHands system. [`OpenHands/OpenHands`](https://github.com/OpenHands/OpenHands) owns Agent Canvas, [`OpenHands/software-agent-sdk`](https://github.com/OpenHands/software-agent-sdk) owns the Python SDK and Agent Server, [`OpenHands/typescript-client`](https://github.com/OpenHands/typescript-client) owns the browser client for the Agent Server API, [`OpenHands/automation`](https://github.com/OpenHands/automation) owns scheduling and dispatch, and [`OpenHands/extensions`](https://github.com/OpenHands/extensions) owns reusable skills, plugins, automations, and integrations.
+
+The usual API flow is SDK/Agent Server → OpenAPI contract → TypeScript client → Agent Canvas. Documentation should preserve these ownership boundaries; a PR opened in the wrong repository should be closed and moved to the repository that owns the change.


### PR DESCRIPTION
HUMAN:

I reviewed the unified documentation architecture and added the five-repository ownership model to contributor and review guidance.

AGENT:

This pull request was created by an AI agent (OpenHands) on behalf of the user.

## Why

The unified docs repository describes multiple OpenHands products and source repositories. Contributors and reviewers need a concise ownership map so documentation changes and source links point to the correct repository.

## Summary

- Document ownership for Agent Canvas, SDK/Agent Server, TypeScript client, automation, and extensions.
- Add the SDK → OpenAPI → TypeScript client → Agent Canvas flow.
- Explain that misplaced documentation PRs should potentially be closed and moved.
- Update `AGENTS.md`, `README.md`, and the documentation code-review skill.

## Issue Number

Fixes #748

## How to Test

Review the three changed Markdown files for accurate repository links and ownership descriptions.

## Video/Screenshots

Not applicable: documentation-only change.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore
