### PR TITLE
docs: add Agent Canvas 1.15.0 release notes

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -313,6 +313,7 @@
           {
             "group": "Release Notes",
             "pages": [
+              "openhands/usage/agent-canvas/release-notes/v1.15.0",
               "openhands/usage/agent-canvas/release-notes/v1.14.0",
               "openhands/usage/agent-canvas/release-notes/v1.13.0",
               "openhands/usage/agent-canvas/release-notes/v1.12.0",

--- a/openhands/usage/agent-canvas/release-notes/v1.15.0.mdx
+++ b/openhands/usage/agent-canvas/release-notes/v1.15.0.mdx
@@ -1,0 +1,36 @@
+---
+title: Agent Canvas 1.15.0
+description: Release notes for Agent Canvas version 1.15.0
+---
+
+# Agent Canvas 1.15.0
+
+Released August 21, 2026.
+
+[View the full release on GitHub](https://github.com/OpenHands/OpenHands/releases/tag/v1.15.0).
+
+## Highlights
+
+- **Getting started checklist** — A new checklist in the sidebar helps users complete initial setup. Its visibility can be controlled in settings.
+- **Workspace paths in Files** — The Files view now shows the workspace path, making it easier to identify the folder currently being explored.
+- **Script-bundle automation installs** — Automation catalog entries can now install a bundled script along with the automation, supporting more complete automation setups.
+- **LLM provider connections** — Local agent-server users can manage LLM provider connections from a dedicated interface.
+- **Automation dashboard and discovery** — The automations dashboard, recommendations rail, and Add/Import flow have been updated to make finding and adding automations easier.
+- **Conversation overview and commits** — Conversations now include an overview panel and a unified commits drawer, bringing key conversation information and Git commits together.
+
+## Improvements and fixes
+
+- Agent profiles are no longer silently downgraded.
+- Grouped workspace views now show all folders even when pagination is in use.
+- The LLM selected from the home dropdown now takes precedence over an agent profile's pinned LLM.
+- The `Cmd`+`Enter` build shortcut now applies only in plan mode.
+- Long skill descriptions no longer hide modal actions.
+- PDF previews now render in the built-in viewer.
+- Agent Canvas no longer persists ACP model selections to agent settings when profile discovery fails.
+- The events socket stays alive across refetches and has a bounded handshake, improving connection reliability.
+- Streaming deltas are batched so the UI can keep up with faster models.
+
+## Full changelog
+
+- [GitHub release notes](https://github.com/OpenHands/OpenHands/releases/tag/v1.15.0)
+- [Compare v1.14.0 to v1.15.0](https://github.com/OpenHands/OpenHands/compare/v1.14.0...v1.15.0)


### PR DESCRIPTION
## Summary
- add user-facing Agent Canvas 1.15.0 release notes
- add v1.15.0 to the Agent Canvas Release Notes navigation

## Validation
- `python3 -m json.tool docs.json`
- `git diff --check`

_This pull request was created by an AI agent (OpenHands) on behalf of the user._