### PR TITLE
Refresh custom sandbox image base tag and document version compatibility

### DIFF
--- a/enterprise/custom-sandbox-image.mdx
+++ b/enterprise/custom-sandbox-image.mdx
@@ -36,15 +36,30 @@ Replicated VM deployment.
 ### Base Image
 
 ```dockerfile
-FROM ghcr.io/openhands/agent-server:1.23.0-python
+FROM ghcr.io/openhands/agent-server:1.41.0-python
 ```
 
 Pin a specific version tag to ensure reproducible builds. Check
 [ghcr.io/openhands/agent-server](https://github.com/OpenHands/OpenHands/pkgs/container/agent-server)
 for the latest available tags.
 
+### Version Compatibility
+
+Each OpenHands Enterprise release expects a specific agent-server version. The base image tag you
+build from must match the release you run: the `openhands-sdk` inside the sandbox and the one inside
+the OpenHands application must agree on major and minor version.
+
+To find the expected tag, enable **Use a Custom Sandbox Image** in the Admin Console. The
+**Sandbox Image Tag** field defaults to the tag the current release expects.
+
+When a conversation starts on a custom image, OpenHands checks the sandbox's agent-server version.
+If it does not match the release, the conversation fails with an error naming the expected and
+actual versions. Rebuild your image from the expected tag and update the **Sandbox Image Tag**
+field to fix it.
+
 <Note>
-  To get the latest features of OpenHands Enterprise, rebuild your custom image before each upgrade. The agent server base image is updated with every OHE release.
+  Rebuild your custom image before each upgrade. The agent-server base image changes with every
+  OHE release, and an image built for an older release will be rejected by the version check.
 </Note>
 
 ### Example: Build and Push


### PR DESCRIPTION
Updates the Enterprise custom sandbox image doc (`enterprise/custom-sandbox-image.mdx`).

- Bump the example base image from `agent-server:1.23.0-python` to `1.41.0-python`, which is what current Stable (0.45.0) and Beta (0.50.0) OHE releases pin. Customers copying the old example got an outdated SDK.
- Add a **Version Compatibility** section. Since OpenHands/OpenHands#14883, conversation start on a custom sandbox image checks the sandbox agent-server SDK version against the release and fails with a clear error on a major.minor mismatch. The doc now explains this, how to find the expected tag (the Admin Console **Sandbox Image Tag** default), and that the image must be rebuilt for each upgrade.

Live page: https://docs.openhands.dev/enterprise/custom-sandbox-image