### PR TITLE
docs: add log collection guide for VM installs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -552,7 +552,8 @@
           {
             "group": "VM Install",
             "pages": [
-              "enterprise/vm-install/admin-console-configuration"
+              "enterprise/vm-install/admin-console-configuration",
+              "enterprise/vm-install/log-collection"
             ]
           },
           {

--- a/enterprise/troubleshooting.mdx
+++ b/enterprise/troubleshooting.mdx
@@ -163,6 +163,10 @@ kubectl logs -n openhands <pod-name> -c <container-name> \
 Use `--previous` after a container restarts. Use `-c` to select a specific
 container, including an init container such as `migrate-db`.
 
+On a Replicated VM, these logs are also written to files on the VM. See
+[Log Collection](/enterprise/vm-install/log-collection) to send them to your own
+observability platform.
+
 ### Choose the Right Component
 
 Pod names may include a release prefix and generated suffix. Match the
@@ -203,5 +207,8 @@ short investigation:
   </Card>
   <Card title="Resource Limits" icon="gauge-high" href="/enterprise/k8s-install/resource-limits">
     Diagnose and tune CPU, memory, replicas, and storage.
+  </Card>
+  <Card title="Log Collection" icon="file-lines" href="/enterprise/vm-install/log-collection">
+    Send VM installation logs to your own observability platform.
   </Card>
 </CardGroup>

--- a/enterprise/vm-install/log-collection.mdx
+++ b/enterprise/vm-install/log-collection.mdx
@@ -19,7 +19,7 @@ For one-off diagnostics, collect a support bundle instead. See
 | The systemd journal | Cluster and operating system logs. |
 | `/var/log/embedded-cluster/` | Installer output, written during installation and upgrades. |
 
-All of these are readable only by `root`.
+The application log files are readable only by `root`.
 
 <Note>
   The VM keeps only recent output, roughly 50 MB per service, and the log files for a sandbox are
@@ -43,11 +43,11 @@ All of these are readable only by `root`.
     Every line begins with a timestamp and the output stream:
 
     ```
-    2026-08-25T11:03:09.766012676Z stdout F INFO: Application startup complete.
+    2026-08-25T13:12:11.300228843Z stdout F {"message": "GET /health 200", "severity": "INFO"}
     ```
 
     Enable your agent's parser for this format, called `cri` in Fluent Bit, so that the timestamp and
-    the message arrive as separate fields.
+    the message arrive as separate fields. The message itself is JSON.
   </Step>
   <Step title="Collect the journal">
     Enable your agent's journald input to pick up cluster and operating system logs.

--- a/enterprise/vm-install/log-collection.mdx
+++ b/enterprise/vm-install/log-collection.mdx
@@ -30,6 +30,16 @@ Files ending in `.log` are the ones being written to. A rotated file has a times
 compressed, such as `16.log.20260824-235907.gz`, so a pattern ending in `*.log` picks up current
 output and skips the rotated copies.
 
+`/var/log/containers` holds a symlink to every one of those files, carrying the same details in the
+file name rather than in the directories:
+
+```
+/var/log/containers/<pod>_<namespace>_<container>-<container-id>.log
+```
+
+Agents with built-in Kubernetes support read that directory, because they can take the pod and
+container names straight from the file name.
+
 | Location | Contains |
 |---|---|
 | `/var/log/pods/` | Output from OpenHands, its supporting services, and sandboxes. |
@@ -52,8 +62,8 @@ The application log files are readable only by `root`.
     instructions. Run it as `root` so that it can read the log files.
   </Step>
   <Step title="Tail the application logs">
-    Configure a file input for `/var/log/pods/*/*/*.log`. If your agent has built-in Kubernetes
-    support, point it at `/var/log/containers/*.log` instead, which is the path it expects.
+    Configure a file input for `/var/log/pods/*/*/*.log`, or `/var/log/containers/*.log` if your
+    agent reads the symlinks.
 
     Every line begins with a timestamp and the output stream:
 

--- a/enterprise/vm-install/log-collection.mdx
+++ b/enterprise/vm-install/log-collection.mdx
@@ -13,9 +13,22 @@ For one-off diagnostics, collect a support bundle instead. See
 
 ## Where the Logs Are
 
+Application logs live under `/var/log/pods`, with one directory per service and one file per
+container:
+
+```
+/var/log/pods/openhands_openhands-cbdbd996b-r54j8_30f64156/  # namespace, service, instance ID
+└── openhands/                                               # container
+    ├── 17.log                                               # active file
+    └── 16.log.20260824-235907.gz                            # rotated
+```
+
+Files ending in `.log` are the ones being written to. Rotated files have a timestamp appended and are
+compressed, so a pattern ending in `*.log` picks up current output and skips the rotated copies.
+
 | Location | Contains |
 |---|---|
-| `/var/log/pods/*/*/*.log` | Output from OpenHands, its supporting services, and sandboxes. |
+| `/var/log/pods/` | Output from OpenHands, its supporting services, and sandboxes. |
 | The systemd journal | Cluster and operating system logs. |
 | `/var/log/embedded-cluster/` | Installer output, written during installation and upgrades. |
 
@@ -35,10 +48,8 @@ The application log files are readable only by `root`.
     instructions. Run it as `root` so that it can read the log files.
   </Step>
   <Step title="Tail the application logs">
-    Configure a file input for `/var/log/pods/*/*/*.log`. This pattern picks up the active file for
-    each service and skips rotated files, so no line is collected twice. If your agent has built-in
-    Kubernetes support, point it at `/var/log/containers/*.log` instead, which is the path it
-    expects.
+    Configure a file input for `/var/log/pods/*/*/*.log`. If your agent has built-in Kubernetes
+    support, point it at `/var/log/containers/*.log` instead, which is the path it expects.
 
     Every line begins with a timestamp and the output stream:
 

--- a/enterprise/vm-install/log-collection.mdx
+++ b/enterprise/vm-install/log-collection.mdx
@@ -37,7 +37,7 @@ file name rather than in the directories:
 /var/log/containers/<pod>_<namespace>_<container>-<container-id>.log
 ```
 
-Agents with built-in Kubernetes support read that directory, because they can take the pod and
+Log agents with built-in Kubernetes support read that directory, because they can take the pod and
 container names straight from the file name.
 
 | Location | Contains |
@@ -50,20 +50,20 @@ The application log files are readable only by `root`.
 
 <Note>
   The VM keeps only recent output, roughly 50 MB per service, and the log files for a sandbox are
-  deleted when its conversation is cleaned up. Run your agent continuously and set your retention
-  period in your observability platform.
+  deleted when its conversation is cleaned up. Run your log agent continuously and set your
+  retention period in your observability platform.
 </Note>
 
 ## Collect the Logs
 
 <Steps>
   <Step title="Install your log agent">
-    Install the Linux agent for your observability platform on the VM, following your vendor's
+    Install the Linux log agent for your observability platform on the VM, following your vendor's
     instructions. Run it as `root` so that it can read the log files.
   </Step>
   <Step title="Tail the application logs">
     Configure a file input for `/var/log/pods/*/*/*.log`, or `/var/log/containers/*.log` if your
-    agent reads the symlinks.
+    log agent reads the symlinks.
 
     Every line begins with a timestamp and the output stream:
 
@@ -71,11 +71,11 @@ The application log files are readable only by `root`.
     2026-08-25T13:12:11.300228843Z stdout F {"message": "GET /health 200", "severity": "INFO"}
     ```
 
-    Enable your agent's parser for this format, called `cri` in Fluent Bit, so that the timestamp and
-    the message arrive as separate fields. The message itself is JSON.
+    Enable your log agent's parser for this format, called `cri` in Fluent Bit, so that the
+    timestamp and the message arrive as separate fields. The message itself is JSON.
   </Step>
   <Step title="Collect the journal">
-    Enable your agent's journald input to pick up cluster and operating system logs.
+    Enable your log agent's journald input to pick up cluster and operating system logs.
   </Step>
   <Step title="Confirm the logs arrive">
     Print a recent line on the VM, then search for it in your observability platform:

--- a/enterprise/vm-install/log-collection.mdx
+++ b/enterprise/vm-install/log-collection.mdx
@@ -1,0 +1,77 @@
+---
+title: Log Collection
+description: Send logs from an OpenHands Enterprise VM installation to your own observability platform.
+icon: file-lines
+---
+
+An OpenHands Enterprise VM installation writes the output of every service to log files on the VM. To
+bring those logs into your observability platform, install your platform's log agent on the VM and
+point it at those files. No OpenHands configuration changes are required.
+
+For one-off diagnostics, collect a support bundle instead. See
+[Troubleshooting](/enterprise/troubleshooting).
+
+## Where the Logs Are
+
+| Location | Contains |
+|---|---|
+| `/var/log/pods/*/*/*.log` | Output from OpenHands, its supporting services, and sandboxes. |
+| The systemd journal | Cluster and operating system logs. |
+| `/var/log/embedded-cluster/` | Installer output, written during installation and upgrades. |
+
+All of these are readable only by `root`.
+
+<Note>
+  The VM keeps only recent output, roughly 50 MB per service, and the log files for a sandbox are
+  deleted when its conversation is cleaned up. Run your agent continuously and set your retention
+  period in your observability platform.
+</Note>
+
+## Collect the Logs
+
+<Steps>
+  <Step title="Install your log agent">
+    Install the Linux agent for your observability platform on the VM, following your vendor's
+    instructions. Run it as `root` so that it can read the log files.
+  </Step>
+  <Step title="Tail the application logs">
+    Configure a file input for `/var/log/pods/*/*/*.log`. This pattern picks up the active file for
+    each service and skips rotated files, so no line is collected twice. If your agent has built-in
+    Kubernetes support, point it at `/var/log/containers/*.log` instead, which is the path it
+    expects.
+
+    Every line begins with a timestamp and the output stream:
+
+    ```
+    2026-08-25T11:03:09.766012676Z stdout F INFO: Application startup complete.
+    ```
+
+    Enable your agent's parser for this format, called `cri` in Fluent Bit, so that the timestamp and
+    the message arrive as separate fields.
+  </Step>
+  <Step title="Collect the journal">
+    Enable your agent's journald input to pick up cluster and operating system logs.
+  </Step>
+  <Step title="Confirm the logs arrive">
+    Print a recent line on the VM, then search for it in your observability platform:
+
+    ```bash
+    sudo sh -c 'tail -n 1 /var/log/pods/openhands_openhands-*/openhands/*.log'
+    ```
+  </Step>
+  <Step title="Repeat on every VM">
+    A VM only holds the logs for the services that run on it. Repeat these steps on each VM in the
+    installation, including any VM that runs sandboxes.
+  </Step>
+</Steps>
+
+## Related Guides
+
+<CardGroup cols={2}>
+  <Card title="Troubleshooting" icon="life-ring" href="/enterprise/troubleshooting">
+    Collect a support bundle and inspect workloads.
+  </Card>
+  <Card title="Admin Console Configuration" icon="sliders" href="/enterprise/vm-install/admin-console-configuration">
+    Configure a Replicated VM installation.
+  </Card>
+</CardGroup>

--- a/enterprise/vm-install/log-collection.mdx
+++ b/enterprise/vm-install/log-collection.mdx
@@ -6,7 +6,7 @@ icon: file-lines
 
 An OpenHands Enterprise VM installation writes the output of every service to log files on the VM. To
 bring those logs into your observability platform, install your platform's log agent on the VM and
-point it at those files. No OpenHands configuration changes are required.
+point it at those files.
 
 For one-off diagnostics, collect a support bundle instead. See
 [Troubleshooting](/enterprise/troubleshooting).

--- a/enterprise/vm-install/log-collection.mdx
+++ b/enterprise/vm-install/log-collection.mdx
@@ -13,18 +13,22 @@ For one-off diagnostics, collect a support bundle instead. See
 
 ## Where the Logs Are
 
-Application logs live under `/var/log/pods`, with one directory per service and one file per
+Application logs live under `/var/log/pods`. Each path is built from the namespace, the pod, and the
 container:
 
 ```
-/var/log/pods/openhands_openhands-cbdbd996b-r54j8_30f64156/  # namespace, service, instance ID
-└── openhands/                                               # container
-    ├── 17.log                                               # active file
-    └── 16.log.20260824-235907.gz                            # rotated
+/var/log/pods/<namespace>_<pod>_<pod-id>/<container>/<restart-count>.log
 ```
 
-Files ending in `.log` are the ones being written to. Rotated files have a timestamp appended and are
-compressed, so a pattern ending in `*.log` picks up current output and skips the rotated copies.
+For example:
+
+```
+/var/log/pods/openhands_openhands-cbdbd996b-r54j8_30f64156-29b8-4b64-b663-cf5b4c697b64/openhands/17.log
+```
+
+Files ending in `.log` are the ones being written to. A rotated file has a timestamp appended and is
+compressed, such as `16.log.20260824-235907.gz`, so a pattern ending in `*.log` picks up current
+output and skips the rotated copies.
 
 | Location | Contains |
 |---|---|

--- a/enterprise/vm-install/log-collection.mdx
+++ b/enterprise/vm-install/log-collection.mdx
@@ -26,9 +26,9 @@ For example:
 /var/log/pods/openhands_openhands-cbdbd996b-r54j8_30f64156-29b8-4b64-b663-cf5b4c697b64/openhands/17.log
 ```
 
-Files ending in `.log` are the ones being written to. A rotated file has a timestamp appended and is
-compressed, such as `16.log.20260824-235907.gz`, so a pattern ending in `*.log` picks up current
-output and skips the rotated copies.
+The VM installation writes to files ending in `.log`. It rotates a file once it grows large,
+appending a timestamp to the name and compressing it, for example `16.log.20260824-235907.gz`. A
+pattern ending in `*.log` therefore collects current output and skips the rotated copies.
 
 `/var/log/containers` holds a symlink to every one of those files, carrying the same details in the
 file name rather than in the directories:


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [x] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

Nothing in the docs tells an operator how to get logs off a VM install. The troubleshooting guide covers one-off diagnostics, so anyone who wants OHE logs flowing continuously into their own observability platform has to work out where the files live on the VM themselves.

This adds a short page under VM Install with the log locations and the steps to point an agent at them.

The page recommends a host-level log agent. It needs no kubernetes access, and a single file glob covers every service on the VM. That glob matches only the active files, so rotated logs don't get re-ingested.

I verified the paths, the permissions, and the `tail` command in the last step against a running VM install.