### PR TITLE
docs(sdk): explain per-task LLM profile selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ mint dev
 Useful checks:
 
 ```bash
-mint broken-links
+mintlify broken-links
 ```
 
 ### Python tooling (sync/generation scripts)

--- a/sdk/guides/task-tool-set.mdx
+++ b/sdk/guides/task-tool-set.mdx
@@ -133,9 +133,32 @@ When the parent agent calls the task tool, it provides these parameters:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `prompt` | `str` | Yes | The instruction for the sub-agent |
-| `subagent_type` | `str` | No | Which registered agent type to use (default: `"default"`) |
+| `subagent_type` | `str` | No | Which registered agent type to use (default: `"general-purpose"`) |
 | `description` | `str` | No | Short label (3-5 words) for display and tracking |
+| `llm_profile` | `str` | No | Saved LLM profile for this sub-agent; if omitted, it inherits the parent model |
 | `resume` | `str` | No | Task ID from a previous invocation to continue |
+
+## Selecting a Model for One Task
+
+Pass `llm_profile` to run a sub-agent on a [saved LLM profile](/sdk/guides/llm-profile-store) without changing the parent agent's model:
+
+```python icon="python"
+conversation.send_message(
+    "Use the task tool to implement this change with "
+    "subagent_type='general-purpose' and llm_profile='fast-worker'."
+)
+conversation.run()
+```
+
+The model is selected in this order:
+
+1. A model profile specified by the sub-agent's file-based definition.
+2. The task call's `llm_profile`.
+3. The parent model, when neither of the above is set.
+
+An unknown profile returns an error instead of silently using the parent model. When you resume a task, omitting `llm_profile` keeps the profile used by that task. Passing a different profile changes it for that resume and later resumes.
+
+The task tool shows the parent agent the names of profiles in the default profile store. It does not include profile configuration or credentials. A file-based sub-agent that uses a custom `profile_store_dir` can resolve profiles from that directory even though the advertised list comes from the default store.
 
 ## Task Observation
 

--- a/sdk/guides/task-tool-set.mdx
+++ b/sdk/guides/task-tool-set.mdx
@@ -150,15 +150,11 @@ conversation.send_message(
 conversation.run()
 ```
 
-The model is selected in this order:
+For a sub-agent definition that inherits the parent model, `llm_profile` selects the worker model. Do not pass `llm_profile` when the selected sub-agent definition already specifies a model; the task returns a configuration error rather than silently choosing one.
 
-1. A model profile specified by the sub-agent's file-based definition.
-2. The task call's `llm_profile`.
-3. The parent model, when neither of the above is set.
+An unknown profile returns an error instead of silently using the parent model. When you resume a task with an inheriting definition, omitting `llm_profile` keeps the profile used by that task. Resuming with a model-pinned definition replaces the stored profile with the definition's model. Passing a different profile changes it for that resume and later resumes.
 
-An unknown profile returns an error instead of silently using the parent model. When you resume a task, omitting `llm_profile` keeps the profile used by that task. Passing a different profile changes it for that resume and later resumes.
-
-The task tool shows the parent agent the names of profiles in the default profile store. It does not include profile configuration or credentials. A file-based sub-agent that uses a custom `profile_store_dir` can resolve profiles from that directory even though the advertised list comes from the default store.
+The task tool shows the parent agent the names of profiles in the default profile store. It does not include profile configuration or credentials. If any registered sub-agent uses a custom `profile_store_dir`, the task tool omits the list rather than advertising names from a store that the selected agent may not use. You can still pass a valid profile name directly.
 
 ## Task Observation
 


### PR DESCRIPTION
- [x] I have read and reviewed the documentation changes to the best of my ability.
- [x] If the change is significant, I have run the documentation site locally and confirmed it renders as expected.

**Summary of changes**

Documents the per-call `llm_profile` option introduced by [OpenHands/software-agent-sdk#4510](https://github.com/OpenHands/software-agent-sdk/pull/4510).

The guide now covers model-selection precedence, unknown-profile errors, resume behavior, and the custom profile-store discovery limitation. It also corrects the documented default subagent type from `default` to `general-purpose`.

Validation: `git diff --check` passes. The docs test suite reaches 35 passes; its two remaining errors come from an existing pricing test that fetches a removed OpenHands source path and receives HTTP 404.
